### PR TITLE
fix(android): prevent encoder & reverse-render crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.2
+- **FIX**(android): Prevent `RENDER_ERROR` codec exceptions on hardware encoders (e.g. Qualcomm AVC `c2.qti.avc.encoder`) by enabling encoder fallback in the main render path, clamping the requested bitrate into the codec's supported range, and preferring VBR over CBR at high bitrates.
+- **FIX**(android): Harden the reverse-video pre-render against crashes. The all-intra encoder is now configured with a clamped bitrate and progressive fallback to avoid `MediaCodec.CodecException`, and the in-memory remux is guarded against `OutOfMemoryError` by checking the temp file size against available heap before loading frames. On failure the clip gracefully degrades to forward playback.
+
 ## 1.17.1
 - **FIX**(android): Fix reversed HEVC videos ignoring the rotation metadata tag, causing sideways/upside-down output.
 - **FIX**(iOS, macOS): Fix `AVErrorInvalidVideoComposition` (Code -11841) during reverse playback. `AudioReverser` produces PCM frames at 44 100 Hz, so the reversed WAV duration (`PCMFrameCount / 44100`) is a few microseconds longer than the video clip duration. This extended `composition.duration` beyond the `AVVideoComposition` instruction coverage. Fixed by clamping the inserted WAV range to `clipDuration` via `CMTimeMinimum`.

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
@@ -335,6 +335,11 @@ class RenderVideo(private val context: Context) {
 
         val outputMimeType = mapFormatToMimeType(config.outputFormat)
         val encoderFactoryBuilder = DefaultEncoderFactory.Builder(context)
+            // Allow Media3 to fall back to supported encoder settings when the
+            // hardware encoder rejects the requested configuration (e.g. an
+            // unsupported bitrate/profile/level combination on Qualcomm encoders)
+            // instead of failing the whole render with a codec exception.
+            .setEnableFallback(true)
 
         applyBitrate(encoderFactoryBuilder, outputMimeType, config.bitrate)
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyBitrate.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyBitrate.kt
@@ -8,9 +8,14 @@ import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
 /**
  * Configures video encoder bitrate settings.
  *
- * Validates bitrate against codec capabilities and selects optimal bitrate mode:
- * - CBR (Constant Bitrate) if supported - predictable file size
- * - VBR (Variable Bitrate) fallback - better quality at same average bitrate
+ * Validates bitrate against codec capabilities and selects an encoder-safe
+ * configuration:
+ * - Clamps the requested bitrate into the codec's supported range
+ * - Uses CBR (Constant Bitrate) for predictable file size when supported and
+ *   the bitrate is not in the upper portion of the range
+ * - Falls back to VBR (Variable Bitrate) when CBR is unsupported or the
+ *   bitrate is high, since high-bitrate CBR is frequently rejected by
+ *   hardware encoders
  *
  * @param encoderFactoryBuilder Encoder factory to configure
  * @param mimeType Video MIME type (e.g., "video/avc" for H.264)
@@ -39,25 +44,38 @@ fun applyBitrate(
     val supportsCBR = capabilities.encoderCapabilities
         .isBitrateModeSupported(MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR)
 
-    if (!bitrateRange.contains(bitrate)) {
-        Log.e(
+    // Clamp the requested bitrate into the supported range instead of bailing
+    // out. Bailing left the encoder on its (often very high) default bitrate,
+    // which is one of the configurations Qualcomm encoders reject outright.
+    val safeBitrate = bitrate.coerceIn(bitrateRange.lower, bitrateRange.upper)
+    if (safeBitrate != bitrate) {
+        Log.w(
             RENDER_TAG,
-            "Bitrate ${bitrate / 1000} kbps outside supported range: ${bitrateRange.lower / 1000}-${bitrateRange.upper / 1000} kbps"
+            "Bitrate ${bitrate / 1000} kbps outside supported range " +
+                    "${bitrateRange.lower / 1000}-${bitrateRange.upper / 1000} kbps, " +
+                    "clamping to ${safeBitrate / 1000} kbps"
         )
-        return
     }
 
-    val bitrateMode = if (supportsCBR) {
+    // CBR at a high bitrate (relative to the codec's max) is the combination
+    // most likely to be rejected by hardware encoders (e.g. Qualcomm AVC at
+    // 1080p with High profile). When the requested bitrate sits in the upper
+    // portion of the supported range, prefer VBR which is far more forgiving.
+    val highBitrateThreshold = (bitrateRange.upper * 0.8).toInt()
+    val useCBR = supportsCBR && safeBitrate <= highBitrateThreshold
+
+    val bitrateMode = if (useCBR) {
         Log.d(RENDER_TAG, "Using CBR (Constant Bitrate) mode")
         MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR
     } else {
-        Log.d(RENDER_TAG, "CBR not supported, using VBR (Variable Bitrate) mode")
+        val reason = if (!supportsCBR) "CBR not supported" else "high bitrate, avoiding CBR"
+        Log.d(RENDER_TAG, "Using VBR (Variable Bitrate) mode ($reason)")
         MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR
     }
 
     val builder = VideoEncoderSettings.Builder()
         .setBitrateMode(bitrateMode)
-        .setBitrate(bitrate)
+        .setBitrate(safeBitrate)
 
     encoderFactoryBuilder.setRequestedVideoEncoderSettings(builder.build())
 }

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoReverser.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoReverser.kt
@@ -4,6 +4,7 @@ import RENDER_TAG
 import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
+import android.media.MediaCodecList
 import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.media.MediaMuxer
@@ -277,21 +278,15 @@ object VideoReverser {
 
         // Encoder: H.264, all-intra (KEY_I_FRAME_INTERVAL = 0).
         val outMime = "video/avc"
-        val encoderFormat = MediaFormat.createVideoFormat(outMime, width, height).apply {
-            setInteger(
-                MediaFormat.KEY_COLOR_FORMAT,
-                MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
-            )
-            val bitRate = if (inputFormat.containsKey(MediaFormat.KEY_BIT_RATE))
-                inputFormat.getInteger(MediaFormat.KEY_BIT_RATE)
-            else width * height * 4
-            setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
-            setInteger(MediaFormat.KEY_FRAME_RATE, frameRate)
-            setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 0) // ← every frame is a keyframe
-        }
-        val encoder = MediaCodec.createEncoderByType(outMime)
-        encoder.configure(encoderFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
-        encoder.start()
+        val rawBitRate = if (inputFormat.containsKey(MediaFormat.KEY_BIT_RATE))
+            inputFormat.getInteger(MediaFormat.KEY_BIT_RATE)
+        else width * height * 4
+        // Configure the encoder with a bitrate clamped into the codec's
+        // supported range and progressively fall back to lower bitrates if the
+        // hardware encoder rejects the configuration. Without this, a source
+        // bitrate that is invalid for AVC (e.g. taken from an HEVC source)
+        // would throw a MediaCodec.CodecException and crash the reverse thread.
+        val encoder = createAllIntraEncoder(outMime, width, height, frameRate, rawBitRate)
 
         // Decoder: flexible YUV so getOutputImage() works on all devices.
         val decoderFormat = extractor.getTrackFormat(videoTrackIndex).also {
@@ -469,6 +464,82 @@ object VideoReverser {
     }
 
     /**
+     * Returns the bitrate range supported by the system AVC encoder, or `null`
+     * if it cannot be determined.
+     */
+    private fun avcBitrateRange(): android.util.Range<Int>? = try {
+        MediaCodecList(MediaCodecList.REGULAR_CODECS)
+            .codecInfos
+            .firstOrNull { info ->
+                info.isEncoder && info.supportedTypes.any { it.equals("video/avc", true) }
+            }
+            ?.getCapabilitiesForType("video/avc")
+            ?.videoCapabilities
+            ?.bitrateRange
+    } catch (e: Exception) {
+        Log.w(RENDER_TAG, "Could not query AVC bitrate range: ${e.message}")
+        null
+    }
+
+    /**
+     * Creates and starts an all-intra (KEY_I_FRAME_INTERVAL = 0) H.264 encoder.
+     *
+     * The requested bitrate is clamped into the codec's supported range and, if
+     * the encoder still rejects the configuration, progressively lower bitrates
+     * are tried. This prevents a [MediaCodec.CodecException] (e.g. from an
+     * out-of-range source bitrate) from crashing the reverse pipeline.
+     */
+    private fun createAllIntraEncoder(
+        mime: String,
+        width: Int,
+        height: Int,
+        frameRate: Int,
+        preferredBitrate: Int,
+    ): MediaCodec {
+        val range = avcBitrateRange()
+        val candidates = listOf(
+            preferredBitrate,
+            (width * height * 4),
+            (width * height * 2),
+        )
+            .map { bitrate ->
+                if (range != null) bitrate.coerceIn(range.lower, range.upper) else bitrate
+            }
+            .filter { it > 0 }
+            .distinct()
+
+        var lastError: Exception? = null
+        for (bitrate in candidates) {
+            val format = MediaFormat.createVideoFormat(mime, width, height).apply {
+                setInteger(
+                    MediaFormat.KEY_COLOR_FORMAT,
+                    MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
+                )
+                setInteger(MediaFormat.KEY_BIT_RATE, bitrate)
+                setInteger(MediaFormat.KEY_FRAME_RATE, frameRate)
+                setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 0) // every frame is a keyframe
+            }
+            val encoder = MediaCodec.createEncoderByType(mime)
+            try {
+                encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+                encoder.start()
+                Log.d(RENDER_TAG, "All-intra encoder configured at ${bitrate / 1000} kbps")
+                return encoder
+            } catch (e: Exception) {
+                Log.w(
+                    RENDER_TAG,
+                    "All-intra encoder rejected ${bitrate / 1000} kbps: ${e.message}"
+                )
+                try { encoder.release() } catch (_: Exception) {}
+                lastError = e
+            }
+        }
+        throw IllegalStateException(
+            "Failed to configure all-intra AVC encoder for ${width}x$height", lastError
+        )
+    }
+
+    /**
      * Reads all compressed video samples from [allIntraFile] (an all-intra
      * MP4) into memory, reverses them by PTS, then writes to [muxer] with
      * monotonically-increasing timestamps. No codec is involved.
@@ -482,6 +553,27 @@ object VideoReverser {
         onProgress: (Float) -> Unit,
     ): Long {
         data class Sample(val ptsUs: Long, val data: ByteArray)
+
+        // Guard against OutOfMemoryError: this remux loads every compressed
+        // I-frame of the (all-intra, therefore large) temp file into RAM at
+        // once. Refuse segments that would not safely fit into the available
+        // heap so the caller can fall back to forward playback instead of the
+        // process being killed.
+        val fileSize = allIntraFile.length()
+        if (fileSize > 0) {
+            val runtime = Runtime.getRuntime()
+            val availableHeap = runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory())
+            // Require a 2x margin for per-sample object overhead and transient
+            // buffers (ByteBuffer wrappers, sort scratch space, etc.).
+            val required = fileSize * 2
+            if (required > availableHeap) {
+                throw IllegalStateException(
+                    "Reversed segment too large to process in memory: " +
+                            "${fileSize / (1024 * 1024)} MB needs ~${required / (1024 * 1024)} MB, " +
+                            "only ${availableHeap / (1024 * 1024)} MB heap available"
+                )
+            }
+        }
 
         val extractor = MediaExtractor().apply { setDataSource(allIntraFile.absolutePath) }
         val trackIdx = findTrack(extractor, "video/")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.17.1
+version: 1.17.2
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Summary

Fixes several crash sources in the Android render pipeline, including a `RENDER_ERROR` codec exception on Qualcomm AVC hardware encoders and potential crashes in the reverse-video pre-render path.

The original failure:
```
PlatformException(RENDER_ERROR, Codec exception: CodecInfo{type=VideoEncoder, ...
mime=video/avc, bitrate=8739850, bitrate-mode=1, profile=8, level=16384, ...
name=c2.qti.avc.encoder}, ...)
```

## Changes

**Main render path**
- Enable encoder fallback (`DefaultEncoderFactory.Builder.setEnableFallback(true)`) so Media3 falls back to supported encoder settings instead of failing the whole render when the hardware encoder rejects the requested configuration.

**`applyBitrate`**
- Clamp the requested bitrate into the codec's supported range instead of bailing out (which previously left the encoder on its very high default bitrate — one of the configurations Qualcomm encoders reject).
- Prefer VBR over CBR when the bitrate sits in the upper portion of the supported range, since high-bitrate CBR is the combination most frequently rejected by hardware encoders.

**`VideoReverser` (reverse pre-render)**
- Configure the all-intra encoder with a clamped bitrate and progressive fallback (`preferred → w·h·4 → w·h·2`), wrapped in `try/catch`, to avoid a `MediaCodec.CodecException` crashing the reverse thread (e.g. when an HEVC source bitrate is invalid for AVC).
- Guard `remuxReversed` against `OutOfMemoryError`: the all-intra temp file is loaded fully into RAM, so its size is checked against available heap (with a 2× margin) before loading. Oversized segments throw a clear exception instead of killing the process.

Both reverse-path exceptions are caught by the existing fallback in `preReverseClips`, so the clip gracefully degrades to forward playback rather than failing the entire render.

## Testing
- Android render verified to compile (no analyzer errors).
- Recommend testing render + reverse render on a Qualcomm/Snapdragon device with high-bitrate 1080p and long/4K clips.