### PR TITLE
feat: add optional size property to ImageLayer for custom scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.13.0
+- **FEAT**(android, iOS, macOS): Add optional `size` field on `ImageLayer` to scale overlay images to specific dimensions before rendering.
+
 ## 1.12.0
 - **FEAT**(android, iOS, macOS): Add layer animations with `LayerAnimation` on `ImageLayer`. Supports fade, slide, and scale animations with `animateIn`, `animateOut`, and `animateInOut` phases. Includes 13 easing curves: linear, easeIn, easeOut, easeInOut, easeInCubic, easeOutCubic, easeInOutCubic, bounceIn, bounceOut, bounceInOut, elasticIn, elasticOut, elasticInOut.
 - **FIX**(iOS, macOS): Replace deprecated `AVMutableVideoCompositionLayerInstruction` with `AVVideoCompositionLayerInstruction.Configuration` on macOS 26+ / iOS 26+, with backward-compatible fallback.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The ProVideoEditor is a Flutter widget designed for video editing within your ap
 #### 🎨 **Visual Effects**
 - 🖼️ **Layers**: Overlay a image like a text or drawings on the video.
 - 🕐 **Timed Image Layers**: Position image overlays at specific coordinates with optional start/end times.
+- 📐 **Layer Size**: Scale image layers to custom dimensions via the `size` property.
 - 🎬 **Layer Animations**: Animate image layers with fade, slide, and scale effects, configurable easing curves, and in/out/inOut phases.
 - 🧮 **Color Matrix**: Apply one or multiple 4x5 color matrices (e.g., for filters).
 - 💧 **Blur**: Add a blur effect to the video.
@@ -147,6 +148,7 @@ The ProVideoEditor is a Flutter widget designed for video editing within your ap
 | `Overlay Layers`           | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Timed Image Layers`       | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Layer Animations`          | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
+| `Layer Size`                | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Multiple ColorMatrix 4x5` | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Cancel export task`       | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Blur background`          | 🧪      | 🧪  | 🧪     | ❌      | ❌     | 🚫   |

--- a/README.md
+++ b/README.md
@@ -180,10 +180,14 @@ No additional setup required.
 #### Basic Example
 ```dart
 var data = VideoRenderData(
-    video: EditorVideo.asset('assets/my-video.mp4'),
-    // video: EditorVideo.file(File('/path/to/video.mp4')),
-    // video: EditorVideo.network('https://example.com/video.mp4'),
-    // video: EditorVideo.memory(videoBytes),
+    videoSegments: [
+        VideoSegment(
+            video: EditorVideo.asset('assets/my-video.mp4'),
+            // video: EditorVideo.file(File('/path/to/video.mp4')),
+            // video: EditorVideo.network('https://example.com/video.mp4'),
+            // video: EditorVideo.memory(videoBytes),
+        ),
+    ],
     enableAudio: false,
     startTime: const Duration(seconds: 5),
     endTime: const Duration(seconds: 20),
@@ -214,7 +218,9 @@ StreamBuilder<ProgressModel>(
 /// Use quality presets for simplified video export configuration
 /// Available presets: ultra4K, k4, p1080High, p1080, p720High, p720, p480, low, custom
 var data = VideoRenderData.withQualityPreset(
-    video: EditorVideo.asset('assets/my-video.mp4'),
+    videoSegments: [
+        VideoSegment(video: EditorVideo.asset('assets/my-video.mp4')),
+    ],
     qualityPreset: VideoQualityPreset.p1080,  // 1080p at 8 Mbps
     startTime: const Duration(seconds: 5),
     endTime: const Duration(seconds: 20),
@@ -224,7 +230,9 @@ Uint8List result = await ProVideoEditor.instance.renderVideo(data);
 
 /// Override the preset's bitrate if needed
 var customData = VideoRenderData.withQualityPreset(
-    video: EditorVideo.asset('assets/my-video.mp4'),
+    videoSegments: [
+        VideoSegment(video: EditorVideo.asset('assets/my-video.mp4')),
+    ],
     qualityPreset: VideoQualityPreset.p720,
     bitrateOverride: 5000000,  // 5 Mbps instead of default 3 Mbps
 );
@@ -393,7 +401,9 @@ When you cancel a render started with `renderVideoToFile`, the returned `Future`
 
 ```dart
 final renderModel = VideoRenderData(
-  video: EditorVideo.asset('assets/sample.mp4'),
+  videoSegments: [
+    VideoSegment(video: EditorVideo.asset('assets/sample.mp4')),
+  ],
 );
 
 final outputPath = '${(await getTemporaryDirectory()).path}/video.mp4';
@@ -422,11 +432,15 @@ if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
 
 #### Advanced Example
 ```dart
-/// Every option except videoBytes is optional.
+/// Every option except videoSegments is optional.
 var task = VideoRenderData(
-    id: 'my-special-task'
-    video: EditorVideo.asset('assets/my-video.mp4'),
-    imageBytes: imageBytes, /// A image "Layer" which will overlay the video.
+    id: 'my-special-task',
+    videoSegments: [
+        VideoSegment(
+            video: EditorVideo.asset('assets/my-video.mp4'),
+            volume: 0.7, // Original audio at 70%
+        ),
+    ],
     imageLayers: [
       ImageLayer(
         imageBytes: layerBytes,
@@ -442,9 +456,12 @@ var task = VideoRenderData(
     blur: 10,
     bitrate: 5000000,
     enableAudio: false,
-    originalAudioVolume: 0.7, // Original audio at 70%
-    customAudioVolume: 0.3, // Background music at 30%
-    customAudioPath: customAudioPath,
+    audioTracks: [
+      VideoAudioTrack(
+        path: customAudioPath,
+        volume: 0.3, // Background music at 30%
+      ),
+    ],
     transform: const ExportTransform(
         flipX: true,
         flipY: true,
@@ -456,9 +473,9 @@ var task = VideoRenderData(
         scaleX: .5,
         scaleY: .5,
     ),
-    colorMatrixList: [
-         [ 1.0, 0.0, 0.0, 0.0, 50.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 ],
-         [ 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 ],
+    colorFilters: [
+         ColorFilter(matrix: [ 1.0, 0.0, 0.0, 0.0, 50.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 ]),
+         ColorFilter(matrix: [ 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 ]),
     ],
 );
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
@@ -87,6 +87,15 @@ fun applyTimedImageLayers(
                 imageBytes, 0, imageBytes.size, options
             )
 
+            // Scale to target size if provided
+            val sizedBitmap = if (layer.width != null && layer.height != null) {
+                val scaled = layerBitmap.scale(layer.width.toInt(), layer.height.toInt())
+                layerBitmap.recycle()
+                scaled
+            } else {
+                layerBitmap
+            }
+
             // Determine if this layer should stretch or be positioned
             val isStretched = layer.x == null && layer.y == null
 
@@ -97,12 +106,12 @@ fun applyTimedImageLayers(
 
             if (isStretched) {
                 // Stretch image to fill the entire video frame
-                val scaledOverlay = if (layerBitmap.width != videoWidth || layerBitmap.height != videoHeight) {
-                    val scaled = layerBitmap.scale(videoWidth, videoHeight)
-                    layerBitmap.recycle()
+                val scaledOverlay = if (sizedBitmap.width != videoWidth || sizedBitmap.height != videoHeight) {
+                    val scaled = sizedBitmap.scale(videoWidth, videoHeight)
+                    sizedBitmap.recycle()
                     scaled
                 } else {
-                    layerBitmap
+                    sizedBitmap
                 }
 
                 val unpremultiplied = unpremultiplyAlpha(scaledOverlay)
@@ -117,11 +126,11 @@ fun applyTimedImageLayers(
                 Log.d(RENDER_TAG, "Layer: stretched to ${videoWidth}x$videoHeight")
             } else {
                 // Position image at specified x/y offset
-                val imageWidth = layerBitmap.width
-                val imageHeight = layerBitmap.height
+                val imageWidth = sizedBitmap.width
+                val imageHeight = sizedBitmap.height
 
-                val unpremultiplied = unpremultiplyAlpha(layerBitmap)
-                if (unpremultiplied !== layerBitmap) layerBitmap.recycle()
+                val unpremultiplied = unpremultiplyAlpha(sizedBitmap)
+                if (unpremultiplied !== sizedBitmap) sizedBitmap.recycle()
                 finalOverlay = unpremultiplied
 
                 val x = layer.x ?: 0

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
@@ -79,6 +79,8 @@ class CompositionBuilder(
                     endUs = imageLayer.endUs,
                     x = imageLayer.x,
                     y = imageLayer.y,
+                    width = imageLayer.width,
+                    height = imageLayer.height,
                     animations = imageLayer.animations
                 )
             })

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -58,6 +58,8 @@ class VideoSequenceBuilder(
         val endUs: Long = -1,
         val x: Int? = null,
         val y: Int? = null,
+        val width: Double? = null,
+        val height: Double? = null,
         val animations: List<LayerAnimationConfig> = emptyList()
     )
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -121,6 +121,8 @@ data class LayerAnimationConfig(
  * @property endUs End time in microseconds when the layer should disappear (-1 = until end of video)
  * @property x Horizontal offset in pixels (null = stretch to fill)
  * @property y Vertical offset in pixels (null = stretch to fill)
+ * @property width Target width in pixels (null = original width)
+ * @property height Target height in pixels (null = original height)
  * @property animations List of animations to apply to this layer
  */
 data class ImageLayer(
@@ -129,6 +131,8 @@ data class ImageLayer(
     val endUs: Long,
     val x: Int? = null,
     val y: Int? = null,
+    val width: Double? = null,
+    val height: Double? = null,
     val animations: List<LayerAnimationConfig> = emptyList()
 ) {
     override fun equals(other: Any?): Boolean {
@@ -140,6 +144,8 @@ data class ImageLayer(
                 endUs == other.endUs &&
                 x == other.x &&
                 y == other.y &&
+                width == other.width &&
+                height == other.height &&
                 animations == other.animations
     }
 
@@ -149,6 +155,8 @@ data class ImageLayer(
         result = 31 * result + endUs.hashCode()
         result = 31 * result + (x?.hashCode() ?: 0)
         result = 31 * result + (y?.hashCode() ?: 0)
+        result = 31 * result + (width?.hashCode() ?: 0)
+        result = 31 * result + (height?.hashCode() ?: 0)
         result = 31 * result + animations.hashCode()
         return result
     }
@@ -240,6 +248,8 @@ data class RenderConfig(
                 val endUs = (layerMap["endUs"] as? Number)?.toLong() ?: -1L
                 val x = (layerMap["x"] as? Number)?.toInt()
                 val y = (layerMap["y"] as? Number)?.toInt()
+                val width = (layerMap["width"] as? Number)?.toDouble()
+                val height = (layerMap["height"] as? Number)?.toDouble()
 
                 // Parse animations
                 @Suppress("UNCHECKED_CAST")
@@ -249,7 +259,7 @@ data class RenderConfig(
                 if (imageData == null || imageData.isEmpty()) {
                     null
                 } else {
-                    ImageLayer(imageData, startUs, endUs, x, y, animations)
+                    ImageLayer(imageData, startUs, endUs, x, y, width, height, animations)
                 }
             } ?: emptyList()
 

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -452,6 +452,34 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     await _renderVideo(data);
   }
 
+  Future<void> _layersWithSize() async {
+    final stickerImage = EditorLayerImage.asset('assets/sticker.png');
+
+    var data = VideoRenderData(
+      videoSegments: [VideoSegment(video: _video)],
+      imageLayers: [
+        /// Scaled to 200×200 at top-left
+        ImageLayer(
+          image: stickerImage,
+          offset: const Offset(20, 20),
+          size: const Size(100, 100),
+        ),
+
+        /// Scaled to 400×100 (stretched) at bottom-right area
+        ImageLayer(
+          image: stickerImage,
+          offset: const Offset(800, 550),
+          size: const Size(400, 100),
+        ),
+
+        /// Original size (no size set) in the center
+        ImageLayer(image: stickerImage, offset: const Offset(500, 230)),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
   Future<void> _colorMatrix() async {
     var data = VideoRenderData(
       videoSegments: [VideoSegment(video: _video)],
@@ -1160,6 +1188,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           onTap: _layersTimed,
           leading: const Icon(Icons.av_timer_outlined),
           title: const Text('Parse with timed layers'),
+        ),
+        ListTile(
+          onTap: _layersWithSize,
+          leading: const Icon(Icons.photo_size_select_large_outlined),
+          title: const Text('Layers with custom size'),
+          subtitle: const Text('Scale layers to specific dimensions'),
         ),
         ListTile(
           onTap: _colorMatrix,

--- a/ios/Classes/src/features/render/models/RenderConfig.swift
+++ b/ios/Classes/src/features/render/models/RenderConfig.swift
@@ -43,6 +43,10 @@ struct ImageLayerConfig {
     let x: Int64?
     /// y position in pixels. When nil, the image is stretched to fill the video frame.
     let y: Int64?
+    /// Target width in pixels. When nil, the image is used at its original width.
+    let width: Double?
+    /// Target height in pixels. When nil, the image is used at its original height.
+    let height: Double?
     /// Animations to apply to this layer.
     let animations: [LayerAnimationConfig]
 
@@ -68,6 +72,10 @@ struct ImageLayerConfig {
             animations = animsRaw.compactMap { LayerAnimationConfig.fromArguments($0) }
         }
 
+        // Parse optional size
+        let width = (args["width"] as? NSNumber)?.doubleValue
+        let height = (args["height"] as? NSNumber)?.doubleValue
+
         // Use -1 as sentinel value for "from start" when startUs is null
         // Use -1 for endUs to signify "until the end of the video"
         return ImageLayerConfig(
@@ -76,6 +84,8 @@ struct ImageLayerConfig {
             endUs: (args["endUs"] as? NSNumber)?.int64Value ?? -1,
             x: (args["x"] as? NSNumber)?.int64Value,
             y: (args["y"] as? NSNumber)?.int64Value,
+            width: width,
+            height: height,
             animations: animations
         )
     }

--- a/ios/Classes/src/features/render/utils/VideoCompositor.swift
+++ b/ios/Classes/src/features/render/utils/VideoCompositor.swift
@@ -10,6 +10,10 @@ struct ImageLayer {
     let x: Int64?
     /// y position in pixels. When nil, the image is stretched to fill the video frame.
     let y: Int64?
+    /// Target width in pixels. When nil, the image is used at its original width.
+    let width: Double?
+    /// Target height in pixels. When nil, the image is used at its original height.
+    let height: Double?
     /// Animations applied to this layer.
     let animations: [LayerAnimationConfig]
 }
@@ -94,6 +98,8 @@ class VideoCompositor: NSObject, AVVideoCompositing {
                     endUs: layer.endUs,
                     x: layer.x,
                     y: layer.y,
+                    width: layer.width,
+                    height: layer.height,
                     animations: layer.animations
                 ))
         }
@@ -336,20 +342,28 @@ class VideoCompositor: NSObject, AVVideoCompositing {
                     && (layer.endUs == -1 || currentTimeUs <= layer.endUs)
 
                 if inTimeRange {
+                    var img = layer.image
+
+                    if let w = layer.width, let h = layer.height {
+                        let sx = CGFloat(w) / img.extent.width
+                        let sy = CGFloat(h) / img.extent.height
+                        img = img.transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+                    }
+
                     let overlay: CIImage
                     if layer.x == nil && layer.y == nil {
                         // Stretch to fill frame when no position is specified
-                        overlay = layer.image.transformed(
+                        overlay = img.transformed(
                             by: CGAffineTransform(
-                                scaleX: imageRect.width / layer.image.extent.width,
-                                y: imageRect.height / layer.image.extent.height))
+                                scaleX: imageRect.width / img.extent.width,
+                                y: imageRect.height / img.extent.height))
                     } else {
                         // Position at specific coordinates
                         let posX = CGFloat(layer.x ?? 0)
                         let posY = CGFloat(layer.y ?? 0)
                         // Convert y from top-left (Dart) to bottom-left (Core Graphics)
-                        let cgY = imageRect.height - posY - layer.image.extent.height
-                        overlay = layer.image.transformed(
+                        let cgY = imageRect.height - posY - img.extent.height
+                        overlay = img.transformed(
                             by: CGAffineTransform(translationX: posX, y: cgY))
                     }
 
@@ -449,20 +463,28 @@ class VideoCompositor: NSObject, AVVideoCompositing {
                     (layer.startUs == -1 || currentTimeUs >= layer.startUs)
                     && (layer.endUs == -1 || currentTimeUs <= layer.endUs)
                 if inTimeRange {
+                    var img = layer.image
+
+                    if let w = layer.width, let h = layer.height {
+                        let sx = CGFloat(w) / img.extent.width
+                        let sy = CGFloat(h) / img.extent.height
+                        img = img.transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+                    }
+
                     let overlay: CIImage
                     if layer.x == nil && layer.y == nil {
                         // Stretch to fill frame when no position is specified
-                        overlay = layer.image.transformed(
+                        overlay = img.transformed(
                             by: CGAffineTransform(
-                                scaleX: imageRect.width / layer.image.extent.width,
-                                y: imageRect.height / layer.image.extent.height))
+                                scaleX: imageRect.width / img.extent.width,
+                                y: imageRect.height / img.extent.height))
                     } else {
                         // Position at specific coordinates
                         let posX = CGFloat(layer.x ?? 0)
                         let posY = CGFloat(layer.y ?? 0)
                         // Convert y from top-left (Dart) to bottom-left (Core Graphics)
-                        let cgY = imageRect.height - posY - layer.image.extent.height
-                        overlay = layer.image.transformed(
+                        let cgY = imageRect.height - posY - img.extent.height
+                        overlay = img.transformed(
                             by: CGAffineTransform(translationX: posX, y: cgY))
                     }
 

--- a/lib/core/models/image/image_layer_model.dart
+++ b/lib/core/models/image/image_layer_model.dart
@@ -19,6 +19,7 @@ class ImageLayer with TimeRangeMixin {
     this.startTime,
     this.endTime,
     this.offset,
+    this.size,
     this.animations = const [],
   }) : assert(
           startTime == null || endTime == null || startTime < endTime,
@@ -44,6 +45,17 @@ class ImageLayer with TimeRangeMixin {
   /// placed at that position at its original size.
   final Offset? offset;
 
+  /// The display size of the image layer, in pixels.
+  ///
+  /// [Size.width] is the target width of the image.
+  /// [Size.height] is the target height of the image.
+  ///
+  /// When `null`, the image is used at its original size (or stretched to
+  /// fill the frame when [offset] is also `null`).
+  final Size? size;
+
+
+
   /// Animations to apply to this layer (e.g. fade, slide, scale).
   ///
   /// Multiple animations can be combined. Each animation specifies its
@@ -56,6 +68,7 @@ class ImageLayer with TimeRangeMixin {
     Duration? startTime,
     Duration? endTime,
     Offset? offset,
+    Size? size,
     List<LayerAnimation>? animations,
   }) {
     return ImageLayer(
@@ -63,6 +76,7 @@ class ImageLayer with TimeRangeMixin {
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
       offset: offset ?? this.offset,
+      size: size ?? this.size,
       animations: animations ?? this.animations,
     );
   }
@@ -73,6 +87,9 @@ class ImageLayer with TimeRangeMixin {
       'startTime': startTime?.inMicroseconds,
       'endTime': endTime?.inMicroseconds,
       'offset': offset != null ? {'dx': offset!.dx, 'dy': offset!.dy} : null,
+      'size': size != null
+          ? {'width': size!.width, 'height': size!.height}
+          : null,
       'animations': animations.map((a) => a.toMap()).toList(),
     };
   }
@@ -90,6 +107,12 @@ class ImageLayer with TimeRangeMixin {
           ? Offset(
               safeParseDouble((map['offset'] as Map<String, dynamic>)['dx']),
               safeParseDouble((map['offset'] as Map<String, dynamic>)['dy']),
+            )
+          : null,
+      size: map['size'] != null
+          ? Size(
+              safeParseDouble((map['size'] as Map<String, dynamic>)['width']),
+              safeParseDouble((map['size'] as Map<String, dynamic>)['height']),
             )
           : null,
       animations: (map['animations'] as List<dynamic>?)
@@ -111,6 +134,7 @@ class ImageLayer with TimeRangeMixin {
         'startTime: $startTime, '
         'endTime: $endTime, '
         'offset: $offset, '
+        'size: $size, '
         'animations: $animations'
         ')';
   }
@@ -123,6 +147,7 @@ class ImageLayer with TimeRangeMixin {
         other.startTime == startTime &&
         other.endTime == endTime &&
         other.offset == offset &&
+        other.size == size &&
         listEquals(other.animations, animations);
   }
 
@@ -132,6 +157,7 @@ class ImageLayer with TimeRangeMixin {
         startTime.hashCode ^
         endTime.hashCode ^
         offset.hashCode ^
+        size.hashCode ^
         animations.hashCode;
   }
 }

--- a/lib/core/models/image/image_layer_model.dart
+++ b/lib/core/models/image/image_layer_model.dart
@@ -54,8 +54,6 @@ class ImageLayer with TimeRangeMixin {
   /// fill the frame when [offset] is also `null`).
   final Size? size;
 
-
-
   /// Animations to apply to this layer (e.g. fade, slide, scale).
   ///
   /// Multiple animations can be combined. Each animation specifies its
@@ -87,9 +85,8 @@ class ImageLayer with TimeRangeMixin {
       'startTime': startTime?.inMicroseconds,
       'endTime': endTime?.inMicroseconds,
       'offset': offset != null ? {'dx': offset!.dx, 'dy': offset!.dy} : null,
-      'size': size != null
-          ? {'width': size!.width, 'height': size!.height}
-          : null,
+      'size':
+          size != null ? {'width': size!.width, 'height': size!.height} : null,
       'animations': animations.map((a) => a.toMap()).toList(),
     };
   }

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -503,6 +503,8 @@ class VideoRenderData {
                 'endUs': layer.endTime?.inMicroseconds,
                 'x': layer.offset?.dx.toInt(),
                 'y': layer.offset?.dy.toInt(),
+                'width': layer.size?.width,
+                'height': layer.size?.height,
                 'animations': layer.animations.map((a) => a.toMap()).toList(),
               }),
         ),

--- a/macos/Classes/src/features/render/models/RenderConfig.swift
+++ b/macos/Classes/src/features/render/models/RenderConfig.swift
@@ -43,6 +43,10 @@ struct ImageLayerConfig {
     let x: Int64?
     /// y position in pixels. When nil, the image is stretched to fill the video frame.
     let y: Int64?
+    /// Target width in pixels. When nil, the image is used at its original width.
+    let width: Double?
+    /// Target height in pixels. When nil, the image is used at its original height.
+    let height: Double?
     /// Animations to apply to this layer.
     let animations: [LayerAnimationConfig]
 
@@ -68,6 +72,10 @@ struct ImageLayerConfig {
             animations = animsRaw.compactMap { LayerAnimationConfig.fromArguments($0) }
         }
 
+        // Parse optional size
+        let width = (args["width"] as? NSNumber)?.doubleValue
+        let height = (args["height"] as? NSNumber)?.doubleValue
+
         // Use -1 as sentinel value for "from start" when startUs is null
         // Use -1 for endUs to signify "until the end of the video"
         return ImageLayerConfig(
@@ -76,6 +84,8 @@ struct ImageLayerConfig {
             endUs: (args["endUs"] as? NSNumber)?.int64Value ?? -1,
             x: (args["x"] as? NSNumber)?.int64Value,
             y: (args["y"] as? NSNumber)?.int64Value,
+            width: width,
+            height: height,
             animations: animations
         )
     }

--- a/macos/Classes/src/features/render/utils/VideoCompositor.swift
+++ b/macos/Classes/src/features/render/utils/VideoCompositor.swift
@@ -10,6 +10,10 @@ struct ImageLayer {
     let x: Int64?
     /// y position in pixels. When nil, the image is stretched to fill the video frame.
     let y: Int64?
+    /// Target width in pixels. When nil, the image is used at its original width.
+    let width: Double?
+    /// Target height in pixels. When nil, the image is used at its original height.
+    let height: Double?
     /// Animations applied to this layer.
     let animations: [LayerAnimationConfig]
 }
@@ -92,6 +96,8 @@ class VideoCompositor: NSObject, AVVideoCompositing {
                     endUs: layer.endUs,
                     x: layer.x,
                     y: layer.y,
+                    width: layer.width,
+                    height: layer.height,
                     animations: layer.animations
                 ))
         }
@@ -331,17 +337,25 @@ class VideoCompositor: NSObject, AVVideoCompositing {
                     && (layer.endUs == -1 || currentTimeUs <= layer.endUs)
 
                 if inTimeRange {
+                    var img = layer.image
+
+                    if let w = layer.width, let h = layer.height {
+                        let sx = CGFloat(w) / img.extent.width
+                        let sy = CGFloat(h) / img.extent.height
+                        img = img.transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+                    }
+
                     let overlay: CIImage
                     if layer.x == nil && layer.y == nil {
-                        overlay = layer.image.transformed(
+                        overlay = img.transformed(
                             by: CGAffineTransform(
-                                scaleX: imageRect.width / layer.image.extent.width,
-                                y: imageRect.height / layer.image.extent.height))
+                                scaleX: imageRect.width / img.extent.width,
+                                y: imageRect.height / img.extent.height))
                     } else {
                         let posX = CGFloat(layer.x ?? 0)
                         let posY = CGFloat(layer.y ?? 0)
-                        let cgY = imageRect.height - posY - layer.image.extent.height
-                        overlay = layer.image.transformed(
+                        let cgY = imageRect.height - posY - img.extent.height
+                        overlay = img.transformed(
                             by: CGAffineTransform(translationX: posX, y: cgY))
                     }
 
@@ -437,17 +451,25 @@ class VideoCompositor: NSObject, AVVideoCompositing {
                     (layer.startUs == -1 || currentTimeUs >= layer.startUs)
                     && (layer.endUs == -1 || currentTimeUs <= layer.endUs)
                 if inTimeRange {
+                    var img = layer.image
+
+                    if let w = layer.width, let h = layer.height {
+                        let sx = CGFloat(w) / img.extent.width
+                        let sy = CGFloat(h) / img.extent.height
+                        img = img.transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+                    }
+
                     let overlay: CIImage
                     if layer.x == nil && layer.y == nil {
-                        overlay = layer.image.transformed(
+                        overlay = img.transformed(
                             by: CGAffineTransform(
-                                scaleX: imageRect.width / layer.image.extent.width,
-                                y: imageRect.height / layer.image.extent.height))
+                                scaleX: imageRect.width / img.extent.width,
+                                y: imageRect.height / img.extent.height))
                     } else {
                         let posX = CGFloat(layer.x ?? 0)
                         let posY = CGFloat(layer.y ?? 0)
-                        let cgY = imageRect.height - posY - layer.image.extent.height
-                        overlay = layer.image.transformed(
+                        let cgY = imageRect.height - posY - img.extent.height
+                        overlay = img.transformed(
                             by: CGAffineTransform(translationX: posX, y: cgY))
                     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.12.0
+version: 1.13.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/image/image_layer_model_test.dart
+++ b/test/core/models/image/image_layer_model_test.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pro_video_editor/core/models/image/editor_layer_image_model.dart';
@@ -15,6 +16,7 @@ void main() {
           startTime: const Duration(seconds: 5),
           endTime: const Duration(seconds: 10),
           offset: const Offset(100, 200),
+          size: const Size(300, 150),
         );
         final map = layer.toMap();
 
@@ -22,6 +24,7 @@ void main() {
         expect(map['startTime'], 5000000);
         expect(map['endTime'], 10000000);
         expect(map['offset'], {'dx': 100.0, 'dy': 200.0});
+        expect(map['size'], {'width': 300.0, 'height': 150.0});
       });
 
       test('serializes null fields as null', () {
@@ -31,6 +34,7 @@ void main() {
         expect(map['startTime'], isNull);
         expect(map['endTime'], isNull);
         expect(map['offset'], isNull);
+        expect(map['size'], isNull);
       });
     });
 
@@ -41,6 +45,7 @@ void main() {
           startTime: const Duration(seconds: 5),
           endTime: const Duration(seconds: 10),
           offset: const Offset(100, 200),
+          size: const Size(300, 150),
         );
         final map = layer.toMap();
         final restored = ImageLayer.fromMap(map);
@@ -48,6 +53,7 @@ void main() {
         expect(restored.startTime, const Duration(seconds: 5));
         expect(restored.endTime, const Duration(seconds: 10));
         expect(restored.offset, const Offset(100, 200));
+        expect(restored.size, const Size(300, 150));
       });
 
       test('handles null optional fields', () {
@@ -58,6 +64,7 @@ void main() {
         expect(restored.startTime, isNull);
         expect(restored.endTime, isNull);
         expect(restored.offset, isNull);
+        expect(restored.size, isNull);
       });
 
       test('parses numeric strings safely for offset', () {
@@ -66,11 +73,13 @@ void main() {
           'startTime': '3000000',
           'endTime': null,
           'offset': {'dx': '50.5', 'dy': '75.0'},
+          'size': {'width': '200.0', 'height': '100.0'},
         };
         final restored = ImageLayer.fromMap(map);
 
         expect(restored.startTime, const Duration(seconds: 3));
         expect(restored.offset, const Offset(50.5, 75.0));
+        expect(restored.size, const Size(200.0, 100.0));
       });
     });
 
@@ -98,10 +107,12 @@ void main() {
         final copy = layer.copyWith(
           startTime: const Duration(seconds: 2),
           offset: const Offset(10, 20),
+          size: const Size(640, 480),
         );
 
         expect(copy.startTime, const Duration(seconds: 2));
         expect(copy.offset, const Offset(10, 20));
+        expect(copy.size, const Size(640, 480));
         expect(copy.endTime, isNull);
       });
     });


### PR DESCRIPTION
## Description

Add an optional `width` and `height` property to the `ImageLayer` class, allowing users to specify custom dimensions for image layers. This feature enhances the flexibility of image rendering in the video editor.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

