### PR TITLE
fix(export): ensure crop dimensions are even to avoid libx264 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.6
+- **FIX**(crop): Ensure crop dimensions are even to avoid libx264 errors
+
 ## 0.0.5
 - **FEAT**: Add support for color 4x5 matrices
 

--- a/example/lib/features/export/video_export_page.dart
+++ b/example/lib/features/export/video_export_page.dart
@@ -35,7 +35,7 @@ class _VideoExportPageState extends State<VideoExportPage> {
   Duration _generationTime = Duration.zero;
 
   double _outputVideoRatio = 1280 / 720;
-  final double _blur = 10;
+  final double _blur = 0;
   final _transform = const ExportTransform();
   final List<List<double>> _colorFilters = [];
   // kBasicFilterMatrix   kComplexFilterMatrix
@@ -84,7 +84,8 @@ class _VideoExportPageState extends State<VideoExportPage> {
       videoDuration: infos.duration,
       devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
       // startTime: const Duration(seconds: 15),
-      endTime: const Duration(seconds: 3),
+      // endTime: const Duration(seconds: 25),
+      endTime: const Duration(seconds: 2),
       encodingPreset: EncodingPreset.ultrafast,
       // outputQuality: OutputQuality.lossless,
       blur: _blur,

--- a/lib/core/models/video/export_video_model.dart
+++ b/lib/core/models/video/export_video_model.dart
@@ -134,8 +134,8 @@ class ExportVideoModel {
     final rotateTurns = transform.rotateTurns % 4;
     final isSwapped = rotateTurns % 2 != 0;
 
-    final width = transform.width;
-    final height = transform.height;
+    final rawWidth = transform.width;
+    final rawHeight = transform.height;
     final x = transform.x;
     final y = transform.y;
     final flipX = transform.flipX;
@@ -149,11 +149,19 @@ class ExportVideoModel {
     };
 
     String? crop;
-    if (width != null && height != null) {
-      final cropWidth = isSwapped ? height.toString() : width.toString();
-      final cropHeight = isSwapped ? width.toString() : height.toString();
+    if (rawWidth != null && rawHeight != null) {
+      // Swap if rotated
+      final unsanitizedWidth = isSwapped ? rawHeight : rawWidth;
+      final unsanitizedHeight = isSwapped ? rawWidth : rawHeight;
+
+      // Ensure even dimensions
+      final cropWidth = (unsanitizedWidth ~/ 2) * 2;
+      final cropHeight = (unsanitizedHeight ~/ 2) * 2;
+
+      // X and Y can remain null for centering or use as-is
       final xExpr = x ?? '(in_w-$cropWidth)/2';
       final yExpr = y ?? '(in_h-$cropHeight)/2';
+
       crop = 'crop=$cropWidth:$cropHeight:$xExpr:$yExpr';
     }
 
@@ -168,8 +176,7 @@ class ExportVideoModel {
       ...flips,
     ];
 
-    final result = filters.join(',');
-    return result;
+    return filters.join(',');
   }
 
   /// Returns a combined FFmpeg complex filter string based on active filters.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 0.0.5
+version: 0.0.6
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
Ensure crop dimensions are even during video export to prevent encoding issues with libx264. Update version to 0.0.6.