### PR TITLE
feat(web): add WASM support and improve platform compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.17.4
+- **FIX**(web, wasm): Fix pub.dev platform compatibility score. Replace direct `dart:io` and `package:path_provider` imports in the package's public import chain with conditional platform shims, eliminating the "Package does not support platform Web" and "Not compatible with runtime wasm" warnings.
+
 ## 1.17.3
 - **FEAT**(darwin): Add Swift Package Manager (SPM) support for iOS and macOS. The darwin implementation is now distributed as a local SPM package, replacing the previous CocoaPods-only setup.
 

--- a/lib/core/models/audio/audio_format_model.dart
+++ b/lib/core/models/audio/audio_format_model.dart
@@ -1,6 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
+
+import '/core/platform/io/io_helper.dart';
 
 /// Audio output formats supported for audio extraction.
 ///

--- a/lib/core/models/video/editor_video_model.dart
+++ b/lib/core/models/video/editor_video_model.dart
@@ -1,8 +1,7 @@
 import 'dart:typed_data';
 
-import 'package:path_provider/path_provider.dart';
-
 import '/core/platform/io/io_helper.dart';
+import '/core/platform/path/path_provider_helper.dart';
 import '/shared/utils/converters.dart';
 import '/shared/utils/file_constructor_utils.dart';
 

--- a/lib/core/platform/io/io_web.dart
+++ b/lib/core/platform/io/io_web.dart
@@ -132,3 +132,15 @@ class Directory {
     return Directory();
   }
 }
+
+/// A stub for [IOSink] on the web platform.
+///
+/// File-based streaming is not supported on web; this class exists solely
+/// to satisfy the type system so the library compiles for web/WASM targets.
+class IOSink {
+  /// Flushes the sink (no-op on web).
+  Future<void> flush() async {}
+
+  /// Closes the sink (no-op on web).
+  Future<void> close() async {}
+}

--- a/lib/core/platform/path/path_provider_helper.dart
+++ b/lib/core/platform/path/path_provider_helper.dart
@@ -1,0 +1,2 @@
+export 'path_provider_web.dart'
+    if (dart.library.io) 'path_provider_native.dart';

--- a/lib/core/platform/path/path_provider_native.dart
+++ b/lib/core/platform/path/path_provider_native.dart
@@ -1,0 +1,1 @@
+export 'package:path_provider/path_provider.dart' show getTemporaryDirectory;

--- a/lib/core/platform/path/path_provider_web.dart
+++ b/lib/core/platform/path/path_provider_web.dart
@@ -1,0 +1,9 @@
+import '/core/platform/io/io_helper.dart';
+
+/// Returns a stub temporary directory for the web platform.
+///
+/// File-based operations are not supported on web, so this returns
+/// a [Directory] stub that throws on actual use.
+Future<Directory> getTemporaryDirectory() async {
+  return Directory('/tmp');
+}

--- a/lib/shared/utils/converters.dart
+++ b/lib/shared/utils/converters.dart
@@ -1,6 +1,4 @@
 // Flutter imports:
-import 'dart:io' show IOSink;
-
 import 'package:flutter/services.dart';
 
 // Package imports:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.17.3
+version: 1.17.4
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Description

Enhance platform compatibility by adding WASM support and addressing issues related to the `dart:io` and `package:path_provider` imports. This update eliminates compatibility warnings for web and WASM targets.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

