### PR TITLE
fix: update media3 compatibility to version 1.10.0 and replace deprecated ChannelMixingMatrix methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.14.1
+- **FIX**(android): Fix compatibility with media3 1.10.0 by replacing removed `ChannelMixingMatrix.create` with `ChannelMixingMatrix.createForConstantGain`.
+
 ## 1.14.0
 - **FEAT**(android, iOS, macOS, web): Add `getSingleThumbnail` method with `SingleThumbnailConfigs` to extract the first or last frame of a video via `ThumbnailPosition.first` / `ThumbnailPosition.last`.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
         testImplementation("org.mockito:mockito-core:5.1.1")
         
         // Media3 dependencies
-        def media3_version = "1.9.0"
+        def media3_version = "1.10.0"
         implementation "androidx.media3:media3-common:$media3_version"
         implementation("androidx.media3:media3-transformer:$media3_version")
         implementation("androidx.media3:media3-effect:$media3_version")

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/AudioSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/AudioSequenceBuilder.kt
@@ -233,12 +233,12 @@ class AudioSequenceBuilder(
 
             // Stereo (2 channels) to Stereo (2 channels) - passthrough
             channelMixer.putChannelMixingMatrix(
-                ChannelMixingMatrix.create(2, 2)
+                ChannelMixingMatrix.createForConstantGain(2, 2)
             )
 
             // Mono (1 channel) to Stereo (2 channels)
             channelMixer.putChannelMixingMatrix(
-                ChannelMixingMatrix.create(1, 2)
+                ChannelMixingMatrix.createForConstantGain(1, 2)
             )
 
             processors.add(channelMixer)

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -360,12 +360,12 @@ class VideoSequenceBuilder(
 
         // Stereo (2 channels) to Stereo (2 channels) - passthrough (no boost needed)
         channelMixer.putChannelMixingMatrix(
-            ChannelMixingMatrix.create(2, 2)
+            ChannelMixingMatrix.createForConstantGain(2, 2)
         )
 
         // Mono (1 channel) to Stereo (2 channels)
         channelMixer.putChannelMixingMatrix(
-            ChannelMixingMatrix.create(1, 2)
+            ChannelMixingMatrix.createForConstantGain(1, 2)
         )
 
         Log.d(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.14.0
+version: 1.14.1
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Description

Update compatibility with media3 to version 1.10.0 by replacing deprecated `ChannelMixingMatrix` methods. 

**Related Issue:** Closes #

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

