### PR TITLE
feat: Add customAudioStartTime option to VideoRenderData for audio offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.8.0
+- **FEAT**(android, iOS, macOS): Add `customAudioStartTime` option to `VideoRenderData`. Allows starting the custom audio track from a specific offset instead of from the beginning. Useful for using a specific section of a longer audio file.
+
 ## 1.7.0
 - **FEAT**(android, iOS, macOS): Add `loopCustomAudio` option to `VideoRenderData`. When `false`, custom audio plays once instead of looping to match the video duration. Defaults to `true` for backward compatibility.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/AudioSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/AudioSequenceBuilder.kt
@@ -27,6 +27,7 @@ class AudioSequenceBuilder(
     private var volume: Float = 1.0f
     private var needsNormalization: Boolean = false
     private var loopAudio: Boolean = true
+    private var startTimeUs: Long = 0
 
     /**
      * Sets the volume multiplier for the custom audio.
@@ -60,6 +61,16 @@ class AudioSequenceBuilder(
     }
 
     /**
+     * Sets the start time offset for the custom audio.
+     *
+     * @param startTimeUs Start time in microseconds from the beginning of the audio file
+     */
+    fun setStartTime(startTimeUs: Long?): AudioSequenceBuilder {
+        this.startTimeUs = startTimeUs ?: 0
+        return this
+    }
+
+    /**
      * Builds the audio sequence with looping to match video duration.
      *
      * @return EditedMediaItemSequence for custom audio, or null if file not found
@@ -67,6 +78,9 @@ class AudioSequenceBuilder(
     fun build(): EditedMediaItemSequence? {
         Log.d(RENDER_TAG, "Building custom audio sequence: $audioPath")
         Log.d(RENDER_TAG, "Custom audio volume: $volume")
+        if (startTimeUs > 0) {
+            Log.d(RENDER_TAG, "Custom audio start offset: ${startTimeUs / 1000} ms")
+        }
 
         val audioFile = File(audioPath)
         if (!audioFile.exists()) {
@@ -74,9 +88,16 @@ class AudioSequenceBuilder(
             return null
         }
 
-        val audioDurationUs = MediaInfoExtractor.getAudioDuration(audioPath)
-        if (audioDurationUs == 0L) {
+        val totalAudioDurationUs = MediaInfoExtractor.getAudioDuration(audioPath)
+        if (totalAudioDurationUs == 0L) {
             Log.w(RENDER_TAG, "Cannot determine custom audio duration")
+            return null
+        }
+
+        // Calculate effective audio duration after start offset
+        val effectiveAudioDurationUs = totalAudioDurationUs - startTimeUs
+        if (effectiveAudioDurationUs <= 0) {
+            Log.w(RENDER_TAG, "Start time ($startTimeUs us) exceeds audio duration ($totalAudioDurationUs us)")
             return null
         }
 
@@ -86,9 +107,9 @@ class AudioSequenceBuilder(
 
         // Create audio items with looping or single play
         val audioItems = if (loopAudio) {
-            createLoopedAudioItems(audioFile, audioDurationUs, audioEffects)
+            createLoopedAudioItems(audioFile, totalAudioDurationUs, effectiveAudioDurationUs, audioEffects)
         } else {
-            createSingleAudioItem(audioFile, audioDurationUs, audioEffects)
+            createSingleAudioItem(audioFile, effectiveAudioDurationUs, audioEffects)
         }
 
         return EditedMediaItemSequence.Builder(audioItems).build()
@@ -163,43 +184,53 @@ class AudioSequenceBuilder(
 
     /**
      * Creates audio items with looping to match video duration.
+     * First iteration uses startTimeUs offset, subsequent loops start from beginning.
      */
     private fun createLoopedAudioItems(
         audioFile: File,
-        audioDurationUs: Long,
+        totalAudioDurationUs: Long,
+        effectiveAudioDurationUs: Long,
         effects: Effects
     ): List<EditedMediaItem> {
         val audioItems = mutableListOf<EditedMediaItem>()
 
-        if (audioDurationUs <= 0 || videoDurationUs <= 0) {
+        if (effectiveAudioDurationUs <= 0 || videoDurationUs <= 0) {
             // Fallback: add audio once without duration constraints
-            val audioItem = createAudioItem(audioFile, null, effects)
+            val audioItem = createAudioItem(audioFile, startTimeUs, null, effects)
             audioItems.add(audioItem)
             return audioItems
         }
 
         var remainingDurationUs = videoDurationUs
         var loopCount = 0
+        var isFirstLoop = true
 
         while (remainingDurationUs > 0) {
             loopCount++
-            val trimDurationUs = if (remainingDurationUs < audioDurationUs) {
+            
+            // First loop uses startTimeUs offset, subsequent loops start from 0
+            val loopStartUs = if (isFirstLoop) startTimeUs else 0L
+            val loopAudioDurationUs = if (isFirstLoop) effectiveAudioDurationUs else totalAudioDurationUs
+            
+            val endPositionUs = if (remainingDurationUs < loopAudioDurationUs) {
                 Log.d(
                     RENDER_TAG,
                     "Loop $loopCount: Trimming audio to ${remainingDurationUs / 1000} ms (final loop)"
                 )
-                remainingDurationUs
+                loopStartUs + remainingDurationUs
             } else {
                 Log.d(
                     RENDER_TAG,
-                    "Loop $loopCount: Using full audio duration ${audioDurationUs / 1000} ms"
+                    "Loop $loopCount: Using audio duration ${loopAudioDurationUs / 1000} ms" +
+                    if (isFirstLoop && startTimeUs > 0) " (starting at ${startTimeUs / 1000} ms)" else ""
                 )
-                null
+                null // Use full remaining audio
             }
 
-            val audioItem = createAudioItem(audioFile, trimDurationUs, effects)
+            val audioItem = createAudioItem(audioFile, loopStartUs, endPositionUs, effects)
             audioItems.add(audioItem)
-            remainingDurationUs -= audioDurationUs
+            remainingDurationUs -= loopAudioDurationUs
+            isFirstLoop = false
         }
 
         Log.d(RENDER_TAG, "Custom audio will loop $loopCount times to match video duration")
@@ -211,35 +242,40 @@ class AudioSequenceBuilder(
      */
     private fun createSingleAudioItem(
         audioFile: File,
-        audioDurationUs: Long,
+        effectiveAudioDurationUs: Long,
         effects: Effects
     ): List<EditedMediaItem> {
-        val trimDurationUs = if (audioDurationUs > videoDurationUs && videoDurationUs > 0) {
+        val endPositionUs = if (effectiveAudioDurationUs > videoDurationUs && videoDurationUs > 0) {
             Log.d(RENDER_TAG, "Trimming audio to ${videoDurationUs / 1000} ms (no loop)")
-            videoDurationUs
+            startTimeUs + videoDurationUs
         } else {
-            Log.d(RENDER_TAG, "Playing audio once (${audioDurationUs / 1000} ms, no loop)")
+            Log.d(RENDER_TAG, "Playing audio once (${effectiveAudioDurationUs / 1000} ms, no loop)" +
+                if (startTimeUs > 0) " starting at ${startTimeUs / 1000} ms" else "")
             null
         }
-        return listOf(createAudioItem(audioFile, trimDurationUs, effects))
+        return listOf(createAudioItem(audioFile, startTimeUs, endPositionUs, effects))
     }
 
     /**
-     * Creates a single audio EditedMediaItem with optional trimming.
+     * Creates a single audio EditedMediaItem with start offset and optional end position.
      */
     private fun createAudioItem(
         audioFile: File,
-        trimDurationUs: Long?,
+        startPositionUs: Long,
+        endPositionUs: Long?,
         effects: Effects
     ): EditedMediaItem {
         val mediaItemBuilder = MediaItem.Builder().setUri(Uri.fromFile(audioFile))
 
-        if (trimDurationUs != null) {
+        if (startPositionUs > 0 || endPositionUs != null) {
             val clippingConfig = MediaItem.ClippingConfiguration.Builder()
-                .setStartPositionMs(0)
-                .setEndPositionMs(trimDurationUs / 1000)
-                .build()
-            mediaItemBuilder.setClippingConfiguration(clippingConfig)
+                .setStartPositionMs(startPositionUs / 1000)
+            
+            if (endPositionUs != null) {
+                clippingConfig.setEndPositionMs(endPositionUs / 1000)
+            }
+            
+            mediaItemBuilder.setClippingConfiguration(clippingConfig.build())
         }
 
         val mediaItem = mediaItemBuilder.build()

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
@@ -111,6 +111,7 @@ class CompositionBuilder(
                 .setVolume(config.customAudioVolume ?: 1.0f)
                 .setNormalization(needsNormalization)
                 .setLoop(config.loopCustomAudio)
+                .setStartTime(config.customAudioStartTimeUs)
                 .build()
 
             if (audioSequence != null) {

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -37,6 +37,8 @@ data class RenderConfig(
     val colorMatrixList: List<List<Double>> = emptyList(),
     val blur: Double? = null,
     val customAudioPath: String? = null,
+    /** Start time offset in microseconds for the custom audio track */
+    val customAudioStartTimeUs: Long? = null,
     val originalAudioVolume: Float? = null,
     val customAudioVolume: Float? = null,
     /** Global start time in microseconds for trimming the final composition */
@@ -128,6 +130,7 @@ data class RenderConfig(
                     ?: emptyList(),
                 blur = call.argument<Number>("blur")?.toDouble(),
                 customAudioPath = call.argument<String?>("customAudioPath"),
+                customAudioStartTimeUs = call.argument<Number?>("customAudioStartTimeUs")?.toLong(),
                 originalAudioVolume = call.argument<Number?>("originalAudioVolume")?.toFloat(),
                 customAudioVolume = call.argument<Number?>("customAudioVolume")?.toFloat(),
                 startUs = call.argument<Number?>("startUs")?.toLong(),

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -152,14 +152,31 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
 
     final directory = await getTemporaryDirectory();
 
+    // Ensure directory exists
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+
     // Extract just the filename from the asset path
     final fileName = assetPath.split('/').last;
     final file = File('${directory.path}/$fileName');
+
+    // Ensure parent directory exists
+    final parent = file.parent;
+    if (!await parent.exists()) {
+      await parent.create(recursive: true);
+    }
 
     await file.writeAsBytes(
       buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
       flush: true,
     );
+
+    // Verify the file was written successfully
+    if (!await file.exists()) {
+      throw Exception('Failed to write audio file to: ${file.path}');
+    }
+    debugPrint('Audio file written to: ${file.path}');
 
     return file;
   }
@@ -241,6 +258,28 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
       originalAudioVolume: 0.0,
       customAudioVolume: 1.0,
       loopCustomAudio: false,
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Start custom audio from a specific offset.
+  ///
+  /// This example demonstrates how to use `customAudioStartTime` to start
+  /// playing the custom audio from a specific position instead of from the
+  /// beginning. This is useful for using a specific section of a longer
+  /// audio file.
+  Future<void> _customAudioStartOffset() async {
+    final customAudioFile =
+        await _writeAssetAudioToFile(kVideoEditorExampleAudio1Path);
+
+    var data = VideoRenderData(
+      video: _video,
+      customAudioPath: customAudioFile.path,
+      customAudioStartTime: const Duration(seconds: 5), // Start at 5 seconds
+      loopCustomAudio: false,
+      originalAudioVolume: 0.0,
+      customAudioVolume: 1.0,
     );
 
     await _renderVideo(data);
@@ -741,6 +780,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           leading: const Icon(Icons.music_off_outlined),
           title: const Text('Custom Audio Without Loop'),
           subtitle: const Text('Plays once, then silence'),
+        ),
+        ListTile(
+          onTap: _customAudioStartOffset,
+          leading: const Icon(Icons.skip_next_outlined),
+          title: const Text('Custom Audio with Start Offset'),
+          subtitle: const Text('Start at 5 seconds into audio'),
         ),
         ..._buildSectionTitle('Quality'),
         ListTile(

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,7 +10,7 @@ import file_picker
 import media_kit_libs_macos_video
 import media_kit_video
 import package_info_plus
-import path_provider_foundation
+import pro_image_editor
 import pro_video_editor
 import shared_preferences_foundation
 import video_player_avfoundation
@@ -23,7 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  ProImageEditorPlugin.register(with: registry.registrar(forPlugin: "ProImageEditorPlugin"))
   ProVideoEditorPlugin.register(with: registry.registrar(forPlugin: "ProVideoEditorPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))

--- a/ios/Classes/src/features/render/RenderVideo.swift
+++ b/ios/Classes/src/features/render/RenderVideo.swift
@@ -106,6 +106,7 @@ class RenderVideo {
                             videoEffects: effectsConfig,
                             enableAudio: config.enableAudio,
                             customAudioPath: config.customAudioPath,
+                            customAudioStartTimeUs: config.customAudioStartTimeUs,
                             originalAudioVolume: config.originalAudioVolume,
                             customAudioVolume: config.customAudioVolume,
                             loopCustomAudio: config.loopCustomAudio

--- a/ios/Classes/src/features/render/helpers/ApplyComposition.swift
+++ b/ios/Classes/src/features/render/helpers/ApplyComposition.swift
@@ -12,6 +12,7 @@ import Foundation
 ///   - videoEffects: Configuration for visual effects (rotation, scale, color, blur, etc.).
 ///   - enableAudio: If true, includes original audio from video clips.
 ///   - customAudioPath: Optional path to custom audio file to mix over the video.
+///   - customAudioStartTimeUs: Start time offset in microseconds for the custom audio.
 ///   - originalAudioVolume: Volume for original video audio (0.0 to 1.0). Default 1.0.
 ///   - customAudioVolume: Volume for custom audio track (0.0 to 1.0). Default 1.0.
 ///
@@ -28,6 +29,7 @@ func applyComposition(
     videoEffects: VideoCompositorConfig,
     enableAudio: Bool,
     customAudioPath: String?,
+    customAudioStartTimeUs: Int64?,
     originalAudioVolume: Float?,
     customAudioVolume: Float?,
     loopCustomAudio: Bool
@@ -35,6 +37,7 @@ func applyComposition(
     return try await CompositionBuilder(videoClips: videoClips, videoEffects: videoEffects)
         .setEnableAudio(enableAudio)
         .setCustomAudioPath(customAudioPath)
+        .setCustomAudioStartTime(customAudioStartTimeUs)
         .setOriginalAudioVolume(originalAudioVolume)
         .setCustomAudioVolume(customAudioVolume)
         .setLoopCustomAudio(loopCustomAudio)

--- a/ios/Classes/src/features/render/helpers/AudioSequenceBuilder.swift
+++ b/ios/Classes/src/features/render/helpers/AudioSequenceBuilder.swift
@@ -11,6 +11,7 @@ internal class AudioSequenceBuilder {
     private let targetDuration: CMTime
     private var volume: Float = 1.0
     private var loopAudio: Bool = true
+    private var startTime: CMTime = .zero
     
     /// Initializes builder with audio path and target duration.
     ///
@@ -37,6 +38,17 @@ internal class AudioSequenceBuilder {
     /// - Returns: Self for chaining
     func setLoop(_ loop: Bool) -> AudioSequenceBuilder {
         self.loopAudio = loop
+        return self
+    }
+    
+    /// Sets the start time offset for the custom audio.
+    ///
+    /// - Parameter startTimeUs: Start time in microseconds from the beginning of the audio file
+    /// - Returns: Self for chaining
+    func setStartTime(_ startTimeUs: Int64?) -> AudioSequenceBuilder {
+        if let startTimeUs = startTimeUs, startTimeUs > 0 {
+            self.startTime = CMTime(value: startTimeUs, timescale: 1_000_000)
+        }
         return self
     }
     
@@ -72,33 +84,52 @@ internal class AudioSequenceBuilder {
             audioDuration = audioAsset.duration
         }
         
+        // Calculate effective audio duration after start offset
+        let effectiveAudioDuration = CMTimeSubtract(audioDuration, startTime)
+        if CMTimeCompare(effectiveAudioDuration, .zero) <= 0 {
+            print("⚠️ Start time (\(startTime.seconds)s) exceeds audio duration (\(audioDuration.seconds)s)")
+            return nil
+        }
+        
+        if CMTimeCompare(startTime, .zero) > 0 {
+            print("🎵 Custom audio start offset: \(startTime.seconds)s")
+        }
+        
         // Trim or loop custom audio to match video duration
-        if audioDuration > targetDuration {
-            // Trim audio to match video duration
-            let timeRange = CMTimeRange(start: .zero, duration: targetDuration)
+        if CMTimeCompare(effectiveAudioDuration, targetDuration) > 0 {
+            // Trim audio to match video duration (starting from startTime)
+            let timeRange = CMTimeRange(start: startTime, duration: targetDuration)
             try compositionAudioTrack.insertTimeRange(timeRange, of: audioTrack, at: .zero)
             print("✂️ Custom audio trimmed to \(targetDuration.seconds)s")
         } else if loopAudio {
             // Loop audio to match video duration
             var currentTime = CMTime.zero
             var loopCount = 0
+            var isFirstLoop = true
             
-            while currentTime < targetDuration {
+            while CMTimeCompare(currentTime, targetDuration) < 0 {
+                loopCount += 1
                 let remainingDuration = CMTimeSubtract(targetDuration, currentTime)
-                let insertDuration = CMTimeMinimum(audioDuration, remainingDuration)
-                let timeRange = CMTimeRange(start: .zero, duration: insertDuration)
+                
+                // First loop uses startTime offset, subsequent loops start from beginning
+                let loopStartTime = isFirstLoop ? startTime : .zero
+                let loopAudioDuration = isFirstLoop ? effectiveAudioDuration : audioDuration
+                
+                let insertDuration = CMTimeMinimum(loopAudioDuration, remainingDuration)
+                let timeRange = CMTimeRange(start: loopStartTime, duration: insertDuration)
                 
                 try compositionAudioTrack.insertTimeRange(timeRange, of: audioTrack, at: currentTime)
                 currentTime = CMTimeAdd(currentTime, insertDuration)
-                loopCount += 1
+                isFirstLoop = false
             }
             
             print("🔄 Custom audio looped \(loopCount) times to match \(targetDuration.seconds)s duration")
         } else {
-            // Play audio once without looping
-            let timeRange = CMTimeRange(start: .zero, duration: audioDuration)
+            // Play audio once without looping (starting from startTime)
+            let timeRange = CMTimeRange(start: startTime, duration: effectiveAudioDuration)
             try compositionAudioTrack.insertTimeRange(timeRange, of: audioTrack, at: .zero)
-            print("▶️ Custom audio plays once (\(audioDuration.seconds)s, no loop)")
+            print("▶️ Custom audio plays once (\(effectiveAudioDuration.seconds)s, no loop)" + 
+                  (CMTimeCompare(startTime, .zero) > 0 ? " starting at \(startTime.seconds)s" : ""))
         }
         
         if volume != 1.0 {

--- a/ios/Classes/src/features/render/helpers/CompositionBuilder.swift
+++ b/ios/Classes/src/features/render/helpers/CompositionBuilder.swift
@@ -12,6 +12,7 @@ internal class CompositionBuilder {
     private let videoEffects: VideoCompositorConfig
     private var enableAudio: Bool = true
     private var customAudioPath: String?
+    private var customAudioStartTimeUs: Int64?
     private var originalAudioVolume: Float = 1.0
     private var customAudioVolume: Float = 1.0
     private var loopCustomAudio: Bool = true
@@ -41,6 +42,15 @@ internal class CompositionBuilder {
     /// - Returns: Self for chaining
     func setCustomAudioPath(_ path: String?) -> CompositionBuilder {
         self.customAudioPath = path
+        return self
+    }
+    
+    /// Sets the start time offset for the custom audio.
+    ///
+    /// - Parameter startTimeUs: Start time in microseconds from the beginning of the audio file
+    /// - Returns: Self for chaining
+    func setCustomAudioStartTime(_ startTimeUs: Int64?) -> CompositionBuilder {
+        self.customAudioStartTimeUs = startTimeUs
         return self
     }
     
@@ -111,6 +121,7 @@ internal class CompositionBuilder {
                 targetDuration: videoResult.totalDuration
             ).setVolume(customAudioVolume)
              .setLoop(loopCustomAudio)
+             .setStartTime(customAudioStartTimeUs)
             
             customAudioTrack = try await audioBuilder.build(in: composition)
         }

--- a/ios/Classes/src/features/render/models/RenderConfig.swift
+++ b/ios/Classes/src/features/render/models/RenderConfig.swift
@@ -64,6 +64,9 @@ struct RenderConfig {
     /// Absolute path to custom audio file to mix in (nil = no custom audio)
     let customAudioPath: String?
     
+    /// Start time offset in microseconds for the custom audio track
+    let customAudioStartTimeUs: Int64?
+    
     /// Volume for original video audio (0.0-1.0, nil = 1.0)
     let originalAudioVolume: Float?
     
@@ -154,6 +157,7 @@ struct RenderConfig {
             colorMatrixList: colorMatrixList,
             blur: (args["blur"] as? NSNumber)?.doubleValue,
             customAudioPath: args["customAudioPath"] as? String,
+            customAudioStartTimeUs: (args["customAudioStartTimeUs"] as? NSNumber)?.int64Value,
             originalAudioVolume: (args["originalAudioVolume"] as? NSNumber)?.floatValue,
             customAudioVolume: (args["customAudioVolume"] as? NSNumber)?.floatValue,
             startUs: (args["startUs"] as? NSNumber)?.int64Value,

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -29,6 +29,7 @@ class VideoRenderData {
     this.colorMatrixList = const [],
     this.qualityConfig,
     this.customAudioPath,
+    this.customAudioStartTime,
     this.originalAudioVolume,
     this.customAudioVolume,
     this.shouldOptimizeForNetworkUse = false,
@@ -101,6 +102,7 @@ class VideoRenderData {
     int? bitrateOverride,
     List<List<double>> colorMatrixList = const [],
     String? customAudioPath,
+    Duration? customAudioStartTime,
     double? originalAudioVolume,
     double? customAudioVolume,
     bool shouldOptimizeForNetworkUse = false,
@@ -125,6 +127,7 @@ class VideoRenderData {
       colorMatrixList: colorMatrixList,
       qualityConfig: qualityConfig,
       customAudioPath: customAudioPath,
+      customAudioStartTime: customAudioStartTime,
       originalAudioVolume: originalAudioVolume,
       customAudioVolume: customAudioVolume,
       shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
@@ -234,6 +237,15 @@ class VideoRenderData {
   /// Use [originalAudioVolume] and [customAudioVolume] to control the mix
   /// levels of each audio track.
   final String? customAudioPath;
+
+  /// The start time offset for the custom audio track.
+  ///
+  /// When provided, the custom audio will start playing from this position
+  /// instead of from the beginning. This is useful for using a specific
+  /// section of a longer audio file.
+  ///
+  /// This parameter is only effective when [customAudioPath] is provided.
+  final Duration? customAudioStartTime;
 
   /// Volume multiplier for the original video audio track.
   ///
@@ -372,6 +384,7 @@ class VideoRenderData {
       'scaleX': scaleX,
       'scaleY': scaleY,
       'customAudioPath': customAudioPath,
+      'customAudioStartTimeUs': customAudioStartTime?.inMicroseconds,
       'originalAudioVolume': originalAudioVolume,
       'customAudioVolume': customAudioVolume,
       // Global trim for entire composition (only for videoSegments,
@@ -402,6 +415,7 @@ class VideoRenderData {
     int? bitrate,
     VideoQualityConfig? qualityConfig,
     String? customAudioPath,
+    Duration? customAudioStartTime,
     double? originalAudioVolume,
     double? customAudioVolume,
     bool? shouldOptimizeForNetworkUse,
@@ -424,6 +438,7 @@ class VideoRenderData {
       bitrate: bitrate ?? this.bitrate,
       qualityConfig: qualityConfig ?? this.qualityConfig,
       customAudioPath: customAudioPath ?? this.customAudioPath,
+      customAudioStartTime: customAudioStartTime ?? this.customAudioStartTime,
       originalAudioVolume: originalAudioVolume ?? this.originalAudioVolume,
       customAudioVolume: customAudioVolume ?? this.customAudioVolume,
       shouldOptimizeForNetworkUse:

--- a/macos/Classes/src/features/render/RenderVideo.swift
+++ b/macos/Classes/src/features/render/RenderVideo.swift
@@ -107,6 +107,7 @@ class RenderVideo {
                             videoEffects: effectsConfig,
                             enableAudio: config.enableAudio,
                             customAudioPath: config.customAudioPath,
+                            customAudioStartTimeUs: config.customAudioStartTimeUs,
                             originalAudioVolume: config.originalAudioVolume,
                             customAudioVolume: config.customAudioVolume,
                             loopCustomAudio: config.loopCustomAudio

--- a/macos/Classes/src/features/render/helpers/ApplyComposition.swift
+++ b/macos/Classes/src/features/render/helpers/ApplyComposition.swift
@@ -12,6 +12,7 @@ import Foundation
 ///   - videoEffects: Configuration for visual effects (rotation, scale, color, blur, etc.).
 ///   - enableAudio: If true, includes original audio from video clips.
 ///   - customAudioPath: Optional path to custom audio file to mix over the video.
+///   - customAudioStartTimeUs: Start time offset in microseconds for the custom audio.
 ///   - originalAudioVolume: Volume for original video audio (0.0 to 1.0). Default 1.0.
 ///   - customAudioVolume: Volume for custom audio track (0.0 to 1.0). Default 1.0.
 ///
@@ -28,6 +29,7 @@ func applyComposition(
     videoEffects: VideoCompositorConfig,
     enableAudio: Bool,
     customAudioPath: String?,
+    customAudioStartTimeUs: Int64?,
     originalAudioVolume: Float?,
     customAudioVolume: Float?,
     loopCustomAudio: Bool
@@ -35,6 +37,7 @@ func applyComposition(
     return try await CompositionBuilder(videoClips: videoClips, videoEffects: videoEffects)
         .setEnableAudio(enableAudio)
         .setCustomAudioPath(customAudioPath)
+        .setCustomAudioStartTime(customAudioStartTimeUs)
         .setOriginalAudioVolume(originalAudioVolume)
         .setCustomAudioVolume(customAudioVolume)
         .setLoopCustomAudio(loopCustomAudio)

--- a/macos/Classes/src/features/render/helpers/AudioSequenceBuilder.swift
+++ b/macos/Classes/src/features/render/helpers/AudioSequenceBuilder.swift
@@ -11,6 +11,7 @@ internal class AudioSequenceBuilder {
     private let targetDuration: CMTime
     private var volume: Float = 1.0
     private var loopAudio: Bool = true
+    private var startTime: CMTime = .zero
     
     /// Initializes builder with audio path and target duration.
     ///
@@ -37,6 +38,17 @@ internal class AudioSequenceBuilder {
     /// - Returns: Self for chaining
     func setLoop(_ loop: Bool) -> AudioSequenceBuilder {
         self.loopAudio = loop
+        return self
+    }
+    
+    /// Sets the start time offset for the custom audio.
+    ///
+    /// - Parameter startTimeUs: Start time in microseconds from the beginning of the audio file
+    /// - Returns: Self for chaining
+    func setStartTime(_ startTimeUs: Int64?) -> AudioSequenceBuilder {
+        if let startTimeUs = startTimeUs, startTimeUs > 0 {
+            self.startTime = CMTime(value: startTimeUs, timescale: 1_000_000)
+        }
         return self
     }
     
@@ -72,33 +84,52 @@ internal class AudioSequenceBuilder {
             audioDuration = audioAsset.duration
         }
         
+        // Calculate effective audio duration after start offset
+        let effectiveAudioDuration = CMTimeSubtract(audioDuration, startTime)
+        if CMTimeCompare(effectiveAudioDuration, .zero) <= 0 {
+            print("⚠️ Start time (\(startTime.seconds)s) exceeds audio duration (\(audioDuration.seconds)s)")
+            return nil
+        }
+        
+        if CMTimeCompare(startTime, .zero) > 0 {
+            print("🎵 Custom audio start offset: \(startTime.seconds)s")
+        }
+        
         // Trim or loop custom audio to match video duration
-        if audioDuration > targetDuration {
-            // Trim audio to match video duration
-            let timeRange = CMTimeRange(start: .zero, duration: targetDuration)
+        if CMTimeCompare(effectiveAudioDuration, targetDuration) > 0 {
+            // Trim audio to match video duration (starting from startTime)
+            let timeRange = CMTimeRange(start: startTime, duration: targetDuration)
             try compositionAudioTrack.insertTimeRange(timeRange, of: audioTrack, at: .zero)
             print("✂️ Custom audio trimmed to \(targetDuration.seconds)s")
         } else if loopAudio {
             // Loop audio to match video duration
             var currentTime = CMTime.zero
             var loopCount = 0
+            var isFirstLoop = true
             
-            while currentTime < targetDuration {
+            while CMTimeCompare(currentTime, targetDuration) < 0 {
+                loopCount += 1
                 let remainingDuration = CMTimeSubtract(targetDuration, currentTime)
-                let insertDuration = CMTimeMinimum(audioDuration, remainingDuration)
-                let timeRange = CMTimeRange(start: .zero, duration: insertDuration)
+                
+                // First loop uses startTime offset, subsequent loops start from beginning
+                let loopStartTime = isFirstLoop ? startTime : .zero
+                let loopAudioDuration = isFirstLoop ? effectiveAudioDuration : audioDuration
+                
+                let insertDuration = CMTimeMinimum(loopAudioDuration, remainingDuration)
+                let timeRange = CMTimeRange(start: loopStartTime, duration: insertDuration)
                 
                 try compositionAudioTrack.insertTimeRange(timeRange, of: audioTrack, at: currentTime)
                 currentTime = CMTimeAdd(currentTime, insertDuration)
-                loopCount += 1
+                isFirstLoop = false
             }
             
             print("🔄 Custom audio looped \(loopCount) times to match \(targetDuration.seconds)s duration")
         } else {
-            // Play audio once without looping
-            let timeRange = CMTimeRange(start: .zero, duration: audioDuration)
+            // Play audio once without looping (starting from startTime)
+            let timeRange = CMTimeRange(start: startTime, duration: effectiveAudioDuration)
             try compositionAudioTrack.insertTimeRange(timeRange, of: audioTrack, at: .zero)
-            print("▶️ Custom audio plays once (\(audioDuration.seconds)s, no loop)")
+            print("▶️ Custom audio plays once (\(effectiveAudioDuration.seconds)s, no loop)" + 
+                  (CMTimeCompare(startTime, .zero) > 0 ? " starting at \(startTime.seconds)s" : ""))
         }
         
         if volume != 1.0 {

--- a/macos/Classes/src/features/render/helpers/CompositionBuilder.swift
+++ b/macos/Classes/src/features/render/helpers/CompositionBuilder.swift
@@ -12,6 +12,7 @@ internal class CompositionBuilder {
     private let videoEffects: VideoCompositorConfig
     private var enableAudio: Bool = true
     private var customAudioPath: String?
+    private var customAudioStartTimeUs: Int64?
     private var originalAudioVolume: Float = 1.0
     private var customAudioVolume: Float = 1.0
     private var loopCustomAudio: Bool = true
@@ -41,6 +42,15 @@ internal class CompositionBuilder {
     /// - Returns: Self for chaining
     func setCustomAudioPath(_ path: String?) -> CompositionBuilder {
         self.customAudioPath = path
+        return self
+    }
+    
+    /// Sets the start time offset for the custom audio.
+    ///
+    /// - Parameter startTimeUs: Start time in microseconds from the beginning of the audio file
+    /// - Returns: Self for chaining
+    func setCustomAudioStartTime(_ startTimeUs: Int64?) -> CompositionBuilder {
+        self.customAudioStartTimeUs = startTimeUs
         return self
     }
     
@@ -111,6 +121,7 @@ internal class CompositionBuilder {
                 targetDuration: videoResult.totalDuration
             ).setVolume(customAudioVolume)
              .setLoop(loopCustomAudio)
+             .setStartTime(customAudioStartTimeUs)
             
             customAudioTrack = try await audioBuilder.build(in: composition)
         }

--- a/macos/Classes/src/features/render/models/RenderConfig.swift
+++ b/macos/Classes/src/features/render/models/RenderConfig.swift
@@ -64,6 +64,9 @@ struct RenderConfig {
     /// Absolute path to custom audio file to mix in (nil = no custom audio)
     let customAudioPath: String?
     
+    /// Start time offset in microseconds for the custom audio track
+    let customAudioStartTimeUs: Int64?
+    
     /// Volume for original video audio (0.0-1.0, nil = 1.0)
     let originalAudioVolume: Float?
     
@@ -145,6 +148,7 @@ struct RenderConfig {
             colorMatrixList: colorMatrixList,
             blur: (args["blur"] as? NSNumber)?.doubleValue,
             customAudioPath: args["customAudioPath"] as? String,
+            customAudioStartTimeUs: (args["customAudioStartTimeUs"] as? NSNumber)?.int64Value,
             originalAudioVolume: (args["originalAudioVolume"] as? NSNumber)?.floatValue,
             customAudioVolume: (args["customAudioVolume"] as? NSNumber)?.floatValue,
             startUs: (args["startUs"] as? NSNumber)?.int64Value,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.7.0
+version: 1.8.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/pro_video_editor_method_channel_test.mocks.dart
+++ b/test/pro_video_editor_method_channel_test.mocks.dart
@@ -32,6 +32,7 @@ import 'package:pro_video_editor/pro_video_editor.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeEditorVideo_0 extends _i1.SmartFake implements _i2.EditorVideo {
   _FakeEditorVideo_0(
@@ -109,19 +110,19 @@ class MockEditorVideo extends _i1.Mock implements _i2.EditorVideo {
       ) as _i2.EditorVideoType);
 
   @override
-  set byteArray(_i5.Uint8List? _byteArray) => super.noSuchMethod(
+  set byteArray(_i5.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #byteArray,
-          _byteArray,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set file(_i6.File? _file) => super.noSuchMethod(
+  set file(_i6.File? value) => super.noSuchMethod(
         Invocation.setter(
           #file,
-          _file,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -420,6 +421,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
     int? bitrate,
     _i4.VideoQualityConfig? qualityConfig,
     String? customAudioPath,
+    Duration? customAudioStartTime,
     double? originalAudioVolume,
     double? customAudioVolume,
     bool? shouldOptimizeForNetworkUse,
@@ -446,6 +448,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
             #bitrate: bitrate,
             #qualityConfig: qualityConfig,
             #customAudioPath: customAudioPath,
+            #customAudioStartTime: customAudioStartTime,
             #originalAudioVolume: originalAudioVolume,
             #customAudioVolume: customAudioVolume,
             #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
@@ -474,6 +477,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
               #bitrate: bitrate,
               #qualityConfig: qualityConfig,
               #customAudioPath: customAudioPath,
+              #customAudioStartTime: customAudioStartTime,
               #originalAudioVolume: originalAudioVolume,
               #customAudioVolume: customAudioVolume,
               #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,


### PR DESCRIPTION
- Introduced `customAudioStartTime` in VideoRenderData to allow starting custom audio from a specific offset.
- Updated AudioSequenceBuilder to handle start time for custom audio.
- Modified CompositionBuilder and RenderConfig to support custom audio start time.
- Enhanced iOS and macOS implementations to respect the custom audio start time.
- Updated example video renderer page to demonstrate custom audio starting at a specific offset.
- Bumped version to 1.8.0 in pubspec.yaml.

## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
<!-- 
Please describe the behavior that is being modified, or link to a relevant issue. 
If the issue is already covered in the title, feel free to leave this section empty. 
-->

Issue Number: N/A

## New Behavior
<!-- If the title already explains the change, you can leave this section empty. -->

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
