### PR TITLE
fix(ios, macOS): swap render dimensions for 90°/270° rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## X.X.X
+- **FIX**(iOS, macOS): Fixed rotation transforms not properly swapping render dimensions for 90°/270° rotations, resolving squeezed video output with black bars
+
 ## 0.1.5
 - **FIX**(window, linux, iOS, macOS): Correct bitrate extraction from metadata. 
 - **FIX**(android): Remove unsupported WebM output format; Android only supports MP4 generation. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## X.X.X
+## 0.1.6
 - **FIX**(iOS, macOS): Fixed rotation transforms not properly swapping render dimensions for 90°/270° rotations, resolving squeezed video output with black bars
 
 ## 0.1.5

--- a/ios/Classes/src/features/render/RenderVideo.swift
+++ b/ios/Classes/src/features/render/RenderVideo.swift
@@ -107,6 +107,16 @@ class RenderVideo {
                     // Only update renderSize if cropping was actually applied
                     if cropWidth != nil || cropHeight != nil {
                         finalRenderSize = croppedSize
+                    } else {
+                        if let rotateTurns = rotateTurns {
+                            let normalizedRotation = (rotateTurns % 4 + 4) % 4
+                            if normalizedRotation == 1 || normalizedRotation == 3 {
+                                finalRenderSize = CGSize(
+                                    width: finalRenderSize.height,
+                                    height: finalRenderSize.width
+                                )
+                            }
+                        }
                     }
 
                     let effectiveScaleX = scaleX ?? 1.0

--- a/macos/Classes/src/features/render/RenderVideo.swift
+++ b/macos/Classes/src/features/render/RenderVideo.swift
@@ -107,6 +107,16 @@ class RenderVideo {
                     // Only update renderSize if cropping was actually applied
                     if cropWidth != nil || cropHeight != nil {
                         finalRenderSize = croppedSize
+                    } else {
+                        if let rotateTurns = rotateTurns {
+                            let normalizedRotation = (rotateTurns % 4 + 4) % 4
+                            if normalizedRotation == 1 || normalizedRotation == 3 {
+                                finalRenderSize = CGSize(
+                                    width: finalRenderSize.height,
+                                    height: finalRenderSize.width
+                                )
+                            }
+                        }
                     }
 
                     let effectiveScaleX = scaleX ?? 1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 0.1.5
+version: 0.1.6
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [x] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
When applying rotation transforms (90° or 270°) without explicit crop settings, the output video displays with incorrect aspect ratio and appears squeezed with black bars. The video content gets rotated but the render dimensions remain unchanged, causing rotated video content to be displayed in a container with the wrong aspect ratio.
Issue Number: #30

## New Behavior
Rotation transforms now automatically swap render dimensions for 90° and 270° rotations when cropping is not applied. The fix ensures that rotation operations only apply dimension swapping when cropping hasn't already handled it, preventing double-swapping issues while maintaining correct video output proportions.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
This fix resolves the dimension mismatch that occurs when rotating videos without explicit crop parameters. The solution intelligently handles the interaction between crop and rotation operations:

When cropping is applied: Uses the cropped dimensions which already account for rotation
When cropping is not applied: Applies rotation dimension swapping to the render size
Prevents double-swapping that would occur if both crop and render size logic handled rotation

## Technical changes:

Enhanced render size calculation logic in RenderVideo.swift
Added conditional rotation handling based on crop application
Maintains compatibility with existing crop + rotation combinations

The fix ensures proper video output dimensions for all rotation scenarios while preserving backward compatibility.
