### PR TITLE
feat: add getSingleThumbnail method to extract first and last frames from videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.14.0
+- **FEAT**(android, iOS, macOS, web): Add `getSingleThumbnail` method with `SingleThumbnailConfigs` to extract the first or last frame of a video via `ThumbnailPosition.first` / `ThumbnailPosition.last`.
+
 ## 1.13.2
 - **FIX**(android): Fix image layer distortion when `imageBytesWithCropping` is enabled with a crop transform and qualityConfigs.
 

--- a/example/lib/features/thumbnail/thumbnail_example_page.dart
+++ b/example/lib/features/thumbnail/thumbnail_example_page.dart
@@ -17,6 +17,8 @@ class ThumbnailExamplePage extends StatefulWidget {
 class _ThumbnailExamplePageState extends State<ThumbnailExamplePage> {
   List<MemoryImage> _thumbnails = [];
   List<MemoryImage> _keyFrames = [];
+  MemoryImage? _firstThumbnail;
+  MemoryImage? _lastThumbnail;
 
   final int _exampleImageCount = 8;
   final double _imageSize = 50;
@@ -80,6 +82,48 @@ class _ThumbnailExamplePageState extends State<ThumbnailExamplePage> {
     setState(() {});
   }
 
+  void _generateFirstThumbnail() async {
+    var outputSize = _imageSize * MediaQuery.devicePixelRatioOf(context);
+
+    var raw = await ProVideoEditor.instance.getSingleThumbnail(
+      SingleThumbnailConfigs(
+        video: EditorVideo.asset(kVideoEditorExampleH264Path),
+        outputFormat: _thumbnailFormat,
+        outputSize: Size(outputSize, outputSize),
+        boxFit: ThumbnailBoxFit.cover,
+        position: ThumbnailPosition.first,
+      ),
+    );
+
+    if (raw != null) {
+      _firstThumbnail = MemoryImage(raw);
+      setState(() {});
+    }
+  }
+
+  void _generateLastThumbnail() async {
+    var outputSize = _imageSize * MediaQuery.devicePixelRatioOf(context);
+
+    if (_informations == null) await _setMetadata();
+
+    var raw = await ProVideoEditor.instance.getSingleThumbnail(
+      SingleThumbnailConfigs(
+        video: EditorVideo.asset(kVideoEditorExampleH264Path),
+        outputFormat: _thumbnailFormat,
+        outputSize: Size(outputSize, outputSize),
+        boxFit: ThumbnailBoxFit.cover,
+        position: ThumbnailPosition.last,
+        // Provide duration to skip an extra metadata lookup
+        videoDuration: _informations!.duration,
+      ),
+    );
+
+    if (raw != null) {
+      _lastThumbnail = MemoryImage(raw);
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -100,6 +144,18 @@ class _ThumbnailExamplePageState extends State<ThumbnailExamplePage> {
             trailing: _buildProgress(_keyFramesTaskId),
           ),
           _buildThumbnails(_keyFrames),
+          ListTile(
+            onTap: _generateFirstThumbnail,
+            leading: const Icon(Icons.first_page_rounded),
+            title: const Text('First Frame'),
+          ),
+          if (_firstThumbnail != null) _buildSingleThumbnail(_firstThumbnail!),
+          ListTile(
+            onTap: _generateLastThumbnail,
+            leading: const Icon(Icons.last_page_rounded),
+            title: const Text('Last Frame'),
+          ),
+          if (_lastThumbnail != null) _buildSingleThumbnail(_lastThumbnail!),
         ],
       ),
     );
@@ -123,6 +179,20 @@ class _ThumbnailExamplePageState extends State<ThumbnailExamplePage> {
             ),
           )
           .toList(),
+    );
+  }
+
+  Widget _buildSingleThumbnail(MemoryImage image) {
+    return Center(
+      child: Container(
+        width: _imageSize,
+        height: _imageSize,
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(7),
+        ),
+        child: Image(image: image, fit: BoxFit.cover),
+      ),
     );
   }
 

--- a/ios/Classes/src/features/thumbnail/ThumbnailGenerator.swift
+++ b/ios/Classes/src/features/thumbnail/ThumbnailGenerator.swift
@@ -39,8 +39,16 @@ class ThumbnailGenerator {
                 let asset = AVURLAsset(url: videoURL)
                 let generator = AVAssetImageGenerator(asset: asset)
                 generator.appliesPreferredTrackTransform = true
-                generator.requestedTimeToleranceBefore = .zero
-                generator.requestedTimeToleranceAfter = .zero
+                if config.lastFrameTolerance {
+                    // Use a small tolerance so AVFoundation decodes the
+                    // nearest frame instead of jumping to a distant keyframe.
+                    generator.requestedTimeToleranceBefore = CMTime(
+                        seconds: 0.1, preferredTimescale: 1_000_000)
+                    generator.requestedTimeToleranceAfter = .zero
+                } else {
+                    generator.requestedTimeToleranceBefore = .zero
+                    generator.requestedTimeToleranceAfter = .zero
+                }
 
                 let times: [NSValue]
                 if !config.timestampsUs.isEmpty {

--- a/ios/Classes/src/features/thumbnail/models/ThumbnailConfig.swift
+++ b/ios/Classes/src/features/thumbnail/models/ThumbnailConfig.swift
@@ -37,6 +37,11 @@ struct ThumbnailConfig {
     /// Nil if using timestamp-based extraction
     let maxOutputFrames: Int?
 
+    /// When true, allows seeking backwards to find the nearest frame.
+    /// Used when extracting the last frame of a video to ensure
+    /// AVAssetImageGenerator finds a valid frame near the end.
+    let lastFrameTolerance: Bool
+
     /// Creates a ThumbnailConfig from Flutter method call arguments.
     ///
     /// - Parameter arguments: Dictionary containing the method call arguments
@@ -62,6 +67,7 @@ struct ThumbnailConfig {
         let rawTimestamps = args["timestamps"] as? [NSNumber] ?? []
         let timestampsUs = rawTimestamps.map { $0.int64Value }
         let maxOutputFrames = args["maxOutputFrames"] as? Int
+        let lastFrameTolerance = args["lastFrameTolerance"] as? Bool ?? false
 
         // At least one extraction mode must be specified
         guard !timestampsUs.isEmpty || maxOutputFrames != nil else {
@@ -78,7 +84,8 @@ struct ThumbnailConfig {
             outputWidth: outputWidth,
             outputHeight: outputHeight,
             timestampsUs: timestampsUs,
-            maxOutputFrames: maxOutputFrames
+            maxOutputFrames: maxOutputFrames,
+            lastFrameTolerance: lastFrameTolerance
         )
     }
 }

--- a/lib/core/models/thumbnail/single_thumbnail_configs_model.dart
+++ b/lib/core/models/thumbnail/single_thumbnail_configs_model.dart
@@ -1,0 +1,72 @@
+import 'thumbnail_base_abstract.dart';
+
+/// Position from which to extract a single thumbnail.
+enum ThumbnailPosition {
+  /// Extract the first frame of the video (at timestamp 0).
+  first,
+
+  /// Extract the last frame of the video (near the end of the duration).
+  last,
+}
+
+/// Configuration model for extracting a single thumbnail from a video.
+///
+/// This convenience model allows extracting either the first or last frame
+/// of a video without needing to specify exact timestamps.
+///
+/// For [ThumbnailPosition.first], a frame at timestamp 0 is extracted.
+/// For [ThumbnailPosition.last], the video duration is resolved automatically
+/// (or from [videoDuration] if provided) and a frame near the end is extracted.
+///
+/// Example:
+/// ```dart
+/// final config = SingleThumbnailConfigs(
+///   video: EditorVideo.file('/path/to/video.mp4'),
+///   outputSize: Size(256, 256),
+///   position: ThumbnailPosition.first,
+/// );
+///
+/// final thumbnail = await ProVideoEditor.instance.getSingleThumbnail(config);
+/// ```
+class SingleThumbnailConfigs extends ThumbnailBase {
+  /// Creates a [SingleThumbnailConfigs] instance.
+  ///
+  /// [position] determines whether to extract the first or last frame.
+  ///
+  /// [videoDuration] can be provided to avoid an additional metadata lookup
+  /// when [position] is [ThumbnailPosition.last]. If not provided,
+  /// the duration will be resolved automatically.
+  SingleThumbnailConfigs({
+    required super.video,
+    required super.outputSize,
+    super.outputFormat,
+    super.boxFit,
+    super.id,
+    super.jpegQuality,
+    required this.position,
+    this.videoDuration,
+  });
+
+  /// Whether to extract the first or last frame.
+  final ThumbnailPosition position;
+
+  /// Optional video duration to avoid an extra metadata lookup when
+  /// extracting the last frame.
+  ///
+  /// If null and [position] is [ThumbnailPosition.last], the duration
+  /// will be fetched automatically via [getMetadata].
+  final Duration? videoDuration;
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'jpegQuality': jpegQuality,
+      'boxFit': boxFit.name,
+      'outputFormat': outputFormat.name,
+      'outputWidth': outputSize.width.round(),
+      'outputHeight': outputSize.height.round(),
+      'timestamps': <int>[],
+    };
+  }
+}

--- a/lib/core/platform/native_method_channel.dart
+++ b/lib/core/platform/native_method_channel.dart
@@ -11,6 +11,7 @@ import '/core/models/audio/waveform_configs_model.dart';
 import '/core/models/audio/waveform_data_model.dart';
 import '/core/models/exceptions/render_exceptions.dart';
 import '/core/models/thumbnail/key_frames_configs_model.dart';
+import '/core/models/thumbnail/single_thumbnail_configs_model.dart';
 import '/core/models/thumbnail/thumbnail_base_abstract.dart';
 import '/core/models/thumbnail/thumbnail_configs_model.dart';
 import '/core/models/video/editor_video_model.dart';
@@ -134,6 +135,34 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
   @override
   Future<List<Uint8List>> getKeyFrames(KeyFramesConfigs value) async {
     return await _extractThumbnails(value);
+  }
+
+  @override
+  Future<Uint8List?> getSingleThumbnail(SingleThumbnailConfigs value) async {
+    final bool isLastFrame = value.position == ThumbnailPosition.last;
+    Duration timestamp;
+    if (isLastFrame) {
+      final duration =
+          value.videoDuration ?? (await getMetadata(value.video)).duration;
+      timestamp = duration;
+    } else {
+      timestamp = Duration.zero;
+    }
+
+    var inputPath = await value.video.safeFilePath();
+
+    final response = await methodChannel.invokeMethod<List<dynamic>>(
+      'getThumbnails',
+      {
+        'inputPath': inputPath,
+        'extension': _getFileExtension(inputPath),
+        ...value.toMap(),
+        'timestamps': [timestamp.inMicroseconds],
+        'lastFrameTolerance': isLastFrame,
+      },
+    );
+    final List<Uint8List> result = response?.cast<Uint8List>() ?? [];
+    return result.isNotEmpty ? result.first : null;
   }
 
   @override

--- a/lib/core/platform/platform_interface.dart
+++ b/lib/core/platform/platform_interface.dart
@@ -8,6 +8,7 @@ import '/core/models/audio/waveform_chunk_model.dart';
 import '/core/models/audio/waveform_configs_model.dart';
 import '/core/models/audio/waveform_data_model.dart';
 import '/core/models/thumbnail/key_frames_configs_model.dart';
+import '/core/models/thumbnail/single_thumbnail_configs_model.dart';
 import '/core/models/thumbnail/thumbnail_configs_model.dart';
 import '/core/models/video/editor_video_model.dart';
 import '/core/models/video/progress_model.dart';
@@ -188,6 +189,37 @@ abstract class ProVideoEditor extends PlatformInterface {
   /// from [KeyFramesConfigs.id].
   Future<List<Uint8List>> getKeyFrames(KeyFramesConfigs value) {
     throw UnimplementedError('getKeyFrames() has not been implemented.');
+  }
+
+  /// Extracts a single thumbnail from a video — either the first or last frame.
+  ///
+  /// This is a convenience method that avoids specifying exact timestamps.
+  /// For [ThumbnailPosition.first], a frame at timestamp 0 is extracted.
+  /// For [ThumbnailPosition.last], the video duration is resolved
+  /// automatically (or from [SingleThumbnailConfigs.videoDuration] if
+  /// provided) and a frame near the end is extracted.
+  ///
+  /// [value] Configuration containing:
+  /// - Video source ([EditorVideo])
+  /// - Desired thumbnail dimensions
+  /// - Image quality settings
+  /// - Position (first or last)
+  ///
+  /// Returns the thumbnail as a [Uint8List], or `null` if extraction fails.
+  ///
+  /// Example:
+  /// ```dart
+  /// final config = SingleThumbnailConfigs(
+  ///   video: EditorVideo.file('/path/to/video.mp4'),
+  ///   outputSize: Size(256, 256),
+  ///   position: ThumbnailPosition.first,
+  /// );
+  ///
+  /// final thumbnail =
+  ///     await ProVideoEditor.instance.getSingleThumbnail(config);
+  /// ```
+  Future<Uint8List?> getSingleThumbnail(SingleThumbnailConfigs value) {
+    throw UnimplementedError('getSingleThumbnail() has not been implemented.');
   }
 
   /// Extracts audio from a video file.

--- a/lib/core/platform/web_method_channel.dart
+++ b/lib/core/platform/web_method_channel.dart
@@ -12,6 +12,7 @@ import 'package:pro_video_editor/core/models/video/progress_model.dart';
 import 'package:web/web.dart' as web;
 
 import '/core/models/thumbnail/key_frames_configs_model.dart';
+import '/core/models/thumbnail/single_thumbnail_configs_model.dart';
 import '/core/models/thumbnail/thumbnail_configs_model.dart';
 import '/core/models/video/editor_video_model.dart';
 import '/core/models/video/video_metadata_model.dart';
@@ -84,6 +85,34 @@ class ProVideoEditorWeb extends ProVideoEditor {
       value,
       onProgress: (progress) => _updateProgress(value.id, progress),
     );
+  }
+
+  @override
+  Future<Uint8List?> getSingleThumbnail(SingleThumbnailConfigs value) async {
+    Duration timestamp;
+    if (value.position == ThumbnailPosition.last) {
+      final duration = value.videoDuration ??
+          (await _manager.getMetadata(value.video)).duration;
+      timestamp = duration;
+    } else {
+      timestamp = Duration.zero;
+    }
+
+    final configs = ThumbnailConfigs(
+      video: value.video,
+      outputSize: value.outputSize,
+      outputFormat: value.outputFormat,
+      boxFit: value.boxFit,
+      id: value.id,
+      jpegQuality: value.jpegQuality,
+      timestamps: [timestamp],
+    );
+
+    final results = await _manager.getThumbnails(
+      configs,
+      onProgress: (progress) => _updateProgress(value.id, progress),
+    );
+    return results.isNotEmpty ? results.first : null;
   }
 
   @override

--- a/lib/pro_video_editor.dart
+++ b/lib/pro_video_editor.dart
@@ -28,6 +28,7 @@ export 'shared/utils/converters.dart';
 
 /// Thumbnails
 export 'core/models/thumbnail/key_frames_configs_model.dart';
+export 'core/models/thumbnail/single_thumbnail_configs_model.dart';
 export 'core/models/thumbnail/thumbnail_box_fit_model.dart';
 export 'core/models/thumbnail/thumbnail_configs_model.dart';
 export 'core/models/thumbnail/thumbnail_format_model.dart';

--- a/macos/Classes/src/features/thumbnail/ThumbnailGenerator.swift
+++ b/macos/Classes/src/features/thumbnail/ThumbnailGenerator.swift
@@ -39,8 +39,16 @@ class ThumbnailGenerator {
             let asset = AVURLAsset(url: videoURL)
             let generator = AVAssetImageGenerator(asset: asset)
             generator.appliesPreferredTrackTransform = true
-            generator.requestedTimeToleranceBefore = .zero
-            generator.requestedTimeToleranceAfter = .zero
+            if config.lastFrameTolerance {
+                // Use a small tolerance so AVFoundation decodes the
+                // nearest frame instead of jumping to a distant keyframe.
+                generator.requestedTimeToleranceBefore = CMTime(
+                    seconds: 0.1, preferredTimescale: 1_000_000)
+                generator.requestedTimeToleranceAfter = .zero
+            } else {
+                generator.requestedTimeToleranceBefore = .zero
+                generator.requestedTimeToleranceAfter = .zero
+            }
 
             let times: [NSValue]
             if !config.timestampsUs.isEmpty {

--- a/macos/Classes/src/features/thumbnail/models/ThumbnailConfig.swift
+++ b/macos/Classes/src/features/thumbnail/models/ThumbnailConfig.swift
@@ -37,6 +37,11 @@ internal struct ThumbnailConfig {
     /// Nil if using timestamp-based extraction
     let maxOutputFrames: Int?
 
+    /// When true, allows seeking backwards to find the nearest frame.
+    /// Used when extracting the last frame of a video to ensure
+    /// AVAssetImageGenerator finds a valid frame near the end.
+    let lastFrameTolerance: Bool
+
     /// Creates a ThumbnailConfig from Flutter method call arguments.
     ///
     /// - Parameter arguments: Dictionary containing the method call arguments
@@ -62,6 +67,7 @@ internal struct ThumbnailConfig {
         let rawTimestamps = args["timestamps"] as? [NSNumber] ?? []
         let timestampsUs = rawTimestamps.map { $0.int64Value }
         let maxOutputFrames = args["maxOutputFrames"] as? Int
+        let lastFrameTolerance = args["lastFrameTolerance"] as? Bool ?? false
 
         // At least one extraction mode must be specified
         guard !timestampsUs.isEmpty || maxOutputFrames != nil else {
@@ -78,7 +84,8 @@ internal struct ThumbnailConfig {
             outputWidth: outputWidth,
             outputHeight: outputHeight,
             timestampsUs: timestampsUs,
-            maxOutputFrames: maxOutputFrames
+            maxOutputFrames: maxOutputFrames,
+            lastFrameTolerance: lastFrameTolerance
         )
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.13.2
+version: 1.14.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/thumbnail/single_thumbnail_configs_model_test.dart
+++ b/test/core/models/thumbnail/single_thumbnail_configs_model_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  group('SingleThumbnailConfigs', () {
+    final video = EditorVideo.asset('assets/test.mp4');
+
+    test('creates with required parameters', () {
+      final config = SingleThumbnailConfigs(
+        video: video,
+        outputSize: const Size(100, 100),
+        position: ThumbnailPosition.first,
+      );
+
+      expect(config.position, ThumbnailPosition.first);
+      expect(config.videoDuration, isNull);
+      expect(config.outputSize, const Size(100, 100));
+      expect(config.outputFormat, ThumbnailFormat.jpeg);
+      expect(config.boxFit, ThumbnailBoxFit.cover);
+      expect(config.jpegQuality, 90);
+      expect(config.id, isNotEmpty);
+    });
+
+    test('creates with all optional parameters', () {
+      final config = SingleThumbnailConfigs(
+        video: video,
+        outputSize: const Size(200, 150),
+        position: ThumbnailPosition.last,
+        videoDuration: const Duration(seconds: 30),
+        outputFormat: ThumbnailFormat.png,
+        boxFit: ThumbnailBoxFit.contain,
+        jpegQuality: 80,
+        id: 'custom-id',
+      );
+
+      expect(config.position, ThumbnailPosition.last);
+      expect(config.videoDuration, const Duration(seconds: 30));
+      expect(config.outputSize, const Size(200, 150));
+      expect(config.outputFormat, ThumbnailFormat.png);
+      expect(config.boxFit, ThumbnailBoxFit.contain);
+      expect(config.jpegQuality, 80);
+      expect(config.id, 'custom-id');
+    });
+
+    test('toMap serializes correctly', () {
+      final config = SingleThumbnailConfigs(
+        video: video,
+        outputSize: const Size(256, 128),
+        position: ThumbnailPosition.first,
+        id: 'test-id',
+        jpegQuality: 75,
+        outputFormat: ThumbnailFormat.png,
+        boxFit: ThumbnailBoxFit.contain,
+      );
+
+      final map = config.toMap();
+
+      expect(map['id'], 'test-id');
+      expect(map['jpegQuality'], 75);
+      expect(map['boxFit'], 'contain');
+      expect(map['outputFormat'], 'png');
+      expect(map['outputWidth'], 256);
+      expect(map['outputHeight'], 128);
+      expect(map['timestamps'], isEmpty);
+    });
+  });
+
+  group('ThumbnailPosition', () {
+    test('has correct values', () {
+      expect(ThumbnailPosition.values.length, 2);
+      expect(ThumbnailPosition.values, contains(ThumbnailPosition.first));
+      expect(ThumbnailPosition.values, contains(ThumbnailPosition.last));
+    });
+  });
+}

--- a/test/pro_video_editor_method_channel_test.dart
+++ b/test/pro_video_editor_method_channel_test.dart
@@ -150,4 +150,125 @@ void main() {
   test('cancel throws when taskId is empty', () {
     expect(() => platform.cancel(''), throwsArgumentError);
   });
+
+  group('getSingleThumbnail', () {
+    test('first position returns thumbnail', () async {
+      final result = await platform.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: mockVideo,
+          outputSize: const Size(100, 100),
+          position: ThumbnailPosition.first,
+        ),
+      );
+
+      expect(result, isA<Uint8List>());
+      expect(result, mockBytes);
+    });
+
+    test('last position with provided duration returns thumbnail', () async {
+      final result = await platform.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: mockVideo,
+          outputSize: const Size(100, 100),
+          position: ThumbnailPosition.last,
+          videoDuration: const Duration(seconds: 10),
+        ),
+      );
+
+      expect(result, isA<Uint8List>());
+      expect(result, mockBytes);
+    });
+
+    test('last position without duration fetches metadata', () async {
+      final result = await platform.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: mockVideo,
+          outputSize: const Size(100, 100),
+          position: ThumbnailPosition.last,
+        ),
+      );
+
+      expect(result, isA<Uint8List>());
+      expect(result, mockBytes);
+    });
+
+    test('returns null when native returns empty list', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        switch (methodCall.method) {
+          case 'getThumbnails':
+            return <Uint8List>[];
+          case 'getMetadata':
+            return {
+              'duration': 1200,
+              'width': 1080,
+              'height': 1920,
+              'rotation': 0,
+              'extension': 'mp4',
+            };
+          default:
+            return null;
+        }
+      });
+
+      final result = await platform.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: mockVideo,
+          outputSize: const Size(100, 100),
+          position: ThumbnailPosition.first,
+        ),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('sends lastFrameTolerance true for last position', () async {
+      Map<dynamic, dynamic>? capturedArgs;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'getThumbnails') {
+          capturedArgs = methodCall.arguments as Map<dynamic, dynamic>;
+          return [mockBytes];
+        }
+        return null;
+      });
+
+      await platform.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: mockVideo,
+          outputSize: const Size(100, 100),
+          position: ThumbnailPosition.last,
+          videoDuration: const Duration(seconds: 5),
+        ),
+      );
+
+      expect(capturedArgs?['lastFrameTolerance'], isTrue);
+      expect(capturedArgs?['timestamps'], [5000000]);
+    });
+
+    test('sends lastFrameTolerance false for first position', () async {
+      Map<dynamic, dynamic>? capturedArgs;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'getThumbnails') {
+          capturedArgs = methodCall.arguments as Map<dynamic, dynamic>;
+          return [mockBytes];
+        }
+        return null;
+      });
+
+      await platform.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: mockVideo,
+          outputSize: const Size(100, 100),
+          position: ThumbnailPosition.first,
+        ),
+      );
+
+      expect(capturedArgs?['lastFrameTolerance'], isFalse);
+      expect(capturedArgs?['timestamps'], [0]);
+    });
+  });
 }

--- a/test/pro_video_editor_method_channel_test.mocks.dart
+++ b/test/pro_video_editor_method_channel_test.mocks.dart
@@ -183,6 +183,15 @@ class MockEditorVideo extends _i1.Mock implements _i2.EditorVideo {
           ),
         ),
       ) as _i2.EditorVideo);
+
+  @override
+  Map<String, dynamic> toMap() => (super.noSuchMethod(
+        Invocation.method(
+          #toMap,
+          [],
+        ),
+        returnValue: <String, dynamic>{},
+      ) as Map<String, dynamic>);
 }
 
 /// A class which mocks [ThumbnailConfigs].
@@ -419,6 +428,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
   @override
   _i4.VideoRenderData copyWith({
     String? id,
+    _i4.VideoQualityConfig? qualityConfig,
     _i4.VideoOutputFormat? outputFormat,
     _i2.EditorVideo? video,
     List<_i4.VideoSegment>? videoSegments,
@@ -434,7 +444,6 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
     List<_i4.VideoAudioTrack>? audioTracks,
     double? blur,
     int? bitrate,
-    _i4.VideoQualityConfig? qualityConfig,
     String? customAudioPath,
     Duration? customAudioStartTime,
     double? originalAudioVolume,
@@ -449,6 +458,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
           [],
           {
             #id: id,
+            #qualityConfig: qualityConfig,
             #outputFormat: outputFormat,
             #video: video,
             #videoSegments: videoSegments,
@@ -464,7 +474,6 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
             #audioTracks: audioTracks,
             #blur: blur,
             #bitrate: bitrate,
-            #qualityConfig: qualityConfig,
             #customAudioPath: customAudioPath,
             #customAudioStartTime: customAudioStartTime,
             #originalAudioVolume: originalAudioVolume,
@@ -481,6 +490,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
             [],
             {
               #id: id,
+              #qualityConfig: qualityConfig,
               #outputFormat: outputFormat,
               #video: video,
               #videoSegments: videoSegments,
@@ -496,7 +506,6 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
               #audioTracks: audioTracks,
               #blur: blur,
               #bitrate: bitrate,
-              #qualityConfig: qualityConfig,
               #customAudioPath: customAudioPath,
               #customAudioStartTime: customAudioStartTime,
               #originalAudioVolume: originalAudioVolume,
@@ -508,4 +517,28 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
           ),
         ),
       ) as _i4.VideoRenderData);
+
+  @override
+  Map<String, dynamic> toMap() => (super.noSuchMethod(
+        Invocation.method(
+          #toMap,
+          [],
+        ),
+        returnValue: <String, dynamic>{},
+      ) as Map<String, dynamic>);
+
+  @override
+  String toJson() => (super.noSuchMethod(
+        Invocation.method(
+          #toJson,
+          [],
+        ),
+        returnValue: _i8.dummyValue<String>(
+          this,
+          Invocation.method(
+            #toJson,
+            [],
+          ),
+        ),
+      ) as String);
 }


### PR DESCRIPTION
## Description

Introduce a new method to extract either the first or last frame from videos, enhancing the video editing capabilities. This feature simplifies thumbnail extraction by allowing users to specify the desired frame position without needing to provide exact timestamps.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

