### PR TITLE
fix: reverse playback – Android HEVC rotation & AVErrorInvalidVideoComposition

### DIFF
--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
@@ -21,6 +21,7 @@ import ch.waio.pro_video_editor.src.features.render.helpers.applyComposition
 import ch.waio.pro_video_editor.src.features.render.helpers.VolumeControlAudioMixerFactory
 import ch.waio.pro_video_editor.src.features.render.helpers.ConfigurableInAppMp4Muxer
 import ch.waio.pro_video_editor.src.features.render.helpers.VideoTranscoder
+import ch.waio.pro_video_editor.src.features.render.helpers.VideoReverser
 import ch.waio.pro_video_editor.src.features.render.models.RenderConfig
 import ch.waio.pro_video_editor.src.features.render.models.RenderJobHandle
 import ch.waio.pro_video_editor.src.features.render.models.VideoClip
@@ -107,84 +108,31 @@ class RenderVideo(private val context: Context) {
         val shouldStopPolling = AtomicBoolean(false)
         val mainHandler = Handler(Looper.getMainLooper())
         var transcodedFiles: List<String> = emptyList()
+        var reversedFiles: List<String> = emptyList()
         val transformerRef = AtomicReference<Transformer?>(null)
         val outputFileRef = AtomicReference<File?>(null)
 
-        // Check if we need to pre-transcode HEVC 10-bit videos
         val needsPreTranscode = needsPreTranscoding(config)
+        val needsPreReverse = config.videoClips.any { it.reverseVideo }
 
-        if (needsPreTranscode) {
-            Log.d(RENDER_TAG, "Pre-transcoding needed, checking for HEVC 10-bit videos...")
+        // Progress split: reverse pre-render is the slowest stage, so it gets the
+        // largest share. Without reverse, the transformer owns the full bar.
+        val reverseShare = if (needsPreReverse) 0.6 else 0.0
+        val transformShare = 1.0 - reverseShare
+        val reverseProgress: (Double) -> Unit = { p ->
+            onProgress((p * reverseShare).coerceIn(0.0, 1.0))
+        }
+        val transformProgress: (Double) -> Unit = { p ->
+            onProgress((reverseShare + p * transformShare).coerceIn(0.0, 1.0))
+        }
 
-            // Pre-transcode in background thread
-            Thread {
-                try {
-                    val inputPaths = config.videoClips.map { it.inputPath }
-                    val transcodeMap = VideoTranscoder.transcodeClipsIfNeeded(context, inputPaths)
+        val cleanupAllPreFiles: () -> Unit = {
+            VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
+            VideoReverser.cleanupReversedFiles(reversedFiles)
+        }
 
-                    // Track transcoded files for cleanup
-                    transcodedFiles = transcodeMap.values.filter {
-                        it.contains("transcoded_")
-                    }
-
-                    if (transcodedFiles.isNotEmpty()) {
-                        Log.i(
-                            RENDER_TAG,
-                            "Pre-transcoded ${transcodedFiles.size} HEVC 10-bit videos to H.264"
-                        )
-                    }
-
-                    // Create new config with transcoded paths
-                    val updatedClips = config.videoClips.map { clip ->
-                        val newPath = transcodeMap[clip.inputPath] ?: clip.inputPath
-                        if (newPath != clip.inputPath) {
-                            // If transcoded, use the new path but keep trim times, volume and speed
-                            VideoClip(
-                                newPath,
-                                clip.startUs,
-                                clip.endUs,
-                                clip.volume,
-                                clip.playbackSpeed,
-                                clip.reverseVideo
-                            )
-                        } else {
-                            clip
-                        }
-                    }
-
-                    val updatedConfig = config.copy(videoClips = updatedClips)
-
-                    mainHandler.post {
-                        if (!shouldStopPolling.get()) {
-                            renderInternal(
-                                config = updatedConfig,
-                                onProgress = onProgress,
-                                onComplete = { result ->
-                                    // Cleanup transcoded files after render
-                                    VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
-                                    onComplete(result)
-                                },
-                                onError = { error ->
-                                    // Cleanup transcoded files on error too
-                                    VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
-                                    onError(error)
-                                },
-                                shouldStopPolling = shouldStopPolling,
-                                mainHandler = mainHandler,
-                                transformerRef = transformerRef,
-                                outputFileRef = outputFileRef
-                            )
-                        }
-                    }
-                } catch (e: Exception) {
-                    mainHandler.post {
-                        VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
-                        onError(e)
-                    }
-                }
-            }.start()
-        } else {
-            // No GPU effects, render directly
+        if (!needsPreTranscode && !needsPreReverse) {
+            // Fast path: nothing to pre-process.
             renderInternal(
                 config = config,
                 onProgress = onProgress,
@@ -195,6 +143,94 @@ class RenderVideo(private val context: Context) {
                 transformerRef = transformerRef,
                 outputFileRef = outputFileRef
             )
+        } else {
+            Thread {
+                try {
+                    var workingConfig = config
+
+                    // 1) Pre-transcode HEVC 10-bit clips (if needed).
+                    if (needsPreTranscode) {
+                        Log.d(RENDER_TAG, "Pre-transcoding HEVC 10-bit videos...")
+                        val inputPaths = workingConfig.videoClips.map { it.inputPath }
+                        val transcodeMap = VideoTranscoder.transcodeClipsIfNeeded(
+                            context, inputPaths
+                        )
+                        transcodedFiles = transcodeMap.values
+                            .filter { it.contains("transcoded_") }
+                        if (transcodedFiles.isNotEmpty()) {
+                            Log.i(
+                                RENDER_TAG,
+                                "Pre-transcoded ${transcodedFiles.size} HEVC 10-bit videos to H.264"
+                            )
+                        }
+                        val updatedClips = workingConfig.videoClips.map { clip ->
+                            val newPath = transcodeMap[clip.inputPath] ?: clip.inputPath
+                            if (newPath != clip.inputPath) {
+                                VideoClip(
+                                    newPath,
+                                    clip.startUs,
+                                    clip.endUs,
+                                    clip.volume,
+                                    clip.playbackSpeed,
+                                    clip.reverseVideo
+                                )
+                            } else clip
+                        }
+                        workingConfig = workingConfig.copy(videoClips = updatedClips)
+                    }
+
+                    // 2) Pre-render reversed clips into single forward MP4 temp files.
+                    if (needsPreReverse && !shouldStopPolling.get()) {
+                        Log.d(
+                            RENDER_TAG,
+                            "Pre-rendering reversed segments (" +
+                                    "${workingConfig.videoClips.count { it.reverseVideo }} clip(s))"
+                        )
+                        val reversedPaths = mutableListOf<String>()
+                        val reversedClips = preReverseClips(
+                            workingConfig.videoClips,
+                            enableAudio = workingConfig.enableAudio,
+                            shouldStop = shouldStopPolling,
+                            collectPath = { reversedPaths.add(it) },
+                            onProgress = { f -> reverseProgress(f.toDouble()) },
+                        )
+                        reversedFiles = reversedPaths
+                        workingConfig = workingConfig.copy(videoClips = reversedClips)
+                        // Make sure the bar fully fills the reverse share before
+                        // the transformer phase starts.
+                        reverseProgress(1.0)
+                    }
+
+                    val finalConfig = workingConfig
+                    mainHandler.post {
+                        if (shouldStopPolling.get()) {
+                            cleanupAllPreFiles()
+                            return@post
+                        }
+                        renderInternal(
+                            config = finalConfig,
+                            onProgress = transformProgress,
+                            onComplete = { result ->
+                                cleanupAllPreFiles()
+                                onComplete(result)
+                            },
+                            onError = { error ->
+                                cleanupAllPreFiles()
+                                onError(error)
+                            },
+                            shouldStopPolling = shouldStopPolling,
+                            mainHandler = mainHandler,
+                            transformerRef = transformerRef,
+                            outputFileRef = outputFileRef
+                        )
+                    }
+                } catch (e: Exception) {
+                    mainHandler.post {
+                        cleanupAllPreFiles()
+                        onError(e)
+                    }
+                }
+            }.start()
         }
 
         // Return cancellation handle
@@ -203,10 +239,70 @@ class RenderVideo(private val context: Context) {
             mainHandler.removeCallbacksAndMessages(null)
             transformerRef.get()?.cancel()
             VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
+            VideoReverser.cleanupReversedFiles(reversedFiles)
             if (config.outputPath == null) {
                 outputFileRef.get()?.delete()
             }
         }
+    }
+
+    /**
+     * Pre-renders all clips with `reverseVideo == true` into single forward
+     * MP4 temp files using [VideoReverser], and returns the rewritten clip
+     * list. Forward clips pass through unchanged.
+     */
+    private fun preReverseClips(
+        clips: List<VideoClip>,
+        enableAudio: Boolean,
+        shouldStop: AtomicBoolean,
+        collectPath: (String) -> Unit,
+        onProgress: (Float) -> Unit,
+    ): List<VideoClip> {
+        val reversedClipIndices = clips.withIndex()
+            .filter { it.value.reverseVideo }
+            .map { it.index }
+        if (reversedClipIndices.isEmpty()) return clips
+        val totalReversed = reversedClipIndices.size
+        val result = clips.toMutableList()
+        reversedClipIndices.forEachIndexed { progressIdx, clipIdx ->
+            if (shouldStop.get()) return result
+            val clip = clips[clipIdx]
+            val startUs = clip.startUs ?: 0L
+            val endUs = clip.endUs
+                ?: ch.waio.pro_video_editor.src.features.render.helpers
+                    .MediaInfoExtractor.getVideoDuration(clip.inputPath)
+            try {
+                val reversed = VideoReverser.reverseSync(
+                    context = context,
+                    inputPath = clip.inputPath,
+                    segmentStartUs = startUs,
+                    segmentEndUs = endUs,
+                    includeAudio = enableAudio && (clip.volume ?: 1.0f) > 0f,
+                    onProgress = { clipFraction ->
+                        // Map per-clip progress into the overall reverse phase.
+                        val overall = (progressIdx + clipFraction) / totalReversed
+                        onProgress(overall.coerceIn(0f, 1f))
+                    },
+                )
+                collectPath(reversed.outputPath)
+                result[clipIdx] = VideoClip(
+                    inputPath = reversed.outputPath,
+                    startUs = 0L,
+                    endUs = reversed.durationUs.takeIf { it > 0 },
+                    volume = clip.volume,
+                    playbackSpeed = clip.playbackSpeed,
+                    reverseVideo = false,
+                )
+            } catch (e: Exception) {
+                Log.e(
+                    RENDER_TAG,
+                    "Reverse pre-render failed for ${clip.inputPath}: ${e.message}. " +
+                            "Falling back to forward playback."
+                )
+                result[clipIdx] = clip.copy(reverseVideo = false)
+            }
+        }
+        return result
     }
 
     /**

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
@@ -71,7 +71,7 @@ class CompositionBuilder(
         val hasCustomAudio = config.audioTracks.isNotEmpty()
 
         // Build video sequence
-        val videoBuilder = VideoSequenceBuilder(config.videoClips)
+        val videoBuilder = VideoSequenceBuilder(config.videoClips, context)
             .setVideoEffects(videoEffects)
             .setAudioEffects(audioEffects)
             .setRotation(rotationDegrees)
@@ -106,6 +106,10 @@ class CompositionBuilder(
 
         // Build video sequence (with audio intact)
         val videoSequence = videoBuilder.build()
+
+        // Forward any temp files produced by VideoSequenceBuilder (reversed-segment
+        // MP4s) so the render pipeline deletes them after export.
+        temporaryFiles.addAll(videoBuilder.temporaryFiles)
 
         // Prepare sequences list
         val sequences = mutableListOf<EditedMediaItemSequence>()

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoReverser.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoReverser.kt
@@ -15,7 +15,7 @@ import java.io.File
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 
-/** My tien
+/** 
  * Pre-renders reversed video segments into a single MP4 temp file so that the
  * main render pipeline can consume them as a normal forward clip.
  *

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoReverser.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoReverser.kt
@@ -1,0 +1,952 @@
+package ch.waio.pro_video_editor.src.features.render.helpers
+
+import RENDER_TAG
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import androidx.media3.common.util.UnstableApi
+import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+
+/** My tien
+ * Pre-renders reversed video segments into a single MP4 temp file so that the
+ * main render pipeline can consume them as a normal forward clip.
+ *
+ * Algorithm ("All-Intra trick"):
+ *  Phase A – decode the source segment in a single forward pass and re-encode
+ *    with KEY_I_FRAME_INTERVAL = 0 so every output frame is a keyframe.
+ *  Phase B – read all compressed I-frames from the Phase-A temp file into
+ *    memory, sort by PTS descending, remux into the output file with new
+ *    monotonically-increasing PTS. Zero codec involvement: pure byte copy.
+ *
+ * Audio is decoded into PCM, byte-reversed per audio frame, and re-encoded
+ * as AAC into the same output muxer.
+ */
+@UnstableApi
+object VideoReverser {
+
+    /** Result of [reverseSync]. */
+    data class ReverseResult(val outputPath: String, val durationUs: Long)
+
+    private const val DECODER_TIMEOUT_US = 10_000L
+    private const val ENCODER_TIMEOUT_US = 10_000L
+
+    /**
+     * Reverses a single segment of [inputPath] (in source-time coordinates) and
+     * writes it to a new temp MP4 inside [Context.getCacheDir].
+     *
+     * @param segmentStartUs Inclusive source start (us). Pass `0` for "from start".
+     * @param segmentEndUs Exclusive source end (us). Pass [Long.MAX_VALUE] for "until end".
+     * @param includeAudio When `true` the audio track is reversed too. When `false`
+     *  the output is video-only.
+     */
+    fun reverseSync(
+        context: Context,
+        inputPath: String,
+        segmentStartUs: Long,
+        segmentEndUs: Long,
+        includeAudio: Boolean,
+        onProgress: (Float) -> Unit = {},
+    ): ReverseResult {
+        val outputFile = File(
+            context.cacheDir,
+            "reversed_${System.currentTimeMillis()}.mp4"
+        )
+
+        Log.i(
+            RENDER_TAG,
+            "Reverse pre-render starting: input=$inputPath, " +
+                    "segment=${segmentStartUs / 1000}..${segmentEndUs / 1000}ms, " +
+                    "audio=$includeAudio, out=${outputFile.absolutePath}"
+        )
+
+        // The muxer is shared between video + audio. MediaMuxer.addTrack() may
+        // only be called BEFORE start(), so we must register both tracks before
+        // writing the first sample. To make that possible we pre-encode the
+        // reversed audio into a temp packet file (capturing its MediaFormat),
+        // then start the muxer once the video format is also known.
+        val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        var muxerStarted = false
+        val workDir = File(context.cacheDir, "reverse_${System.currentTimeMillis()}")
+        workDir.mkdirs()
+        var audioPre: AudioPreEncoded? = null
+
+        try {
+            // Phase 1: pre-encode reversed audio to a packet file (no muxer yet).
+            if (includeAudio) {
+                try {
+                    audioPre = preEncodeReversedAudio(
+                        inputPath = inputPath,
+                        segmentStartUs = segmentStartUs,
+                        segmentEndUs = segmentEndUs,
+                        workDir = workDir,
+                        onProgress = { f ->
+                            // Audio gets 0..0.1, video gets 0.1..0.95, audio remux 0.95..1.0
+                            onProgress((f * 0.1f).coerceIn(0f, 1f))
+                        },
+                    )
+                } catch (e: Exception) {
+                    // Audio reversal is best-effort: never fail the whole render.
+                    Log.w(RENDER_TAG, "Audio pre-encode failed, continuing without audio: ${e.message}")
+                    audioPre = null
+                }
+            }
+
+            // Phase 2: reverse the video track. The format-ready callback adds
+            // BOTH the (pre-encoded) audio track and the video track to the
+            // muxer, then starts it. The returned track index is for the video.
+            var audioTrackIdx = -1
+            val videoResult = reverseVideoTrack(
+                inputPath = inputPath,
+                segmentStartUs = segmentStartUs,
+                segmentEndUs = segmentEndUs,
+                muxer = muxer,
+                onVideoFormatReady = { videoFmt ->
+                    audioPre?.let { audioTrackIdx = muxer.addTrack(it.format) }
+                    val videoIdx = muxer.addTrack(videoFmt)
+                    muxer.start()
+                    muxerStarted = true
+                    videoIdx
+                },
+                workDir = workDir,
+                onProgress = { f ->
+                    val base = if (includeAudio && audioPre != null) 0.1f else 0f
+                    val share = if (includeAudio && audioPre != null) 0.85f else 1.0f
+                    onProgress((base + f * share).coerceIn(0f, 1f))
+                },
+            )
+
+            // Phase 3: remux buffered audio packets into the muxer.
+            audioPre?.let { pre ->
+                if (muxerStarted && audioTrackIdx >= 0) {
+                    try {
+                        writeBufferedAudio(
+                            muxer = muxer,
+                            audioTrackIndex = audioTrackIdx,
+                            packets = pre.packetsFile,
+                            onProgress = { f -> onProgress((0.95f + f * 0.05f).coerceIn(0f, 1f)) },
+                        )
+                    } catch (e: Exception) {
+                        Log.w(RENDER_TAG, "Audio remux failed, output will be silent: ${e.message}")
+                    }
+                }
+            }
+
+            return ReverseResult(outputFile.absolutePath, videoResult.durationUs)
+        } catch (e: Exception) {
+            outputFile.delete()
+            throw e
+        } finally {
+            try {
+                if (muxerStarted) muxer.stop()
+            } catch (e: Exception) {
+                Log.w(RENDER_TAG, "Muxer stop failed: ${e.message}")
+            }
+            try {
+                muxer.release()
+            } catch (_: Exception) { /* ignore */ }
+            try { audioPre?.packetsFile?.delete() } catch (_: Exception) {}
+            // Best-effort cleanup of intermediate frame files.
+            workDir.deleteRecursively()
+        }
+    }
+
+    /** Pre-encoded reversed audio: AAC packets + format, both ready to be muxed. */
+    private data class AudioPreEncoded(val format: MediaFormat, val packetsFile: File)
+
+    // ---------------------------------------------------------------------
+    // VIDEO
+    // ---------------------------------------------------------------------
+
+    private data class VideoReverseResult(val durationUs: Long)
+
+    /**
+     * Two-phase "All-Intra" approach:
+     *
+     * Phase A – [transcodeSegmentToAllIntra]: decode the source segment in a
+     *   single forward pass and re-encode with KEY_I_FRAME_INTERVAL = 0 so
+     *   every output frame is an independent keyframe. No seeking, no
+     *   YUV file-spilling; one straight decode → encode pass.
+     *
+     * Phase B – [remuxReversed]: read all compressed I-frames from the Phase-A
+     *   temp file into memory, sort by PTS descending, then write to the output
+     *   muxer with new monotonically-increasing timestamps. Zero codec
+     *   involvement — pure byte copy.
+     *
+     * Memory: roughly (bitrate × duration / 8) bytes for the in-memory sample
+     * list, typically 20–80 MB for a 40-second 1080p clip at 4–8 Mbps.
+     */
+    private fun reverseVideoTrack(
+        inputPath: String,
+        segmentStartUs: Long,
+        segmentEndUs: Long,
+        muxer: MediaMuxer,
+        onVideoFormatReady: (MediaFormat) -> Int,
+        workDir: File,
+        onProgress: (Float) -> Unit,
+    ): VideoReverseResult {
+        val allIntraFile = File(workDir, "all_intra.mp4")
+
+        // Read container-level rotation from the source once so it can be
+        // forwarded to the final output muxer (MediaMuxer.setOrientationHint
+        // must be called before start(), which happens inside remuxReversed).
+        val rotation = run {
+            val ex = MediaExtractor().apply { setDataSource(inputPath) }
+            try {
+                val vidIdx = findTrack(ex, "video/")
+                if (vidIdx != null) {
+                    val fmt = ex.getTrackFormat(vidIdx)
+                    if (fmt.containsKey(MediaFormat.KEY_ROTATION))
+                        fmt.getInteger(MediaFormat.KEY_ROTATION)
+                    else 0
+                } else 0
+            } finally {
+                ex.release()
+            }
+        }
+
+        // Phase A: single forward decode + re-encode (70 % of progress).
+        transcodeSegmentToAllIntra(
+            inputPath = inputPath,
+            segmentStartUs = segmentStartUs,
+            segmentEndUs = segmentEndUs,
+            outFile = allIntraFile,
+            onProgress = { f -> onProgress(f * 0.7f) },
+        )
+
+        // Phase B: byte-level reverse + remux into the shared output muxer
+        //          (remaining 30 % of progress).
+        val durationUs = remuxReversed(
+            allIntraFile = allIntraFile,
+            muxer = muxer,
+            onVideoFormatReady = { fmt ->
+                // Apply rotation BEFORE the muxer is started inside the callback.
+                if (rotation != 0) muxer.setOrientationHint(rotation)
+                onVideoFormatReady(fmt)
+            },
+            onProgress = { f -> onProgress(0.7f + f * 0.3f) },
+        )
+
+        return VideoReverseResult(durationUs = durationUs)
+    }
+
+    /**
+     * Decodes [inputPath] within [[segmentStartUs]..[segmentEndUs]] in a
+     * single forward pass and writes an all-intra H.264 MP4 to [outFile].
+     * KEY_I_FRAME_INTERVAL = 0 forces every output frame to be an I-frame,
+     * making Phase B (sample reorder) codec-free.
+     */
+    private fun transcodeSegmentToAllIntra(
+        inputPath: String,
+        segmentStartUs: Long,
+        segmentEndUs: Long,
+        outFile: File,
+        onProgress: (Float) -> Unit,
+    ) {
+        val extractor = MediaExtractor().apply { setDataSource(inputPath) }
+        val videoTrackIndex = findTrack(extractor, "video/")
+            ?: throw IllegalStateException("No video track found in $inputPath")
+        extractor.selectTrack(videoTrackIndex)
+        val inputFormat = extractor.getTrackFormat(videoTrackIndex)
+
+        val width = inputFormat.getInteger(MediaFormat.KEY_WIDTH)
+        val height = inputFormat.getInteger(MediaFormat.KEY_HEIGHT)
+        val frameRate = if (inputFormat.containsKey(MediaFormat.KEY_FRAME_RATE))
+            inputFormat.getInteger(MediaFormat.KEY_FRAME_RATE) else 30
+        val mime = inputFormat.getString(MediaFormat.KEY_MIME)
+            ?: throw IllegalStateException("Video mime missing")
+
+        // Estimate segment duration for smooth progress reporting.
+        val trackDurationUs = if (inputFormat.containsKey(MediaFormat.KEY_DURATION))
+            inputFormat.getLong(MediaFormat.KEY_DURATION) else Long.MAX_VALUE
+        val effectiveEndUs = if (segmentEndUs == Long.MAX_VALUE) trackDurationUs else segmentEndUs
+        val totalDurationUs = (effectiveEndUs - segmentStartUs).coerceAtLeast(1L)
+
+        Log.d(
+            RENDER_TAG,
+            "All-intra transcode: ${width}x$height @ ${frameRate}fps, mime=$mime, " +
+                    "segment=${segmentStartUs / 1000}..${effectiveEndUs / 1000}ms"
+        )
+
+        // Encoder: H.264, all-intra (KEY_I_FRAME_INTERVAL = 0).
+        val outMime = "video/avc"
+        val encoderFormat = MediaFormat.createVideoFormat(outMime, width, height).apply {
+            setInteger(
+                MediaFormat.KEY_COLOR_FORMAT,
+                MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
+            )
+            val bitRate = if (inputFormat.containsKey(MediaFormat.KEY_BIT_RATE))
+                inputFormat.getInteger(MediaFormat.KEY_BIT_RATE)
+            else width * height * 4
+            setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
+            setInteger(MediaFormat.KEY_FRAME_RATE, frameRate)
+            setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 0) // ← every frame is a keyframe
+        }
+        val encoder = MediaCodec.createEncoderByType(outMime)
+        encoder.configure(encoderFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        encoder.start()
+
+        // Decoder: flexible YUV so getOutputImage() works on all devices.
+        val decoderFormat = extractor.getTrackFormat(videoTrackIndex).also {
+            it.setInteger(
+                MediaFormat.KEY_COLOR_FORMAT,
+                MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
+            )
+        }
+        val decoder = MediaCodec.createDecoderByType(mime)
+        decoder.configure(decoderFormat, null, null, 0)
+        decoder.start()
+
+        val tempMuxer = MediaMuxer(outFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        // Carry over container-level rotation so the Phase-A output file is
+        // correctly oriented (required for Phase-B remux and any direct inspection).
+        if (inputFormat.containsKey(MediaFormat.KEY_ROTATION)) {
+            tempMuxer.setOrientationHint(inputFormat.getInteger(MediaFormat.KEY_ROTATION))
+        }
+        var tempMuxerStarted = false
+        var tempTrackIndex = -1
+        val encInfo = MediaCodec.BufferInfo()
+
+        extractor.seekTo(segmentStartUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+        val decInfo = MediaCodec.BufferInfo()
+        var inputDone = false
+        var outputDone = false
+
+        try {
+            while (!outputDone) {
+                // ── Fill ALL available decoder input slots (non-blocking after first) ──
+                if (!inputDone) {
+                    var firstInput = true
+                    while (!inputDone) {
+                        val inTimeout = if (firstInput) DECODER_TIMEOUT_US else 0L
+                        firstInput = false
+                        val inIdx = decoder.dequeueInputBuffer(inTimeout)
+                        if (inIdx < 0) break
+                        val t = extractor.sampleTime
+                        if (t < 0 || t >= segmentEndUs) {
+                            decoder.queueInputBuffer(
+                                inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                            )
+                            inputDone = true
+                        } else {
+                            val buf = decoder.getInputBuffer(inIdx)!!
+                            buf.clear()
+                            val size = extractor.readSampleData(buf, 0)
+                            if (size < 0) {
+                                decoder.queueInputBuffer(
+                                    inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                                )
+                                inputDone = true
+                            } else {
+                                decoder.queueInputBuffer(
+                                    inIdx, 0, size, t, extractor.sampleFlags
+                                )
+                                extractor.advance()
+                            }
+                        }
+                    }
+                }
+
+                // ── Drain ALL available decoder output frames ──────────────────────
+                // Use DECODER_TIMEOUT_US on first call so we yield to the decoder;
+                // thereafter non-blocking to process all buffered frames at once.
+                var firstOutput = true
+                while (true) {
+                    val outTimeout = if (firstOutput) DECODER_TIMEOUT_US else 0L
+                    firstOutput = false
+                    val outIdx = decoder.dequeueOutputBuffer(decInfo, outTimeout)
+                    when {
+                        outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> break
+                        outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                            firstOutput = true // re-try with timeout after format change
+                        }
+                        outIdx >= 0 -> {
+                            if (decInfo.size > 0) {
+                                val pts = decInfo.presentationTimeUs
+                                if (pts in segmentStartUs until effectiveEndUs) {
+                                    val decImage = decoder.getOutputImage(outIdx)
+                                    if (decImage != null) {
+                                        // Drain encoder BEFORE getting its input slot to
+                                        // avoid spin-waiting when the pipeline is full.
+                                        drainEncoder(
+                                            encoder = encoder,
+                                            muxer = tempMuxer,
+                                            bufferInfo = encInfo,
+                                            endOfStream = false,
+                                            onFormatChanged = { fmt ->
+                                                if (tempTrackIndex < 0) {
+                                                    tempTrackIndex = tempMuxer.addTrack(fmt)
+                                                    tempMuxer.start()
+                                                    tempMuxerStarted = true
+                                                }
+                                            },
+                                            getTrackIndex = { tempTrackIndex },
+                                        )
+                                        // Direct decoder-image → encoder-image copy:
+                                        // no intermediate I420 ByteArray, half the
+                                        // memory bandwidth of the two-step approach.
+                                        var encInIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                                        while (encInIdx < 0) {
+                                            drainEncoder(
+                                                encoder = encoder,
+                                                muxer = tempMuxer,
+                                                bufferInfo = encInfo,
+                                                endOfStream = false,
+                                                onFormatChanged = { fmt ->
+                                                    if (tempTrackIndex < 0) {
+                                                        tempTrackIndex = tempMuxer.addTrack(fmt)
+                                                        tempMuxer.start()
+                                                        tempMuxerStarted = true
+                                                    }
+                                                },
+                                                getTrackIndex = { tempTrackIndex },
+                                            )
+                                            encInIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                                        }
+                                        val encImage = encoder.getInputImage(encInIdx)
+                                        if (encImage != null) {
+                                            copyImageDirect(decImage, encImage)
+                                            encoder.queueInputBuffer(
+                                                encInIdx, 0, width * height * 3 / 2, pts, 0
+                                            )
+                                        } else {
+                                            encoder.queueInputBuffer(encInIdx, 0, 0, pts, 0)
+                                        }
+                                        decImage.close()
+                                        onProgress(
+                                            ((pts - segmentStartUs).toFloat() / totalDurationUs)
+                                                .coerceIn(0f, 1f)
+                                        )
+                                    }
+                                }
+                            }
+                            decoder.releaseOutputBuffer(outIdx, false)
+                            if ((decInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                                outputDone = true
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Drain encoder after EOS.
+            feedEncoderEos(encoder)
+            drainEncoder(
+                encoder = encoder,
+                muxer = tempMuxer,
+                bufferInfo = encInfo,
+                endOfStream = true,
+                onFormatChanged = { fmt ->
+                    if (tempTrackIndex < 0) {
+                        tempTrackIndex = tempMuxer.addTrack(fmt)
+                        tempMuxer.start()
+                        tempMuxerStarted = true
+                    }
+                },
+                getTrackIndex = { tempTrackIndex },
+            )
+        } finally {
+            try { decoder.stop() } catch (_: Exception) {}
+            try { decoder.release() } catch (_: Exception) {}
+            try { encoder.stop() } catch (_: Exception) {}
+            try { encoder.release() } catch (_: Exception) {}
+            try { extractor.release() } catch (_: Exception) {}
+            if (tempMuxerStarted) {
+                try { tempMuxer.stop() } catch (_: Exception) {}
+            }
+            try { tempMuxer.release() } catch (_: Exception) {}
+        }
+
+        Log.d(RENDER_TAG, "All-intra transcode done: ${outFile.length()} bytes")
+    }
+
+    /**
+     * Reads all compressed video samples from [allIntraFile] (an all-intra
+     * MP4) into memory, reverses them by PTS, then writes to [muxer] with
+     * monotonically-increasing timestamps. No codec is involved.
+     *
+     * Returns the total output duration in microseconds.
+     */
+    private fun remuxReversed(
+        allIntraFile: File,
+        muxer: MediaMuxer,
+        onVideoFormatReady: (MediaFormat) -> Int,
+        onProgress: (Float) -> Unit,
+    ): Long {
+        data class Sample(val ptsUs: Long, val data: ByteArray)
+
+        val extractor = MediaExtractor().apply { setDataSource(allIntraFile.absolutePath) }
+        val trackIdx = findTrack(extractor, "video/")
+            ?: throw IllegalStateException("No video track in all-intra temp file")
+        extractor.selectTrack(trackIdx)
+        val format = extractor.getTrackFormat(trackIdx)
+
+        // Load all compressed I-frames into memory.
+        val samples = mutableListOf<Sample>()
+        try {
+            while (true) {
+                val pts = extractor.sampleTime
+                if (pts < 0) break
+                val sampleSize = extractor.sampleSize
+                if (sampleSize <= 0) { extractor.advance(); continue }
+                val rawBuf = ByteArray(sampleSize.toInt())
+                val wrapped = ByteBuffer.wrap(rawBuf)
+                val bytesRead = extractor.readSampleData(wrapped, 0)
+                if (bytesRead < 0) break
+                val data = if (bytesRead.toLong() < sampleSize) rawBuf.copyOf(bytesRead) else rawBuf
+                samples.add(Sample(pts, data))
+                if (!extractor.advance()) break
+            }
+        } finally {
+            extractor.release()
+        }
+
+        if (samples.isEmpty()) {
+            throw IllegalStateException("All-intra file has no video samples")
+        }
+
+        Log.d(RENDER_TAG, "Remux reversed: ${samples.size} I-frames loaded, reversing…")
+
+        // Sort descending: last original frame becomes first output frame.
+        samples.sortByDescending { it.ptsUs }
+
+        // Compute frame duration from PTS spread.
+        val maxPts = samples.maxOf { it.ptsUs }
+        val minPts = samples.minOf { it.ptsUs }
+        val frameDurationUs = if (samples.size > 1)
+            (maxPts - minPts) / (samples.size - 1)
+        else
+            1_000_000L / 30
+
+        // Register video track + start the shared muxer (audio is registered
+        // beforehand via the onVideoFormatReady callback in reverseSync).
+        val muxerTrackIndex = onVideoFormatReady(format)
+
+        val bufInfo = MediaCodec.BufferInfo()
+        var newPts = 0L
+        val total = samples.size
+        for ((i, sample) in samples.withIndex()) {
+            val buf = ByteBuffer.wrap(sample.data)
+            bufInfo.offset = 0
+            bufInfo.size = sample.data.size
+            bufInfo.presentationTimeUs = newPts
+            bufInfo.flags = MediaCodec.BUFFER_FLAG_KEY_FRAME
+            muxer.writeSampleData(muxerTrackIndex, buf, bufInfo)
+            newPts += frameDurationUs
+            onProgress((i + 1).toFloat() / total)
+        }
+
+        return newPts
+    }
+
+    /**
+     * Copies all three YUV planes directly from a decoder [android.media.Image]
+     * into an encoder [android.media.Image], handling any combination of planar
+     * (pixelStride = 1) and semi-planar (pixelStride = 2, NV12) layouts on
+     * either side. This avoids allocating an intermediate I420 ByteArray and
+     * halves the memory bandwidth compared to the two-step approach.
+     */
+    private fun copyImageDirect(src: android.media.Image, dst: android.media.Image) {
+        copyImagePlane(src.planes[0], dst.planes[0], src.width,     src.height)
+        copyImagePlane(src.planes[1], dst.planes[1], src.width / 2, src.height / 2)
+        copyImagePlane(src.planes[2], dst.planes[2], src.width / 2, src.height / 2)
+    }
+
+    private fun copyImagePlane(
+        src: android.media.Image.Plane,
+        dst: android.media.Image.Plane,
+        planeWidth: Int,
+        planeHeight: Int,
+    ) {
+        val srcBuf         = src.buffer
+        val dstBuf         = dst.buffer
+        val srcRowStride   = src.rowStride
+        val srcPixelStride = src.pixelStride
+        val dstRowStride   = dst.rowStride
+        val dstPixelStride = dst.pixelStride
+
+        // Reusable row scratch buffers — allocated once per plane call.
+        val srcRow = ByteArray(planeWidth)  // de-interleaved source pixels
+
+        for (r in 0 until planeHeight) {
+            // ── Read source row, de-interleaving if needed ──────────────────
+            srcBuf.position(r * srcRowStride)
+            if (srcPixelStride == 1) {
+                srcBuf.get(srcRow, 0, planeWidth)
+            } else {
+                val raw = ByteArray(minOf(planeWidth * srcPixelStride, srcBuf.remaining()))
+                srcBuf.get(raw)
+                for (c in 0 until planeWidth) srcRow[c] = raw[c * srcPixelStride]
+            }
+
+            // ── Write to destination row, interleaving if needed ────────────
+            val dstPos = r * dstRowStride
+            if (dstPixelStride == 1) {
+                dstBuf.position(dstPos)
+                dstBuf.put(srcRow, 0, planeWidth)
+            } else {
+                // Interleaved dst (e.g. NV12): U and V share one buffer.
+                // Read existing row first so the OTHER component's bytes are
+                // preserved, then overwrite only OUR component bytes.
+                val dstRow = ByteArray(minOf(planeWidth * dstPixelStride, dstBuf.limit() - dstPos))
+                dstBuf.position(dstPos)
+                dstBuf.get(dstRow)
+                for (c in 0 until planeWidth) dstRow[c * dstPixelStride] = srcRow[c]
+                dstBuf.position(dstPos)
+                dstBuf.put(dstRow)
+            }
+        }
+    }
+
+    private fun feedEncoderEos(encoder: MediaCodec) {
+        while (true) {
+            val idx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+            if (idx >= 0) {
+                encoder.queueInputBuffer(
+                    idx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                )
+                return
+            }
+        }
+    }
+
+    private fun drainEncoder(
+        encoder: MediaCodec,
+        muxer: MediaMuxer,
+        bufferInfo: MediaCodec.BufferInfo,
+        endOfStream: Boolean,
+        onFormatChanged: (MediaFormat) -> Unit,
+        getTrackIndex: () -> Int,
+    ) {
+        while (true) {
+            val idx = encoder.dequeueOutputBuffer(bufferInfo, ENCODER_TIMEOUT_US)
+            when {
+                idx == MediaCodec.INFO_TRY_AGAIN_LATER -> {
+                    if (!endOfStream) return
+                    // else continue waiting for EOS
+                }
+                idx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                    onFormatChanged(encoder.outputFormat)
+                }
+                idx >= 0 -> {
+                    val outBuf = encoder.getOutputBuffer(idx)!!
+                    if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                        bufferInfo.size = 0
+                    }
+                    if (bufferInfo.size > 0) {
+                        val trackIdx = getTrackIndex()
+                        if (trackIdx >= 0) {
+                            outBuf.position(bufferInfo.offset)
+                            outBuf.limit(bufferInfo.offset + bufferInfo.size)
+                            muxer.writeSampleData(trackIdx, outBuf, bufferInfo)
+                        }
+                    }
+                    encoder.releaseOutputBuffer(idx, false)
+                    if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // AUDIO
+    // ---------------------------------------------------------------------
+
+    private fun preEncodeReversedAudio(
+        inputPath: String,
+        segmentStartUs: Long,
+        segmentEndUs: Long,
+        workDir: File,
+        onProgress: (Float) -> Unit = {},
+    ): AudioPreEncoded? {
+        val extractor = MediaExtractor().apply { setDataSource(inputPath) }
+        val audioTrackIndex = findTrack(extractor, "audio/")
+        if (audioTrackIndex == null) {
+            extractor.release()
+            Log.d(RENDER_TAG, "Reverse audio skipped: no audio track")
+            return null
+        }
+        extractor.selectTrack(audioTrackIndex)
+        val inputFormat = extractor.getTrackFormat(audioTrackIndex)
+        val sampleRate = inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        val channelCount = inputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        val inMime = inputFormat.getString(MediaFormat.KEY_MIME)!!
+
+        // 1) Decode PCM into a temp file (16-bit signed LE, frame = channelCount * 2 bytes).
+        val pcmFile = File.createTempFile("rev_pcm_", ".raw")
+        val decoder = MediaCodec.createDecoderByType(inMime)
+        decoder.configure(inputFormat, null, null, 0)
+        decoder.start()
+
+        extractor.seekTo(segmentStartUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+
+        val bufferInfo = MediaCodec.BufferInfo()
+        var inputDone = false
+        var outputDone = false
+
+        try {
+            pcmFile.outputStream().use { pcmOut ->
+                while (!outputDone) {
+                    if (!inputDone) {
+                        val inIdx = decoder.dequeueInputBuffer(DECODER_TIMEOUT_US)
+                        if (inIdx >= 0) {
+                            val t = extractor.sampleTime
+                            if (t < 0 || t >= segmentEndUs) {
+                                decoder.queueInputBuffer(
+                                    inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                                )
+                                inputDone = true
+                            } else {
+                                val buf = decoder.getInputBuffer(inIdx)!!
+                                buf.clear()
+                                val size = extractor.readSampleData(buf, 0)
+                                if (size < 0) {
+                                    decoder.queueInputBuffer(
+                                        inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                                    )
+                                    inputDone = true
+                                } else {
+                                    decoder.queueInputBuffer(inIdx, 0, size, t, 0)
+                                    extractor.advance()
+                                }
+                            }
+                        }
+                    }
+                    val outIdx = decoder.dequeueOutputBuffer(bufferInfo, DECODER_TIMEOUT_US)
+                    when {
+                        outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> {}
+                        outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {}
+                        outIdx >= 0 -> {
+                            if (bufferInfo.size > 0 &&
+                                bufferInfo.presentationTimeUs in segmentStartUs until segmentEndUs
+                            ) {
+                                val outBuf = decoder.getOutputBuffer(outIdx)!!
+                                outBuf.position(bufferInfo.offset)
+                                outBuf.limit(bufferInfo.offset + bufferInfo.size)
+                                val tmp = ByteArray(bufferInfo.size)
+                                outBuf.get(tmp)
+                                pcmOut.write(tmp)
+                            }
+                            decoder.releaseOutputBuffer(outIdx, false)
+                            if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                                outputDone = true
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+            try { decoder.stop() } catch (_: Exception) {}
+            try { decoder.release() } catch (_: Exception) {}
+            try { extractor.release() } catch (_: Exception) {}
+        }
+
+        val pcmLength = pcmFile.length()
+        val frameSize = channelCount * 2
+        if (pcmLength < frameSize) {
+            pcmFile.delete()
+            Log.w(RENDER_TAG, "Reverse audio: no PCM samples extracted")
+            return null
+        }
+
+        // 2) Set up AAC encoder.
+        val outMime = "audio/mp4a-latm"
+        val outFormat = MediaFormat.createAudioFormat(outMime, sampleRate, channelCount).apply {
+            setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+            setInteger(MediaFormat.KEY_BIT_RATE, 128_000)
+            setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 16384)
+        }
+        val encoder = MediaCodec.createEncoderByType(outMime)
+        encoder.configure(outFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        encoder.start()
+
+        // Buffer encoded AAC packets to a file together with their BufferInfo,
+        // so they can be remuxed AFTER the muxer is started (which only happens
+        // once the video track format is also known).
+        val packetsFile = File(workDir, "reversed_audio_packets.bin")
+        val packetsOut = DataOutputStream(packetsFile.outputStream().buffered())
+        var capturedAudioFormat: MediaFormat? = null
+        val encInfo = MediaCodec.BufferInfo()
+
+        fun drain(endOfStream: Boolean) {
+            while (true) {
+                val idx = encoder.dequeueOutputBuffer(encInfo, ENCODER_TIMEOUT_US)
+                when {
+                    idx == MediaCodec.INFO_TRY_AGAIN_LATER -> {
+                        if (!endOfStream) return
+                    }
+                    idx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                        capturedAudioFormat = encoder.outputFormat
+                    }
+                    idx >= 0 -> {
+                        val outBuf = encoder.getOutputBuffer(idx)!!
+                        val isCodecConfig =
+                            (encInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0
+                        if (!isCodecConfig && encInfo.size > 0) {
+                            outBuf.position(encInfo.offset)
+                            outBuf.limit(encInfo.offset + encInfo.size)
+                            val bytes = ByteArray(encInfo.size)
+                            outBuf.get(bytes)
+                            packetsOut.writeInt(encInfo.size)
+                            packetsOut.writeLong(encInfo.presentationTimeUs)
+                            packetsOut.writeInt(encInfo.flags)
+                            packetsOut.write(bytes)
+                        }
+                        encoder.releaseOutputBuffer(idx, false)
+                        if ((encInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) return
+                    }
+                }
+            }
+        }
+
+        // 3) Feed PCM in reverse, frame-aligned.
+        val readChunkBytes = 4096 * frameSize // ~32k per chunk; small enough for any encoder input
+        val raf = RandomAccessFile(pcmFile, "r")
+        val totalFrames = pcmLength / frameSize
+        val sampleDurationUs = 1_000_000L / sampleRate
+        var outFramePos = 0L
+
+        try {
+            var remainingFrames = totalFrames
+            while (remainingFrames > 0) {
+                val chunkFrames = minOf(remainingFrames, (readChunkBytes / frameSize).toLong())
+                val chunkBytes = (chunkFrames * frameSize).toInt()
+                val startByte = (remainingFrames - chunkFrames) * frameSize
+                raf.seek(startByte)
+                val chunk = ByteArray(chunkBytes)
+                raf.readFully(chunk)
+                reverseFramesInPlace(chunk, frameSize)
+
+                var offset = 0
+                while (offset < chunkBytes) {
+                    val inIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                    if (inIdx < 0) {
+                        drain(false)
+                        continue
+                    }
+                    val buf = encoder.getInputBuffer(inIdx)!!
+                    buf.clear()
+                    val toWrite = minOf(buf.capacity(), chunkBytes - offset)
+                    val toWriteFrameAligned = (toWrite / frameSize) * frameSize
+                    if (toWriteFrameAligned == 0) {
+                        encoder.queueInputBuffer(inIdx, 0, 0, 0, 0)
+                        break
+                    }
+                    buf.put(chunk, offset, toWriteFrameAligned)
+                    val ptsUs = outFramePos * sampleDurationUs
+                    encoder.queueInputBuffer(inIdx, 0, toWriteFrameAligned, ptsUs, 0)
+                    outFramePos += toWriteFrameAligned / frameSize
+                    offset += toWriteFrameAligned
+                    drain(false)
+                }
+                remainingFrames -= chunkFrames
+                onProgress(
+                    ((totalFrames - remainingFrames).toFloat() / totalFrames.toFloat())
+                        .coerceIn(0f, 1f)
+                )
+            }
+            // EOS
+            while (true) {
+                val inIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                if (inIdx >= 0) {
+                    encoder.queueInputBuffer(
+                        inIdx, 0, 0, outFramePos * sampleDurationUs,
+                        MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                    )
+                    break
+                }
+                drain(false)
+            }
+            drain(true)
+        } finally {
+            try { raf.close() } catch (_: Exception) {}
+            try { pcmFile.delete() } catch (_: Exception) {}
+            try { encoder.stop() } catch (_: Exception) {}
+            try { encoder.release() } catch (_: Exception) {}
+            try { packetsOut.close() } catch (_: Exception) {}
+        }
+
+        val format = capturedAudioFormat
+        if (format == null || packetsFile.length() == 0L) {
+            packetsFile.delete()
+            Log.w(RENDER_TAG, "Reverse audio: encoder produced no packets")
+            return null
+        }
+        return AudioPreEncoded(format, packetsFile)
+    }
+
+    /** Replays the packets produced by [preEncodeReversedAudio] into [muxer]. */
+    private fun writeBufferedAudio(
+        muxer: MediaMuxer,
+        audioTrackIndex: Int,
+        packets: File,
+        onProgress: (Float) -> Unit,
+    ) {
+        val totalLength = packets.length().coerceAtLeast(1L)
+        var bytesRead = 0L
+        val info = MediaCodec.BufferInfo()
+        DataInputStream(packets.inputStream().buffered()).use { input ->
+            while (true) {
+                val size = try { input.readInt() } catch (_: Exception) { break }
+                val ptsUs = input.readLong()
+                val flags = input.readInt()
+                val bytes = ByteArray(size)
+                input.readFully(bytes)
+                val buf = ByteBuffer.allocate(size).apply { put(bytes); flip() }
+                info.set(0, size, ptsUs, flags)
+                muxer.writeSampleData(audioTrackIndex, buf, info)
+                bytesRead += 4 + 8 + 4 + size
+                onProgress((bytesRead.toFloat() / totalLength.toFloat()).coerceIn(0f, 1f))
+            }
+        }
+    }
+
+    /** Reverses `data` frame-by-frame in place (frame = [frameSize] bytes). */
+    private fun reverseFramesInPlace(data: ByteArray, frameSize: Int) {
+        val frames = data.size / frameSize
+        val tmp = ByteArray(frameSize)
+        var i = 0
+        var j = frames - 1
+        while (i < j) {
+            System.arraycopy(data, i * frameSize, tmp, 0, frameSize)
+            System.arraycopy(data, j * frameSize, data, i * frameSize, frameSize)
+            System.arraycopy(tmp, 0, data, j * frameSize, frameSize)
+            i++
+            j--
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // SHARED
+    // ---------------------------------------------------------------------
+
+    private fun findTrack(extractor: MediaExtractor, mimePrefix: String): Int? {
+        for (i in 0 until extractor.trackCount) {
+            val mime = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME) ?: continue
+            if (mime.startsWith(mimePrefix)) return i
+        }
+        return null
+    }
+
+    /** Deletes reversed-segment temp files (best effort). */
+    fun cleanupReversedFiles(paths: Collection<String>) {
+        for (path in paths) {
+            try {
+                val f = File(path)
+                if (f.exists() && f.name.startsWith("reversed_")) {
+                    f.delete()
+                }
+            } catch (_: Exception) { /* ignore */ }
+        }
+    }
+}

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -1,6 +1,7 @@
 package ch.waio.pro_video_editor.src.features.render.helpers
 
 import RENDER_TAG
+import android.content.Context
 import android.net.Uri
 import applyScale
 import androidx.media3.common.C
@@ -29,8 +30,16 @@ import java.io.File
  */
 @UnstableApi
 class VideoSequenceBuilder(
-    private val videoClips: List<VideoClip>
+    private val videoClips: List<VideoClip>,
+    private val context: Context? = null,
 ) {
+    /**
+     * Paths to temp files produced while building the sequence (currently:
+     * reversed-segment MP4s pre-rendered by [VideoReverser]). The caller MUST
+     * delete these after the Transformer export finishes.
+     */
+    val temporaryFiles: MutableList<java.io.File> = mutableListOf()
+
     private var videoEffects: List<Effect> = emptyList()
     private var audioEffects: List<AudioProcessor> = emptyList()
     private var rotationDegrees: Float = 0f
@@ -683,56 +692,69 @@ class VideoSequenceBuilder(
     }
 
     /**
-     * Expands reversed clips into frame-sized forward slices ordered from end to start.
-     *
-     * Media3 Transformer does not provide a native negative-speed effect. Small slices
-     * preserve the existing effect pipeline while producing backwards visual playback.
+     * Materializes any clip still flagged as reversed. In normal operation
+     * [RenderVideo] pre-renders reversed clips BEFORE the sequence is built
+     * (so it can report progress on the slow MediaCodec pre-render). This
+     * fallback only triggers if a reversed clip somehow reaches the builder
+     * directly (e.g. tests bypassing [RenderVideo]).
      */
     private fun expandReversedClips(clips: List<VideoClip>): List<VideoClip> {
-        val result = mutableListOf<VideoClip>()
+        if (clips.none { it.reverseVideo }) return clips
+        val ctx = context
+        if (ctx == null) {
+            Log.w(
+                RENDER_TAG,
+                "Reverse requested but no Context provided to VideoSequenceBuilder; " +
+                        "leaving clips unchanged."
+            )
+            return clips
+        }
+        Log.w(
+            RENDER_TAG,
+            "Reversed clip reached VideoSequenceBuilder — pre-render fallback engaged " +
+                    "(progress will NOT be reported for this stage)."
+        )
 
+        val result = mutableListOf<VideoClip>()
         for (clip in clips) {
             if (!clip.reverseVideo) {
                 result.add(clip)
                 continue
             }
-
             val sourceStartUs = clip.startUs ?: 0L
             val sourceEndUs = clip.endUs ?: MediaInfoExtractor.getVideoDuration(clip.inputPath)
             if (sourceEndUs <= sourceStartUs) {
                 Log.w(RENDER_TAG, "Skipping reversed clip with invalid range: ${clip.inputPath}")
                 continue
             }
-
-            val frameRate = MediaInfoExtractor.getVideoFrameRate(clip.inputPath)
-                ?.takeIf { it > 0f }
-                ?: 30f
-            val frameDurationUs = (1_000_000f / frameRate).toLong().coerceAtLeast(1L)
-            var cursorEndUs = sourceEndUs
-            var sliceCount = 0
-
-            while (cursorEndUs > sourceStartUs) {
-                val sliceStartUs = maxOf(sourceStartUs, cursorEndUs - frameDurationUs)
+            try {
+                val reversed = VideoReverser.reverseSync(
+                    context = ctx,
+                    inputPath = clip.inputPath,
+                    segmentStartUs = sourceStartUs,
+                    segmentEndUs = sourceEndUs,
+                    includeAudio = enableAudio && (clip.volume ?: 1.0f) > 0f,
+                )
+                temporaryFiles.add(java.io.File(reversed.outputPath))
                 result.add(
                     VideoClip(
-                        inputPath = clip.inputPath,
-                        startUs = sliceStartUs,
-                        endUs = cursorEndUs,
+                        inputPath = reversed.outputPath,
+                        startUs = 0L,
+                        endUs = reversed.durationUs.takeIf { it > 0 },
                         volume = clip.volume,
                         playbackSpeed = clip.playbackSpeed,
                         reverseVideo = false
                     )
                 )
-                cursorEndUs = sliceStartUs
-                sliceCount++
+            } catch (e: Exception) {
+                Log.e(
+                    RENDER_TAG,
+                    "Reverse pre-render failed for ${clip.inputPath}: ${e.message}. " +
+                            "Falling back to forward playback."
+                )
+                result.add(clip.copy(reverseVideo = false))
             }
-
-            Log.d(
-                RENDER_TAG,
-                "Expanded reversed clip into $sliceCount slices at ${frameRate}fps: ${clip.inputPath}"
-            )
         }
-
         return result
     }
 }

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -166,14 +166,14 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     var data = VideoRenderData(
       videoSegments: [
         VideoSegment(
-          video: _video,
+          video: EditorVideo.asset(kVideoEditorExampleH264Path),
           startTime: const Duration(seconds: 0),
-          endTime: const Duration(seconds: 4),
+          endTime: const Duration(seconds: 20),
         ),
         VideoSegment(
-          video: _video,
+          video: EditorVideo.asset(kVideoEditorExampleH264Path),
           startTime: const Duration(seconds: 0),
-          endTime: const Duration(seconds: 4),
+          endTime: const Duration(seconds: 20),
           reverseVideo: true,
         ),
       ],

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -168,12 +168,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
         VideoSegment(
           video: _video,
           startTime: const Duration(seconds: 0),
-          endTime: const Duration(seconds: 20),
+          endTime: const Duration(seconds: 4),
         ),
         VideoSegment(
           video: _video,
           startTime: const Duration(seconds: 0),
-          endTime: const Duration(seconds: 20),
+          endTime: const Duration(seconds: 4),
           reverseVideo: true,
         ),
       ],

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -166,12 +166,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     var data = VideoRenderData(
       videoSegments: [
         VideoSegment(
-          video: EditorVideo.asset(kVideoEditorExampleH264Path),
+          video: _video,
           startTime: const Duration(seconds: 0),
           endTime: const Duration(seconds: 20),
         ),
         VideoSegment(
-          video: EditorVideo.asset(kVideoEditorExampleH264Path),
+          video: _video,
           startTime: const Duration(seconds: 0),
           endTime: const Duration(seconds: 20),
           reverseVideo: true,

--- a/ios/Classes/src/features/render/helpers/AudioReverser.swift
+++ b/ios/Classes/src/features/render/helpers/AudioReverser.swift
@@ -1,0 +1,260 @@
+import AVFoundation
+import Foundation
+
+/// Pre-renders a reversed audio segment into a PCM WAV temp file.
+///
+/// Unlike the frame-slice approach used by the old `reverseTimeRanges`
+/// implementation (which reverses ~30 chunk positions per second but plays
+/// each chunk forward, causing ~30 audible artefacts per second), this
+/// class decodes the audio to raw PCM, reverses every sample in-place,
+/// and writes the result as a WAV file.  The caller inserts the WAV into
+/// the composition with a single `insertTimeRange` call — no clicks, no
+/// gaps, and the audio sounds exactly like the video played backwards.
+internal enum AudioReverser {
+
+    /// Result of a successful reversal.
+    struct Result {
+        /// Temporary PCM WAV file.  The caller MUST delete this once
+        /// the AVAssetExportSession has finished.
+        let outputURL: URL
+        /// Duration of the reversed audio.
+        let duration: CMTime
+    }
+
+    // MARK: - Public API
+
+    /// Decodes [startTime, endTime) from `inputPath`, reverses the PCM
+    /// samples on the frame level (stereo 16-bit, 44.1 kHz), and writes
+    /// the result to a temporary WAV file.
+    ///
+    /// Returns `nil` on failure (no audio track, empty PCM, write error)
+    /// so the caller can fall back gracefully to no audio rather than
+    /// failing the whole render.
+    static func reverse(
+        inputPath: String,
+        startTime: CMTime,
+        endTime: CMTime
+    ) async -> Result? {
+        let sourceURL = URL(fileURLWithPath: inputPath)
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            PluginLog.print("⚠️ AudioReverser: source file not found: \(inputPath)")
+            return nil
+        }
+
+        let asset = AVURLAsset(url: sourceURL)
+
+        // Resolve actual asset duration for the "until end" case.
+        let assetDuration: CMTime
+        if #available(iOS 15.0, *) {
+            assetDuration = (try? await asset.load(.duration)) ?? .zero
+        } else {
+            assetDuration = asset.duration
+        }
+
+        let effectiveStart = CMTimeMaximum(startTime, .zero)
+        let effectiveEnd   = CMTimeMinimum(endTime, assetDuration)
+        let segmentDuration = CMTimeSubtract(effectiveEnd, effectiveStart)
+        guard CMTimeCompare(segmentDuration, .zero) > 0 else {
+            PluginLog.print("⚠️ AudioReverser: invalid segment \(effectiveStart.seconds)s–\(effectiveEnd.seconds)s")
+            return nil
+        }
+
+        // Load audio track.
+        let audioTracks: [AVAssetTrack]
+        do {
+            if #available(iOS 15.0, *) {
+                audioTracks = try await asset.loadTracks(withMediaType: .audio)
+            } else {
+                audioTracks = asset.tracks(withMediaType: .audio)
+            }
+        } catch {
+            PluginLog.print("⚠️ AudioReverser: failed to load tracks: \(error)")
+            return nil
+        }
+        guard let audioTrack = audioTracks.first else {
+            PluginLog.print("⚠️ AudioReverser: no audio track in \(inputPath)")
+            return nil
+        }
+
+        // Fixed decode format: 44.1 kHz stereo 16-bit LE PCM.
+        let sampleRate: Double  = 44100
+        let channelCount: Int   = 2
+        let bitsPerSample: Int  = 16
+        let bytesPerFrame       = channelCount * (bitsPerSample / 8) // = 4
+
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey:                  kAudioFormatLinearPCM,
+            AVSampleRateKey:                sampleRate,
+            AVNumberOfChannelsKey:          channelCount,
+            AVLinearPCMBitDepthKey:         bitsPerSample,
+            AVLinearPCMIsFloatKey:          false,
+            AVLinearPCMIsBigEndianKey:      false,
+            AVLinearPCMIsNonInterleaved:    false,
+        ]
+
+        // Decode PCM.
+        let pcm: Data
+        do {
+            pcm = try await readPcm(
+                from: asset,
+                track: audioTrack,
+                start: effectiveStart,
+                duration: segmentDuration,
+                outputSettings: outputSettings
+            )
+        } catch {
+            PluginLog.print("⚠️ AudioReverser: PCM decode failed: \(error)")
+            return nil
+        }
+        guard !pcm.isEmpty else {
+            PluginLog.print("⚠️ AudioReverser: decoded PCM is empty")
+            return nil
+        }
+
+        // Reverse PCM on the frame level (swap frame 0 ↔ last, etc.).
+        var bytes = [UInt8](pcm)
+        let frameCount = bytes.count / bytesPerFrame
+        var lo = 0
+        var hi = frameCount - 1
+        while lo < hi {
+            let loOff = lo * bytesPerFrame
+            let hiOff = hi * bytesPerFrame
+            for i in 0..<bytesPerFrame {
+                bytes.swapAt(loOff + i, hiOff + i)
+            }
+            lo += 1
+            hi -= 1
+        }
+
+        // Write WAV file.
+        let outputURL = makeTemporaryWavURL()
+        do {
+            let wavData = makeWav(
+                pcmBytes: Data(bytes),
+                sampleRate:   Int(sampleRate),
+                channelCount: channelCount,
+                bitsPerSample: bitsPerSample
+            )
+            try wavData.write(to: outputURL, options: .atomic)
+        } catch {
+            PluginLog.print("⚠️ AudioReverser: WAV write failed: \(error)")
+            return nil
+        }
+
+        let outputFrameCount = bytes.count / bytesPerFrame
+        let duration = CMTime(
+            value: CMTimeValue(outputFrameCount),
+            timescale: CMTimeScale(sampleRate)
+        )
+
+        PluginLog.print(
+            "⏪ AudioReverser: reversed \(bytes.count) bytes (\(duration.seconds)s) for \(inputPath)"
+        )
+        return Result(outputURL: outputURL, duration: duration)
+    }
+
+    // MARK: - Private helpers
+
+    private static func readPcm(
+        from asset: AVAsset,
+        track: AVAssetTrack,
+        start: CMTime,
+        duration: CMTime,
+        outputSettings: [String: Any]
+    ) async throws -> Data {
+        let reader = try AVAssetReader(asset: asset)
+        reader.timeRange = CMTimeRange(start: start, duration: duration)
+
+        let trackOutput = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: outputSettings
+        )
+        trackOutput.alwaysCopiesSampleData = false
+        guard reader.canAdd(trackOutput) else {
+            throw NSError(
+                domain: "AudioReverser",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Cannot add track output to reader"]
+            )
+        }
+        reader.add(trackOutput)
+        guard reader.startReading() else {
+            throw reader.error ?? NSError(
+                domain: "AudioReverser",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "AVAssetReader.startReading failed"]
+            )
+        }
+
+        var pcm = Data()
+        while reader.status == .reading,
+              let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+            if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                let length = CMBlockBufferGetDataLength(blockBuffer)
+                if length > 0 {
+                    var tempBytes = [UInt8](repeating: 0, count: length)
+                    let status = CMBlockBufferCopyDataBytes(
+                        blockBuffer,
+                        atOffset: 0,
+                        dataLength: length,
+                        destination: &tempBytes
+                    )
+                    if status == kCMBlockBufferNoErr {
+                        pcm.append(contentsOf: tempBytes)
+                    }
+                }
+            }
+        }
+        if reader.status == .failed, let err = reader.error { throw err }
+        return pcm
+    }
+
+    private static func makeTemporaryWavURL() -> URL {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        let name = "reverse_audio_\(Int(Date().timeIntervalSince1970 * 1000))_\(UUID().uuidString).wav"
+        return tmp.appendingPathComponent(name)
+    }
+
+    private static func makeWav(
+        pcmBytes: Data,
+        sampleRate: Int,
+        channelCount: Int,
+        bitsPerSample: Int
+    ) -> Data {
+        let byteRate   = sampleRate * channelCount * bitsPerSample / 8
+        let blockAlign = channelCount * bitsPerSample / 8
+        let dataSize   = UInt32(pcmBytes.count)
+        let chunkSize  = UInt32(36) + dataSize
+
+        var header = Data(capacity: 44)
+        header.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
+        header.appendLE(UInt32(chunkSize))
+        header.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
+        header.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
+        header.appendLE(UInt32(16))
+        header.appendLE(UInt16(1))                           // PCM
+        header.appendLE(UInt16(channelCount))
+        header.appendLE(UInt32(sampleRate))
+        header.appendLE(UInt32(byteRate))
+        header.appendLE(UInt16(blockAlign))
+        header.appendLE(UInt16(bitsPerSample))
+        header.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
+        header.appendLE(dataSize)
+
+        var out = Data(capacity: header.count + pcmBytes.count)
+        out.append(header)
+        out.append(pcmBytes)
+        return out
+    }
+}
+
+private extension Data {
+    mutating func appendLE(_ v: UInt32) {
+        var x = v.littleEndian
+        Swift.withUnsafeBytes(of: &x) { append(contentsOf: $0) }
+    }
+    mutating func appendLE(_ v: UInt16) {
+        var x = v.littleEndian
+        Swift.withUnsafeBytes(of: &x) { append(contentsOf: $0) }
+    }
+}

--- a/ios/Classes/src/features/render/helpers/CompositionBuilder.swift
+++ b/ios/Classes/src/features/render/helpers/CompositionBuilder.swift
@@ -69,7 +69,7 @@ internal class CompositionBuilder {
 
         // Add custom audio tracks (each pre-rendered to a single PCM WAV).
         var customAudioTracks: [(track: AVMutableCompositionTrack, config: AudioTrackConfig)] = []
-        var temporaryAudioURLs: [URL] = []
+        var temporaryAudioURLs: [URL] = videoResult.reversedAudioTempURLs
         for trackConfig in audioTracks {
             PluginLog.print("🎵 Adding audio track: \(trackConfig.path)")
             let audioBuilder = AudioSequenceBuilder(

--- a/ios/Classes/src/features/render/helpers/VideoSequenceBuilder.swift
+++ b/ios/Classes/src/features/render/helpers/VideoSequenceBuilder.swift
@@ -85,6 +85,7 @@ internal class VideoSequenceBuilder {
         var maxFrameRate: Float = 30.0
         var originalAudioTracks: [AVMutableCompositionTrack] = []
         var clipInstructions: [ClipInstruction] = []
+        var reversedAudioTempURLs: [URL] = []
 
         // Create single video track for all clips
         guard
@@ -254,29 +255,59 @@ internal class VideoSequenceBuilder {
                 PluginLog.print("      Format: \(audioTrack.mediaType)")
 
                 do {
-                    var audioInsertTime = insertStart
-                    for sourceRange in sourceRanges {
-                        try sharedAudioTrack.insertTimeRange(
-                            sourceRange,
-                            of: audioTrack,
-                            at: audioInsertTime
-                        )
-                        audioInsertTime = CMTimeAdd(audioInsertTime, sourceRange.duration)
+                    if clip.reverseVideo {
+                        // True PCM-level reversal: decode → reverse samples → WAV.
+                        // This avoids the ~30 audible artefacts/second that the
+                        // frame-slice approach produces.
+                        if let reversed = await AudioReverser.reverse(
+                            inputPath: clip.inputPath,
+                            startTime: clipTimeRange.start,
+                            endTime: CMTimeRangeGetEnd(clipTimeRange)
+                        ) {
+                            reversedAudioTempURLs.append(reversed.outputURL)
+                            let wavAsset = AVURLAsset(url: reversed.outputURL)
+                            let wavTracks: [AVAssetTrack]
+                            if #available(iOS 15.0, *) {
+                                wavTracks = (try? await wavAsset.loadTracks(withMediaType: .audio)) ?? []
+                            } else {
+                                wavTracks = wavAsset.tracks(withMediaType: .audio)
+                            }
+                            if let wavTrack = wavTracks.first {
+                                // Clamp WAV duration to clipDuration to prevent audio
+                                // overhang that would cause AVErrorInvalidVideoComposition.
+                                let clampedDuration = CMTimeMinimum(reversed.duration, clipDuration)
+                                let wavRange = CMTimeRange(start: .zero, duration: clampedDuration)
+                                try sharedAudioTrack.insertTimeRange(wavRange, of: wavTrack, at: insertStart)
+                                if let speed = clip.playbackSpeed, speed > 0, speed != 1.0 {
+                                    let insertedRange = CMTimeRange(start: insertStart, duration: clipDuration)
+                                    sharedAudioTrack.scaleTimeRange(insertedRange, toDuration: effectiveDuration)
+                                }
+                                PluginLog.print("   ✅ Reversed audio inserted (PCM-level, \(reversed.duration.seconds)s)")
+                            }
+                        } else {
+                            PluginLog.print("   ⚠️ AudioReverser returned nil, skipping audio for reversed clip")
+                        }
+                    } else {
+                        var audioInsertTime = insertStart
+                        for sourceRange in sourceRanges {
+                            try sharedAudioTrack.insertTimeRange(
+                                sourceRange,
+                                of: audioTrack,
+                                at: audioInsertTime
+                            )
+                            audioInsertTime = CMTimeAdd(audioInsertTime, sourceRange.duration)
+                        }
+                        if let speed = clip.playbackSpeed, speed > 0, speed != 1.0 {
+                            let insertedAudioRange = CMTimeRange(start: insertStart, duration: clipDuration)
+                            sharedAudioTrack.scaleTimeRange(insertedAudioRange, toDuration: effectiveDuration)
+                        }
+                        PluginLog.print("   ✅ Audio inserted into SHARED track!")
                     }
-                    // Apply per-clip playback speed to audio segment to keep A/V in sync.
-                    if let speed = clip.playbackSpeed, speed > 0, speed != 1.0 {
-                        let insertedAudioRange = CMTimeRange(start: insertStart, duration: clipDuration)
-                        sharedAudioTrack.scaleTimeRange(insertedAudioRange, toDuration: effectiveDuration)
-                    }
-                    PluginLog.print("   ✅ Audio inserted into SHARED track!")
                     PluginLog.print(
                         "      Source time range: \(String(format: "%.2f", clipTimeRange.start.seconds))s - \(String(format: "%.2f", (clipTimeRange.start + clipTimeRange.duration).seconds))s"
                     )
                     PluginLog.print(
                         "      Inserted at composition time: \(String(format: "%.2f", totalDuration.seconds))s"
-                    )
-                    PluginLog.print(
-                        "      Audio duration: \(String(format: "%.2f", clipTimeRange.duration.seconds))s"
                     )
                 } catch {
                     PluginLog.print("   ❌ ERROR inserting audio: \(error.localizedDescription)")
@@ -321,7 +352,8 @@ internal class VideoSequenceBuilder {
             totalDuration: totalDuration,
             renderSize: maxRenderSize,
             frameRate: maxFrameRate,
-            clipInstructions: clipInstructions
+            clipInstructions: clipInstructions,
+            reversedAudioTempURLs: reversedAudioTempURLs
         )
     }
 
@@ -398,6 +430,9 @@ internal struct VideoSequenceResult {
     let renderSize: CGSize
     let frameRate: Float
     let clipInstructions: [ClipInstruction]
+    /// Temporary WAV files created by AudioReverser for reversed clips.
+    /// Must be deleted after the export session finishes.
+    let reversedAudioTempURLs: [URL]
 }
 
 /// Holds the data needed to construct an AVMutableVideoComposition without

--- a/macos/Classes/src/features/render/helpers/AudioReverser.swift
+++ b/macos/Classes/src/features/render/helpers/AudioReverser.swift
@@ -1,0 +1,260 @@
+import AVFoundation
+import Foundation
+
+/// Pre-renders a reversed audio segment into a PCM WAV temp file.
+///
+/// Unlike the frame-slice approach used by the old `reverseTimeRanges`
+/// implementation (which reverses ~30 chunk positions per second but plays
+/// each chunk forward, causing ~30 audible artefacts per second), this
+/// class decodes the audio to raw PCM, reverses every sample in-place,
+/// and writes the result as a WAV file.  The caller inserts the WAV into
+/// the composition with a single `insertTimeRange` call — no clicks, no
+/// gaps, and the audio sounds exactly like the video played backwards.
+internal enum AudioReverser {
+
+    /// Result of a successful reversal.
+    struct Result {
+        /// Temporary PCM WAV file.  The caller MUST delete this once
+        /// the AVAssetExportSession has finished.
+        let outputURL: URL
+        /// Duration of the reversed audio.
+        let duration: CMTime
+    }
+
+    // MARK: - Public API
+
+    /// Decodes [startTime, endTime) from `inputPath`, reverses the PCM
+    /// samples on the frame level (stereo 16-bit, 44.1 kHz), and writes
+    /// the result to a temporary WAV file.
+    ///
+    /// Returns `nil` on failure (no audio track, empty PCM, write error)
+    /// so the caller can fall back gracefully to no audio rather than
+    /// failing the whole render.
+    static func reverse(
+        inputPath: String,
+        startTime: CMTime,
+        endTime: CMTime
+    ) async -> Result? {
+        let sourceURL = URL(fileURLWithPath: inputPath)
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            PluginLog.print("⚠️ AudioReverser: source file not found: \(inputPath)")
+            return nil
+        }
+
+        let asset = AVURLAsset(url: sourceURL)
+
+        // Resolve actual asset duration for the "until end" case.
+        let assetDuration: CMTime
+        if #available(macOS 13.0, *) {
+            assetDuration = (try? await asset.load(.duration)) ?? .zero
+        } else {
+            assetDuration = asset.duration
+        }
+
+        let effectiveStart = CMTimeMaximum(startTime, .zero)
+        let effectiveEnd   = CMTimeMinimum(endTime, assetDuration)
+        let segmentDuration = CMTimeSubtract(effectiveEnd, effectiveStart)
+        guard CMTimeCompare(segmentDuration, .zero) > 0 else {
+            PluginLog.print("⚠️ AudioReverser: invalid segment \(effectiveStart.seconds)s–\(effectiveEnd.seconds)s")
+            return nil
+        }
+
+        // Load audio track.
+        let audioTracks: [AVAssetTrack]
+        do {
+            if #available(macOS 13.0, *) {
+                audioTracks = try await asset.loadTracks(withMediaType: .audio)
+            } else {
+                audioTracks = asset.tracks(withMediaType: .audio)
+            }
+        } catch {
+            PluginLog.print("⚠️ AudioReverser: failed to load tracks: \(error)")
+            return nil
+        }
+        guard let audioTrack = audioTracks.first else {
+            PluginLog.print("⚠️ AudioReverser: no audio track in \(inputPath)")
+            return nil
+        }
+
+        // Fixed decode format: 44.1 kHz stereo 16-bit LE PCM.
+        let sampleRate: Double  = 44100
+        let channelCount: Int   = 2
+        let bitsPerSample: Int  = 16
+        let bytesPerFrame       = channelCount * (bitsPerSample / 8) // = 4
+
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey:                  kAudioFormatLinearPCM,
+            AVSampleRateKey:                sampleRate,
+            AVNumberOfChannelsKey:          channelCount,
+            AVLinearPCMBitDepthKey:         bitsPerSample,
+            AVLinearPCMIsFloatKey:          false,
+            AVLinearPCMIsBigEndianKey:      false,
+            AVLinearPCMIsNonInterleaved:    false,
+        ]
+
+        // Decode PCM.
+        let pcm: Data
+        do {
+            pcm = try await readPcm(
+                from: asset,
+                track: audioTrack,
+                start: effectiveStart,
+                duration: segmentDuration,
+                outputSettings: outputSettings
+            )
+        } catch {
+            PluginLog.print("⚠️ AudioReverser: PCM decode failed: \(error)")
+            return nil
+        }
+        guard !pcm.isEmpty else {
+            PluginLog.print("⚠️ AudioReverser: decoded PCM is empty")
+            return nil
+        }
+
+        // Reverse PCM on the frame level (swap frame 0 ↔ last, etc.).
+        var bytes = [UInt8](pcm)
+        let frameCount = bytes.count / bytesPerFrame
+        var lo = 0
+        var hi = frameCount - 1
+        while lo < hi {
+            let loOff = lo * bytesPerFrame
+            let hiOff = hi * bytesPerFrame
+            for i in 0..<bytesPerFrame {
+                bytes.swapAt(loOff + i, hiOff + i)
+            }
+            lo += 1
+            hi -= 1
+        }
+
+        // Write WAV file.
+        let outputURL = makeTemporaryWavURL()
+        do {
+            let wavData = makeWav(
+                pcmBytes: Data(bytes),
+                sampleRate:   Int(sampleRate),
+                channelCount: channelCount,
+                bitsPerSample: bitsPerSample
+            )
+            try wavData.write(to: outputURL, options: .atomic)
+        } catch {
+            PluginLog.print("⚠️ AudioReverser: WAV write failed: \(error)")
+            return nil
+        }
+
+        let outputFrameCount = bytes.count / bytesPerFrame
+        let duration = CMTime(
+            value: CMTimeValue(outputFrameCount),
+            timescale: CMTimeScale(sampleRate)
+        )
+
+        PluginLog.print(
+            "⏪ AudioReverser: reversed \(bytes.count) bytes (\(duration.seconds)s) for \(inputPath)"
+        )
+        return Result(outputURL: outputURL, duration: duration)
+    }
+
+    // MARK: - Private helpers
+
+    private static func readPcm(
+        from asset: AVAsset,
+        track: AVAssetTrack,
+        start: CMTime,
+        duration: CMTime,
+        outputSettings: [String: Any]
+    ) async throws -> Data {
+        let reader = try AVAssetReader(asset: asset)
+        reader.timeRange = CMTimeRange(start: start, duration: duration)
+
+        let trackOutput = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: outputSettings
+        )
+        trackOutput.alwaysCopiesSampleData = false
+        guard reader.canAdd(trackOutput) else {
+            throw NSError(
+                domain: "AudioReverser",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Cannot add track output to reader"]
+            )
+        }
+        reader.add(trackOutput)
+        guard reader.startReading() else {
+            throw reader.error ?? NSError(
+                domain: "AudioReverser",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "AVAssetReader.startReading failed"]
+            )
+        }
+
+        var pcm = Data()
+        while reader.status == .reading,
+              let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+            if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                let length = CMBlockBufferGetDataLength(blockBuffer)
+                if length > 0 {
+                    var tempBytes = [UInt8](repeating: 0, count: length)
+                    let status = CMBlockBufferCopyDataBytes(
+                        blockBuffer,
+                        atOffset: 0,
+                        dataLength: length,
+                        destination: &tempBytes
+                    )
+                    if status == kCMBlockBufferNoErr {
+                        pcm.append(contentsOf: tempBytes)
+                    }
+                }
+            }
+        }
+        if reader.status == .failed, let err = reader.error { throw err }
+        return pcm
+    }
+
+    private static func makeTemporaryWavURL() -> URL {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        let name = "reverse_audio_\(Int(Date().timeIntervalSince1970 * 1000))_\(UUID().uuidString).wav"
+        return tmp.appendingPathComponent(name)
+    }
+
+    private static func makeWav(
+        pcmBytes: Data,
+        sampleRate: Int,
+        channelCount: Int,
+        bitsPerSample: Int
+    ) -> Data {
+        let byteRate   = sampleRate * channelCount * bitsPerSample / 8
+        let blockAlign = channelCount * bitsPerSample / 8
+        let dataSize   = UInt32(pcmBytes.count)
+        let chunkSize  = UInt32(36) + dataSize
+
+        var header = Data(capacity: 44)
+        header.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
+        header.appendLE(UInt32(chunkSize))
+        header.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
+        header.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
+        header.appendLE(UInt32(16))
+        header.appendLE(UInt16(1))                           // PCM
+        header.appendLE(UInt16(channelCount))
+        header.appendLE(UInt32(sampleRate))
+        header.appendLE(UInt32(byteRate))
+        header.appendLE(UInt16(blockAlign))
+        header.appendLE(UInt16(bitsPerSample))
+        header.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
+        header.appendLE(dataSize)
+
+        var out = Data(capacity: header.count + pcmBytes.count)
+        out.append(header)
+        out.append(pcmBytes)
+        return out
+    }
+}
+
+private extension Data {
+    mutating func appendLE(_ v: UInt32) {
+        var x = v.littleEndian
+        Swift.withUnsafeBytes(of: &x) { append(contentsOf: $0) }
+    }
+    mutating func appendLE(_ v: UInt16) {
+        var x = v.littleEndian
+        Swift.withUnsafeBytes(of: &x) { append(contentsOf: $0) }
+    }
+}

--- a/macos/Classes/src/features/render/helpers/CompositionBuilder.swift
+++ b/macos/Classes/src/features/render/helpers/CompositionBuilder.swift
@@ -69,7 +69,8 @@ internal class CompositionBuilder {
 
         // Add custom audio tracks (each pre-rendered to a single PCM WAV).
         var customAudioTracks: [(track: AVMutableCompositionTrack, config: AudioTrackConfig)] = []
-        var temporaryAudioURLs: [URL] = []
+        // Start with any reversed-audio temp WAVs created by VideoSequenceBuilder.
+        var temporaryAudioURLs: [URL] = videoResult.reversedAudioTempURLs
         for trackConfig in audioTracks {
             PluginLog.print("🎵 Adding audio track: \(trackConfig.path)")
             let audioBuilder = AudioSequenceBuilder(

--- a/macos/Classes/src/features/render/helpers/VideoSequenceBuilder.swift
+++ b/macos/Classes/src/features/render/helpers/VideoSequenceBuilder.swift
@@ -85,6 +85,7 @@ internal class VideoSequenceBuilder {
         var maxFrameRate: Float = 30.0
         var originalAudioTracks: [AVMutableCompositionTrack] = []
         var clipInstructions: [ClipInstruction] = []
+        var reversedAudioTempURLs: [URL] = []
 
         // Create single video track for all clips
         guard
@@ -241,37 +242,66 @@ internal class VideoSequenceBuilder {
                 let sharedAudioTrack = sharedAudioTrack
             {
                 PluginLog.print("🔊 Processing audio for clip \(index)...")
-                PluginLog.print("   ✅ Audio track loaded from asset")
-                PluginLog.print("      Track ID: \(audioTrack.trackID)")
-                PluginLog.print(
-                    "      Duration: \(String(format: "%.2f", audioTrack.timeRange.duration.seconds))s"
-                )
-                PluginLog.print("      Format: \(audioTrack.mediaType)")
 
                 do {
-                    var audioInsertTime = insertStart
-                    for sourceRange in sourceRanges {
-                        try sharedAudioTrack.insertTimeRange(
-                            sourceRange,
-                            of: audioTrack,
-                            at: audioInsertTime
-                        )
-                        audioInsertTime = CMTimeAdd(audioInsertTime, sourceRange.duration)
+                    if clip.reverseVideo {
+                        // True PCM-level reversal: decode → reverse samples → WAV.
+                        // This avoids the ~30 audible artefacts/second that the
+                        // frame-slice approach produces.
+                        if let reversed = await AudioReverser.reverse(
+                            inputPath: clip.inputPath,
+                            startTime: clipTimeRange.start,
+                            endTime: CMTimeRangeGetEnd(clipTimeRange)
+                        ) {
+                            reversedAudioTempURLs.append(reversed.outputURL)
+                            let wavAsset = AVURLAsset(url: reversed.outputURL)
+                            let wavTracks: [AVAssetTrack]
+                            if #available(macOS 13.0, *) {
+                                wavTracks = (try? await wavAsset.loadTracks(withMediaType: .audio)) ?? []
+                            } else {
+                                wavTracks = wavAsset.tracks(withMediaType: .audio)
+                            }
+                            if let wavTrack = wavTracks.first {
+                                // Clamp the WAV duration to clipDuration.
+                                // AudioReverser produces PCM frames at 44 100 Hz, so
+                                // reversed.duration (= PCMFrameCount/44100) is rarely
+                                // equal to clipDuration (video frames / fps).  Even a
+                                // few microseconds of overhang extend composition.duration
+                                // beyond the AVVideoComposition instruction coverage,
+                                // triggering AVErrorInvalidVideoComposition (-11841).
+                                let clampedDuration = CMTimeMinimum(reversed.duration, clipDuration)
+                                let wavRange = CMTimeRange(start: .zero, duration: clampedDuration)
+                                try sharedAudioTrack.insertTimeRange(wavRange, of: wavTrack, at: insertStart)
+                                if let speed = clip.playbackSpeed, speed > 0, speed != 1.0 {
+                                    let insertedRange = CMTimeRange(start: insertStart, duration: clipDuration)
+                                    sharedAudioTrack.scaleTimeRange(insertedRange, toDuration: effectiveDuration)
+                                }
+                                PluginLog.print("   ✅ Reversed audio inserted (PCM-level, \(reversed.duration.seconds)s)")
+                            }
+                        } else {
+                            PluginLog.print("   ⚠️ AudioReverser returned nil, skipping audio for reversed clip")
+                        }
+                    } else {
+                        var audioInsertTime = insertStart
+                        for sourceRange in sourceRanges {
+                            try sharedAudioTrack.insertTimeRange(
+                                sourceRange,
+                                of: audioTrack,
+                                at: audioInsertTime
+                            )
+                            audioInsertTime = CMTimeAdd(audioInsertTime, sourceRange.duration)
+                        }
+                        if let speed = clip.playbackSpeed, speed > 0, speed != 1.0 {
+                            let insertedAudioRange = CMTimeRange(start: insertStart, duration: clipDuration)
+                            sharedAudioTrack.scaleTimeRange(insertedAudioRange, toDuration: effectiveDuration)
+                        }
+                        PluginLog.print("   ✅ Audio inserted into SHARED track!")
                     }
-                    // Apply per-clip playback speed to audio segment to keep A/V in sync.
-                    if let speed = clip.playbackSpeed, speed > 0, speed != 1.0 {
-                        let insertedAudioRange = CMTimeRange(start: insertStart, duration: clipDuration)
-                        sharedAudioTrack.scaleTimeRange(insertedAudioRange, toDuration: effectiveDuration)
-                    }
-                    PluginLog.print("   ✅ Audio inserted into SHARED track!")
                     PluginLog.print(
                         "      Source time range: \(String(format: "%.2f", clipTimeRange.start.seconds))s - \(String(format: "%.2f", (clipTimeRange.start + clipTimeRange.duration).seconds))s"
                     )
                     PluginLog.print(
                         "      Inserted at composition time: \(String(format: "%.2f", totalDuration.seconds))s"
-                    )
-                    PluginLog.print(
-                        "      Audio duration: \(String(format: "%.2f", clipTimeRange.duration.seconds))s"
                     )
                 } catch {
                     PluginLog.print("   ❌ ERROR inserting audio: \(error.localizedDescription)")
@@ -326,7 +356,8 @@ internal class VideoSequenceBuilder {
             totalDuration: totalDuration,
             renderSize: maxRenderSize,
             frameRate: maxFrameRate,
-            clipInstructions: clipInstructions
+            clipInstructions: clipInstructions,
+            reversedAudioTempURLs: reversedAudioTempURLs
         )
     }
 
@@ -403,6 +434,9 @@ internal struct VideoSequenceResult {
     let renderSize: CGSize
     let frameRate: Float
     let clipInstructions: [ClipInstruction]
+    /// Temporary WAV files created by AudioReverser for reversed clips.
+    /// CompositionBuilder MUST forward these into the caller's cleanup list.
+    let reversedAudioTempURLs: [URL]
 }
 
 /// Holds the data needed to construct an AVMutableVideoComposition without


### PR DESCRIPTION
## Summary

This branch fixes two bugs that caused reverse playback to fail.

---

### 1. Android – HEVC video rotation ignored during reversal

**Problem:** On Android, HEVC-encoded videos with a rotation metadata tag (e.g. 90°) were not correctly rotated when played in reverse. The reversed output appeared sideways or upside-down.

**Fix:** Applied the rotation matrix from the video's `MediaFormat` when writing reversed frames, so the output matches the original orientation.

---

### 2. iOS / macOS – `AVErrorInvalidVideoComposition` (-11841) during reverse playback

**Problem:** After `AudioReverser` was introduced, exporting a reversed clip failed with:

```
AVFoundationErrorDomain Code=-11841 "The video could not be composed."
```

**Root cause:** `AudioReverser` decodes audio to PCM at 44 100 Hz and produces a WAV file with duration `PCMFrameCount / 44100`. This value is typically a few microseconds *longer* than the video clip duration (which is quantised to the video frame timescale). Inserting the WAV into the `AVMutableComposition` audio track extended `composition.duration` beyond the coverage of the `AVVideoComposition` instructions, which is forbidden by AVFoundation.

**Fix:** Clamp the inserted WAV range to `clipDuration` using `CMTimeMinimum` in `VideoSequenceBuilder.swift` (both iOS and macOS):

```swift
// Clamp the WAV duration to clipDuration.
// AudioReverser produces PCM frames at 44 100 Hz, so
// reversed.duration (= PCMFrameCount/44100) is rarely
// equal to clipDuration (video frames / fps). Even a
// few microseconds of overhang extend composition.duration
// beyond the AVVideoComposition instruction coverage,
// triggering AVErrorInvalidVideoComposition (-11841).
let clampedDuration = CMTimeMinimum(reversed.duration, clipDuration)
let wavRange = CMTimeRange(start: .zero, duration: clampedDuration)
try sharedAudioTrack.insertTimeRange(wavRange, of: wavTrack, at: insertStart)
```

---

### Files changed

| File | Change |
|------|--------|
| `android/…/VideoReverser.kt` | Apply HEVC rotation matrix during frame reversal |
| `ios/Classes/…/AudioReverser.swift` | New: PCM-level audio reversal for iOS |
| `macos/Classes/…/AudioReverser.swift` | New: PCM-level audio reversal for macOS |
| `ios/Classes/…/VideoSequenceBuilder.swift` | Clamp reversed WAV duration to `clipDuration` |
| `macos/Classes/…/VideoSequenceBuilder.swift` | Clamp reversed WAV duration to `clipDuration` |
| `macos/Classes/…/RenderVideo.swift` | Remove temporary debug logging |