### PR TITLE
feat: add enableAudio parameter and version bump to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.8
+- **FEAT**(audio): Add enable audio parameter
+
+## 0.0.7
+- **FEAT**(iOS, macOS): Add video generation support for macOS and iOS
+
 ## 0.0.6
 - **FIX**(crop): Ensure crop dimensions are even to avoid libx264 errors
 

--- a/lib/core/models/video/editor_video_model.dart
+++ b/lib/core/models/video/editor_video_model.dart
@@ -93,6 +93,21 @@ class EditorVideo {
     }
   }
 
+  /// Returns a copy of this config with the given fields replaced.
+  EditorVideo copyWith({
+    Uint8List? byteArray,
+    File? file,
+    String? networkUrl,
+    String? assetPath,
+  }) {
+    return EditorVideo(
+      byteArray: byteArray ?? this.byteArray,
+      file: file ?? this.file,
+      networkUrl: networkUrl ?? this.networkUrl,
+      assetPath: assetPath ?? this.assetPath,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/lib/core/models/video/encoding/avi_encoding_config.dart
+++ b/lib/core/models/video/encoding/avi_encoding_config.dart
@@ -10,7 +10,6 @@ class AviEncodingConfig extends VideoEncodingConfig {
     this.videoCodec = 'mpeg4',
     this.qualityScale = 5,
     this.audioCodec = 'mp3',
-    super.customArgs,
   });
 
   /// The video codec to use (default: `mpeg4`).
@@ -24,7 +23,7 @@ class AviEncodingConfig extends VideoEncodingConfig {
   final String audioCodec;
 
   @override
-  List<String> toFFmpegArgs() {
+  List<String> toFFmpegArgs(bool enableAudio) {
     return [
       ///
       '-c:v', videoCodec,
@@ -32,9 +31,41 @@ class AviEncodingConfig extends VideoEncodingConfig {
       ///
       '-qscale:v', '$qualityScale',
 
-      ///
-      '-c:a', audioCodec,
+      /// Audio settings
+      if (enableAudio) ...[
+        // e.g., 'aac'
+        '-c:a', audioCodec,
+      ] else ...[
+        '-an', // disable audio
+      ],
       ...customArgs,
     ];
   }
+
+  /// Returns a copy of this config with the given fields replaced.
+  AviEncodingConfig copyWith({
+    String? videoCodec,
+    int? qualityScale,
+    String? audioCodec,
+  }) {
+    return AviEncodingConfig(
+      videoCodec: videoCodec ?? this.videoCodec,
+      qualityScale: qualityScale ?? this.qualityScale,
+      audioCodec: audioCodec ?? this.audioCodec,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is AviEncodingConfig &&
+        other.videoCodec == videoCodec &&
+        other.qualityScale == qualityScale &&
+        other.audioCodec == audioCodec;
+  }
+
+  @override
+  int get hashCode =>
+      videoCodec.hashCode ^ qualityScale.hashCode ^ audioCodec.hashCode;
 }

--- a/lib/core/models/video/encoding/base_encoding_config.dart
+++ b/lib/core/models/video/encoding/base_encoding_config.dart
@@ -13,5 +13,5 @@ abstract class VideoEncodingConfig {
 
   /// Converts the encoding configuration into a list of FFmpeg command-line
   /// arguments, including any [customArgs] at the end.
-  List<String> toFFmpegArgs();
+  List<String> toFFmpegArgs(bool enableAudio);
 }

--- a/lib/core/models/video/encoding/gif_encoding_config.dart
+++ b/lib/core/models/video/encoding/gif_encoding_config.dart
@@ -8,18 +8,36 @@ class GifEncodingConfig extends VideoEncodingConfig {
   /// Creates a [GifEncodingConfig] with optional custom settings.
   const GifEncodingConfig({
     this.loop = 0,
-    super.customArgs,
   });
 
   /// Loop count for the GIF (0 = infinite loop).
   final int loop;
 
   @override
-  List<String> toFFmpegArgs() {
+  List<String> toFFmpegArgs([bool enableAudio = false]) {
     return [
       '-loop',
       '$loop',
       ...customArgs,
     ];
   }
+
+  /// Returns a copy of this config with the given fields replaced.
+  GifEncodingConfig copyWith({
+    int? loop,
+  }) {
+    return GifEncodingConfig(
+      loop: loop ?? this.loop,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is GifEncodingConfig && other.loop == loop;
+  }
+
+  @override
+  int get hashCode => loop.hashCode;
 }

--- a/lib/core/models/video/encoding/mkv_encoding_config.dart
+++ b/lib/core/models/video/encoding/mkv_encoding_config.dart
@@ -11,7 +11,6 @@ class MkvEncodingConfig extends VideoEncodingConfig {
     this.preset = 'fast',
     this.pixelFormat = 'yuv420p',
     this.audioCodec = 'aac',
-    super.customArgs,
   });
 
   /// Constant Rate Factor (CRF) for controlling video quality.
@@ -31,7 +30,7 @@ class MkvEncodingConfig extends VideoEncodingConfig {
   final String audioCodec;
 
   @override
-  List<String> toFFmpegArgs() {
+  List<String> toFFmpegArgs(bool enableAudio) {
     return [
       /// Set video codec to H.264 (widely supported)
       '-c:v', 'libx264',
@@ -45,9 +44,47 @@ class MkvEncodingConfig extends VideoEncodingConfig {
       /// Pixel format
       '-pix_fmt', pixelFormat,
 
-      /// Audio encoding
-      '-c:a', audioCodec,
+      /// Audio handling
+      if (enableAudio) ...[
+        '-c:a', audioCodec, // e.g., 'aac'
+      ] else ...[
+        '-an', // disable audio
+      ],
       ...customArgs,
     ];
+  }
+
+  /// Returns a copy of this config with the given fields replaced.
+  MkvEncodingConfig copyWith({
+    int? crf,
+    String? preset,
+    String? pixelFormat,
+    String? audioCodec,
+  }) {
+    return MkvEncodingConfig(
+      crf: crf ?? this.crf,
+      preset: preset ?? this.preset,
+      pixelFormat: pixelFormat ?? this.pixelFormat,
+      audioCodec: audioCodec ?? this.audioCodec,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MkvEncodingConfig &&
+        other.crf == crf &&
+        other.preset == preset &&
+        other.pixelFormat == pixelFormat &&
+        other.audioCodec == audioCodec;
+  }
+
+  @override
+  int get hashCode {
+    return crf.hashCode ^
+        preset.hashCode ^
+        pixelFormat.hashCode ^
+        audioCodec.hashCode;
   }
 }

--- a/lib/core/models/video/encoding/mov_encoding_config.dart
+++ b/lib/core/models/video/encoding/mov_encoding_config.dart
@@ -12,7 +12,6 @@ class MovEncodingConfig extends VideoEncodingConfig {
     this.preset = 'fast',
     this.pixelFormat = 'yuv420p',
     this.audioCodec = 'aac',
-    super.customArgs,
   });
 
   /// Constant Rate Factor (CRF) for controlling video quality.
@@ -32,7 +31,7 @@ class MovEncodingConfig extends VideoEncodingConfig {
   final String audioCodec;
 
   @override
-  List<String> toFFmpegArgs() {
+  List<String> toFFmpegArgs(bool enableAudio) {
     return [
       /// Set video codec to H.264 (widely supported)
       '-c:v', 'libx264',
@@ -46,9 +45,47 @@ class MovEncodingConfig extends VideoEncodingConfig {
       /// Pixel format
       '-pix_fmt', pixelFormat,
 
-      /// Audio encoding
-      '-c:a', audioCodec,
+      /// Audio handling
+      if (enableAudio) ...[
+        '-c:a', audioCodec, // e.g., 'aac'
+      ] else ...[
+        '-an', // disable audio
+      ],
       ...customArgs,
     ];
+  }
+
+  /// Returns a copy of this config with the given fields replaced.
+  MovEncodingConfig copyWith({
+    int? crf,
+    String? preset,
+    String? pixelFormat,
+    String? audioCodec,
+  }) {
+    return MovEncodingConfig(
+      crf: crf ?? this.crf,
+      preset: preset ?? this.preset,
+      pixelFormat: pixelFormat ?? this.pixelFormat,
+      audioCodec: audioCodec ?? this.audioCodec,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MovEncodingConfig &&
+        other.crf == crf &&
+        other.preset == preset &&
+        other.pixelFormat == pixelFormat &&
+        other.audioCodec == audioCodec;
+  }
+
+  @override
+  int get hashCode {
+    return crf.hashCode ^
+        preset.hashCode ^
+        pixelFormat.hashCode ^
+        audioCodec.hashCode;
   }
 }

--- a/lib/core/models/video/encoding/mp4_encoding_config.dart
+++ b/lib/core/models/video/encoding/mp4_encoding_config.dart
@@ -12,7 +12,6 @@ class Mp4EncodingConfig extends VideoEncodingConfig {
     this.preset = 'fast',
     this.pixelFormat = 'yuv420p',
     this.audioCodec = 'aac',
-    super.customArgs,
   });
 
   /// Constant Rate Factor (CRF) for controlling video quality.
@@ -32,7 +31,7 @@ class Mp4EncodingConfig extends VideoEncodingConfig {
   final String audioCodec;
 
   @override
-  List<String> toFFmpegArgs() {
+  List<String> toFFmpegArgs(bool enableAudio) {
     return [
       /// Set video codec to H.264 (widely supported)
       '-c:v', 'libx264',
@@ -46,9 +45,47 @@ class Mp4EncodingConfig extends VideoEncodingConfig {
       /// Pixel format
       '-pix_fmt', pixelFormat,
 
-      /// Audio encoding
-      '-c:a', audioCodec,
+      /// Audio handling
+      if (enableAudio) ...[
+        '-c:a', audioCodec, // e.g., 'aac'
+      ] else ...[
+        '-an', // disable audio
+      ],
       ...customArgs,
     ];
+  }
+
+  /// Returns a copy of this config with the given fields replaced.
+  Mp4EncodingConfig copyWith({
+    int? crf,
+    String? preset,
+    String? pixelFormat,
+    String? audioCodec,
+  }) {
+    return Mp4EncodingConfig(
+      crf: crf ?? this.crf,
+      preset: preset ?? this.preset,
+      pixelFormat: pixelFormat ?? this.pixelFormat,
+      audioCodec: audioCodec ?? this.audioCodec,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is Mp4EncodingConfig &&
+        other.crf == crf &&
+        other.preset == preset &&
+        other.pixelFormat == pixelFormat &&
+        other.audioCodec == audioCodec;
+  }
+
+  @override
+  int get hashCode {
+    return crf.hashCode ^
+        preset.hashCode ^
+        pixelFormat.hashCode ^
+        audioCodec.hashCode;
   }
 }

--- a/lib/core/models/video/encoding/video_encoding.dart
+++ b/lib/core/models/video/encoding/video_encoding.dart
@@ -42,8 +42,11 @@ class VideoEncoding {
   final AviEncodingConfig aviEncodingConfig;
 
   /// Returns the FFmpeg arguments for the specified [outputFormat].
-  List<String> toFFmpegArgs(VideoOutputFormat outputFormat) {
-    return getEncodingConfig(outputFormat).toFFmpegArgs();
+  List<String> toFFmpegArgs({
+    required VideoOutputFormat outputFormat,
+    required bool enableAudio,
+  }) {
+    return getEncodingConfig(outputFormat).toFFmpegArgs(enableAudio);
   }
 
   /// Returns the encoding configuration matching the given [outputFormat].
@@ -62,5 +65,47 @@ class VideoEncoding {
       case VideoOutputFormat.gif:
         return gifEncodingConfig;
     }
+  }
+
+  /// Returns a copy of this config with the given fields replaced.
+  VideoEncoding copyWith({
+    Mp4EncodingConfig? mp4EncodingConfig,
+    MovEncodingConfig? movEncodingConfig,
+    MkvEncodingConfig? mkvEncodingConfig,
+    WebMEncodingConfig? webMEncodingConfig,
+    GifEncodingConfig? gifEncodingConfig,
+    AviEncodingConfig? aviEncodingConfig,
+  }) {
+    return VideoEncoding(
+      mp4EncodingConfig: mp4EncodingConfig ?? this.mp4EncodingConfig,
+      movEncodingConfig: movEncodingConfig ?? this.movEncodingConfig,
+      mkvEncodingConfig: mkvEncodingConfig ?? this.mkvEncodingConfig,
+      webMEncodingConfig: webMEncodingConfig ?? this.webMEncodingConfig,
+      gifEncodingConfig: gifEncodingConfig ?? this.gifEncodingConfig,
+      aviEncodingConfig: aviEncodingConfig ?? this.aviEncodingConfig,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is VideoEncoding &&
+        other.mp4EncodingConfig == mp4EncodingConfig &&
+        other.movEncodingConfig == movEncodingConfig &&
+        other.mkvEncodingConfig == mkvEncodingConfig &&
+        other.webMEncodingConfig == webMEncodingConfig &&
+        other.gifEncodingConfig == gifEncodingConfig &&
+        other.aviEncodingConfig == aviEncodingConfig;
+  }
+
+  @override
+  int get hashCode {
+    return mp4EncodingConfig.hashCode ^
+        movEncodingConfig.hashCode ^
+        mkvEncodingConfig.hashCode ^
+        webMEncodingConfig.hashCode ^
+        gifEncodingConfig.hashCode ^
+        aviEncodingConfig.hashCode;
   }
 }

--- a/lib/core/models/video/encoding/webm_encoding_config.dart
+++ b/lib/core/models/video/encoding/webm_encoding_config.dart
@@ -13,7 +13,6 @@ class WebMEncodingConfig extends VideoEncodingConfig {
     this.cpuUsed = 5,
     this.deadline = 'realtime',
     this.threads = 4,
-    super.customArgs,
   });
 
   /// The video codec to use (default: `libvpx-vp9`).
@@ -37,7 +36,7 @@ class WebMEncodingConfig extends VideoEncodingConfig {
 
   /// Converts the configuration into a list of FFmpeg command-line arguments.
   @override
-  List<String> toFFmpegArgs() {
+  List<String> toFFmpegArgs(bool enableAudio) {
     return [
       /// Set video codec to VP9 for WebM
       '-c:v', videoCodec,
@@ -57,9 +56,55 @@ class WebMEncodingConfig extends VideoEncodingConfig {
       /// Deadline
       '-deadline', deadline,
 
-      /// Audio codec
-      '-c:a', audioCodec,
+      /// Audio handling
+      if (enableAudio) ...[
+        '-c:a', audioCodec, // e.g., 'aac'
+      ] else ...[
+        '-an', // disable audio
+      ],
       ...customArgs,
     ];
+  }
+
+  /// Returns a copy of this config with the given fields replaced.
+  WebMEncodingConfig copyWith({
+    String? videoCodec,
+    String? audioCodec,
+    String? bitrate,
+    int? cpuUsed,
+    String? deadline,
+    int? threads,
+  }) {
+    return WebMEncodingConfig(
+      videoCodec: videoCodec ?? this.videoCodec,
+      audioCodec: audioCodec ?? this.audioCodec,
+      bitrate: bitrate ?? this.bitrate,
+      cpuUsed: cpuUsed ?? this.cpuUsed,
+      deadline: deadline ?? this.deadline,
+      threads: threads ?? this.threads,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is WebMEncodingConfig &&
+        other.videoCodec == videoCodec &&
+        other.audioCodec == audioCodec &&
+        other.bitrate == bitrate &&
+        other.cpuUsed == cpuUsed &&
+        other.deadline == deadline &&
+        other.threads == threads;
+  }
+
+  @override
+  int get hashCode {
+    return videoCodec.hashCode ^
+        audioCodec.hashCode ^
+        bitrate.hashCode ^
+        cpuUsed.hashCode ^
+        deadline.hashCode ^
+        threads.hashCode;
   }
 }

--- a/lib/core/models/video/export_transform_model.dart
+++ b/lib/core/models/video/export_transform_model.dart
@@ -40,6 +40,27 @@ class ExportTransform {
   /// Whether to flip vertically.
   final bool flipY;
 
+  /// Returns a copy of this config with the given fields replaced.
+  ExportTransform copyWith({
+    int? width,
+    int? height,
+    int? rotateTurns,
+    String? x,
+    String? y,
+    bool? flipX,
+    bool? flipY,
+  }) {
+    return ExportTransform(
+      width: width ?? this.width,
+      height: height ?? this.height,
+      rotateTurns: rotateTurns ?? this.rotateTurns,
+      x: x ?? this.x,
+      y: y ?? this.y,
+      flipX: flipX ?? this.flipX,
+      flipY: flipY ?? this.flipY,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/lib/core/models/video/export_video_model.dart
+++ b/lib/core/models/video/export_video_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 
 import '/core/models/video/export_transform_model.dart';
 import 'encoding/video_encoding.dart';
@@ -24,6 +24,7 @@ class ExportVideoModel {
     this.startTime,
     this.endTime,
     this.blur = 0,
+    this.enableAudio = true,
     this.transform = const ExportTransform(),
     this.colorFilters = const [],
     this.customFilter = '',
@@ -74,6 +75,11 @@ class ExportVideoModel {
   ///
   /// Higher values result in a stronger blur effect.
   final double blur;
+
+  /// Whether to include audio in the exported video.
+  ///
+  /// **Default**: `true`
+  final bool enableAudio;
 
   /// The device pixel ratio used for rendering accuracy and scale adjustments.
   ///
@@ -194,6 +200,84 @@ class ExportVideoModel {
       ..removeWhere((item) => item.isEmpty);
 
     return filters.join(',');
+  }
+
+  /// Returns a copy of this config with the given fields replaced.
+  ExportVideoModel copyWith({
+    VideoOutputFormat? outputFormat,
+    Uint8List? videoBytes,
+    Uint8List? imageBytes,
+    Duration? videoDuration,
+    OutputQuality? outputQuality,
+    EncodingPreset? encodingPreset,
+    Duration? startTime,
+    Duration? endTime,
+    List<List<double>>? colorFilters,
+    double? blur,
+    bool? enableAudio,
+    double? devicePixelRatio,
+    ExportTransform? transform,
+    String? customFilter,
+    VideoEncoding? encoding,
+  }) {
+    return ExportVideoModel(
+      outputFormat: outputFormat ?? this.outputFormat,
+      videoBytes: videoBytes ?? this.videoBytes,
+      imageBytes: imageBytes ?? this.imageBytes,
+      videoDuration: videoDuration ?? this.videoDuration,
+      outputQuality: outputQuality ?? this.outputQuality,
+      encodingPreset: encodingPreset ?? this.encodingPreset,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      colorFilters: colorFilters ?? this.colorFilters,
+      blur: blur ?? this.blur,
+      enableAudio: enableAudio ?? this.enableAudio,
+      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
+      transform: transform ?? this.transform,
+      customFilter: customFilter ?? this.customFilter,
+      encoding: encoding ?? this.encoding,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ExportVideoModel &&
+        other.outputFormat == outputFormat &&
+        other.videoBytes == videoBytes &&
+        other.imageBytes == imageBytes &&
+        other.videoDuration == videoDuration &&
+        other.outputQuality == outputQuality &&
+        other.encodingPreset == encodingPreset &&
+        other.startTime == startTime &&
+        other.endTime == endTime &&
+        listEquals(other.colorFilters, colorFilters) &&
+        other.blur == blur &&
+        other.enableAudio == enableAudio &&
+        other.devicePixelRatio == devicePixelRatio &&
+        other.transform == transform &&
+        other.customFilter == customFilter &&
+        other.encoding == encoding;
+  }
+
+  @override
+  int get hashCode {
+    return outputFormat.hashCode ^
+        videoBytes.hashCode ^
+        imageBytes.hashCode ^
+        videoDuration.hashCode ^
+        outputQuality.hashCode ^
+        encodingPreset.hashCode ^
+        startTime.hashCode ^
+        endTime.hashCode ^
+        colorFilters.hashCode ^
+        blur.hashCode ^
+        enableAudio.hashCode ^
+        devicePixelRatio.hashCode ^
+        transform.hashCode ^
+        customFilter.hashCode ^
+        encoding.hashCode;
   }
 }
 

--- a/lib/core/models/video/video_information_model.dart
+++ b/lib/core/models/video/video_information_model.dart
@@ -36,4 +36,38 @@ class VideoInformation {
 
   /// The format of the video file, such as "mp4" or "avi".
   final String extension;
+
+  /// Returns a copy of this config with the given fields replaced.
+  VideoInformation copyWith({
+    int? fileSize,
+    Size? resolution,
+    Duration? duration,
+    String? extension,
+  }) {
+    return VideoInformation(
+      fileSize: fileSize ?? this.fileSize,
+      resolution: resolution ?? this.resolution,
+      duration: duration ?? this.duration,
+      extension: extension ?? this.extension,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is VideoInformation &&
+        other.fileSize == fileSize &&
+        other.resolution == resolution &&
+        other.duration == duration &&
+        other.extension == extension;
+  }
+
+  @override
+  int get hashCode {
+    return fileSize.hashCode ^
+        resolution.hashCode ^
+        duration.hashCode ^
+        extension.hashCode;
+  }
 }

--- a/lib/pro_video_editor_method_channel.dart
+++ b/lib/pro_video_editor_method_channel.dart
@@ -78,7 +78,10 @@ class MethodChannelProVideoEditor extends ProVideoEditorPlatform {
     final Uint8List? result = await methodChannel.invokeMethod<Uint8List>(
       'exportVideo',
       {
-        'codecArgs': value.encoding.toFFmpegArgs(value.outputFormat),
+        'codecArgs': value.encoding.toFFmpegArgs(
+          outputFormat: value.outputFormat,
+          enableAudio: value.enableAudio,
+        ),
         'videoBytes': value.videoBytes,
         'imageBytes': value.imageBytes,
         'videoDuration': value.videoDuration.inMilliseconds,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 0.0.7
+version: 0.0.8
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
Introduce an `enableAudio` parameter for FFmpeg argument generation to control audio inclusion in video exports. Implement `copyWith` methods for various encoding configurations to enhance object manipulation. Update the version to 0.0.8.