### PR TITLE
fix(android): resolve crash when exporting video with overlay effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8
+- **FIX**(android): Fixed crash during video export when applying overlay effects. The issue was caused by using `ImmutableList.of(bitmapOverlay)` instead of a Kotlin-compatible list. This has been resolved by using `listOf(bitmapOverlay)` instead.
+- **CHORE**(android): Updated `media3` dependencies to the latest stable versions for better compatibility and stability.
+
 ## 0.1.7
 - **FIX**(iOS, macOS): Resolved a crash that occurred when setting playback speed below 1x. This resolves issue [#29](https://github.com/hm21/pro_video_editor/issues/29).
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,13 +49,13 @@ android {
 
     dependencies {
         testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation("org.mockito:mockito-core:5.0.0")
+        testImplementation("org.mockito:mockito-core:5.1.1")
         
         // Media3 dependencies
-        implementation "androidx.media3:media3-common:1.4.1"
-        implementation("androidx.media3:media3-transformer:1.4.1")
-        implementation("androidx.media3:media3-effect:1.4.1")
-        implementation("androidx.media3:media3-muxer:1.4.1")
+        implementation "androidx.media3:media3-common:1.7.1"
+        implementation("androidx.media3:media3-transformer:1.7.1")
+        implementation("androidx.media3:media3-effect:1.7.1")
+        implementation("androidx.media3:media3-muxer:1.7.1")
         
         // Coroutines
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
@@ -54,7 +54,7 @@ fun applyImageLayer(
         Bitmap.createScaledBitmap(overlayBitmap, videoWidth, videoHeight, true)
 
     val bitmapOverlay = BitmapOverlay.createStaticBitmapOverlay(scaledOverlay)
-    val overlayEffect = OverlayEffect(ImmutableList.of(bitmapOverlay))
+    val overlayEffect = OverlayEffect(listOf(bitmapOverlay))
 
     videoEffects += overlayEffect
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [x] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Breaking Changes?
Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Current Behavior
The app crashes during video export when an overlay is applied. This was due to an incorrect usage of `ImmutableList.of(bitmapOverlay)` which caused issues in certain environments.

## New Behavior
The crash has been resolved by replacing the incorrect usage with a standard Kotlin list:  
```kotlin
val overlayEffect = OverlayEffect(listOf(bitmapOverlay))



