### PR TITLE
fix(web): resolve thumbnail generation on web

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,3 +1,8 @@
 .idea/
 .vs/
 .vscode/
+.dart_tool/
+.idea/
+.vs/
+.vscode/
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3
+- **FIX**: Resolve thumbnail generation on web.
+
 ## 0.0.2
 - **FEAT**: Add `getVideoInformation` and `createVideoThumbnails` for all platforms.
 

--- a/lib/core/services/web/web_thumbnail_generator.dart
+++ b/lib/core/services/web/web_thumbnail_generator.dart
@@ -54,6 +54,11 @@ class WebThumbnailGenerator {
 
       await video.onSeeked.first;
 
+      /// Short delay is important that the video frame is correctly loaded.
+      /// Without that delay is the possibility high that the video frame from
+      /// before is recorded again.
+      await Future.delayed(const Duration(milliseconds: 1));
+
       ctx.drawImage(video, 0, 0, width.toDouble(), height.toDouble());
 
       final blob = await canvas.toBlobAsync('image/${value.format}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
Resolve issues with thumbnail generation on the web by adding a short delay to ensure the video frame is correctly loaded. Update version to 0.0.3.