### PR TITLE
feat: add native log streaming to Dart for enhanced diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.19.0
+- **FEAT**(android, iOS, macOS): Forward native plugin logs back to Dart via `ProVideoEditor.instance.logStream`. Every entry written through the shared native logger (including the full renderer diagnostics) is now emitted as a `NativeLogEntry` (`level`, `tag`, `message`, `timestamp`, optional `stackTrace`), so host apps can pipe these into their own Dart logger and export them. Forwarding is gated by the same `nativeLogLevel` as the native console output. Web/Windows/Linux keep an empty stream.
+
 ## 1.18.0
 - **FEAT**(android, iOS, macOS): Add `speed` to `AudioExtractConfigs` for pitch-preserving playback-speed changes during audio extraction (e.g. `2.0` for double speed, `0.5` for half). WAV applies the time-stretch directly on the decoded PCM (Android `SonicAudioProcessor`; AVFoundation `AVAssetReaderAudioMixOutput` with the spectral time-pitch algorithm), while compressed formats are re-encoded — Android via a Media3 `Transformer`, Darwin via `AVAssetExportPresetAppleM4A` with a scaled time range. Note: on Apple platforms a non-`1.0` speed re-encodes to AAC/M4A, so `caf` output falls back to M4A content.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The ProVideoEditor is a Flutter widget designed for video editing within your ap
 - 📊 **Progress**: Track the progress of one or multiple running tasks.
 - 🧵 **Multi-Tasking**: Execute multiple video processing tasks concurrently.
 - 🔇 **Native Log Level**: Control native log verbosity per API call with `NativeLogLevel` (`none`, `error`, `warning`, `info`, `debug`, `verbose`).
+- 🪵 **Native Log Stream**: Receive native logs (including renderer diagnostics) back in Dart via `logStream` to pipe into your own logger and export.
 
 
 ### Platform Support
@@ -633,6 +634,32 @@ VideoMetadata metadata = await ProVideoEditor.instance.getMetadata(
 );
 
 /// Available levels: none, error, warning, info, debug, verbose
+```
+
+#### Native Log Stream Example
+
+Capture native logs (including the renderer diagnostics) in Dart so you can
+forward them to your own logger and let users export them. The stream emits a
+`NativeLogEntry` for every native log on Android, iOS, and macOS, gated by the
+`nativeLogLevel` you pass to the operation. On Web, Windows, and Linux the
+stream stays empty.
+
+```dart
+final subscription = ProVideoEditor.instance.logStream.listen((entry) {
+    // entry: level, tag, message, timestamp, optional stackTrace
+    myLogger.log(entry.level.name, entry.message,
+        tag: entry.tag, stackTrace: entry.stackTrace);
+});
+
+// Emit the rich renderer logs by raising the level for the call.
+await ProVideoEditor.instance.renderVideoToFile(
+    outputPath,
+    renderData,
+    nativeLogLevel: NativeLogLevel.debug,
+);
+
+// Cancel when no longer needed.
+await subscription.cancel();
 ```
 
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/ProVideoEditorPlugin.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/ProVideoEditorPlugin.kt
@@ -48,6 +48,10 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
     private lateinit var eventChannel: EventChannel
     private var eventSink: EventChannel.EventSink? = null
 
+    /// Event channel for streaming native log entries back to Dart
+    private lateinit var logChannel: EventChannel
+    private var logSink: EventChannel.EventSink? = null
+
     private lateinit var renderVideo: RenderVideo
     private lateinit var metadata: Metadata
     private lateinit var thumbnailGenerator: ThumbnailGenerator
@@ -77,6 +81,8 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
             EventChannel(flutterPluginBinding.binaryMessenger, "pro_video_editor_progress")
         waveformStreamChannel =
             EventChannel(flutterPluginBinding.binaryMessenger, "pro_video_editor_waveform_stream")
+        logChannel =
+            EventChannel(flutterPluginBinding.binaryMessenger, "pro_video_editor_logs")
 
         methodChannel.setMethodCallHandler(this)
         eventChannel.setStreamHandler(object : EventChannel.StreamHandler {
@@ -99,6 +105,20 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
             }
         })
 
+        logChannel.setStreamHandler(object : EventChannel.StreamHandler {
+            override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+                logSink = events
+                Log.sink = { level, tag, message, throwable ->
+                    postLog(level, tag, message, throwable)
+                }
+            }
+
+            override fun onCancel(arguments: Any?) {
+                Log.sink = null
+                logSink = null
+            }
+        })
+
         renderVideo = RenderVideo(flutterPluginBinding.applicationContext)
         metadata = Metadata(flutterPluginBinding.applicationContext)
         thumbnailGenerator = ThumbnailGenerator(flutterPluginBinding.applicationContext)
@@ -118,6 +138,9 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
         methodChannel.setMethodCallHandler(null)
         eventChannel.setStreamHandler(null)
         waveformStreamChannel.setStreamHandler(null)
+        logChannel.setStreamHandler(null)
+        Log.sink = null
+        logSink = null
     }
 
     /**
@@ -618,6 +641,28 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
                 mapOf(
                     "id" to id,
                     "progress" to progress
+                )
+            )
+        }
+    }
+
+    /**
+     * Forwards a native log entry to Flutter via the log event channel.
+     *
+     * Log events are sent on the main thread with level, tag, message,
+     * timestamp, and an optional stack trace.
+     */
+    private fun postLog(level: String, tag: String, message: String, throwable: Throwable?) {
+        val timestamp = System.currentTimeMillis()
+        val stackTrace = throwable?.stackTraceToString()
+        mainHandler.post {
+            logSink?.success(
+                mapOf(
+                    "level" to level,
+                    "tag" to tag,
+                    "message" to message,
+                    "timestamp" to timestamp,
+                    "stackTrace" to stackTrace
                 )
             )
         }

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/shared/logging/PluginLog.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/shared/logging/PluginLog.kt
@@ -8,6 +8,16 @@ object PluginLog {
     @Volatile
     private var minimumPriority = defaultPriority()
 
+    /**
+     * Optional sink that forwards every emitted log entry to Flutter.
+     *
+     * Set by the plugin while a Dart listener is attached to the
+     * `pro_video_editor_logs` event channel. The level string matches
+     * `NativeLogLevel.methodValue` on the Dart side.
+     */
+    @Volatile
+    var sink: ((level: String, tag: String, message: String, throwable: Throwable?) -> Unit)? = null
+
     fun setMinimumLevel(level: String) {
         minimumPriority = parsePriority(level)
     }
@@ -38,31 +48,66 @@ object PluginLog {
         return priority >= minimumPriority
     }
 
+    private fun levelName(priority: Int): String {
+        return when (priority) {
+            AndroidLog.VERBOSE -> "verbose"
+            AndroidLog.DEBUG -> "debug"
+            AndroidLog.INFO -> "info"
+            AndroidLog.WARN -> "warning"
+            AndroidLog.ERROR -> "error"
+            else -> "info"
+        }
+    }
+
+    /**
+     * Forwards an entry to the Dart [sink], if one is attached.
+     *
+     * Called only after the priority passed [shouldLog], so the Dart stream
+     * is gated by the same level as the native console output.
+     */
+    private fun forward(priority: Int, tag: String, message: String, throwable: Throwable?) {
+        sink?.invoke(levelName(priority), tag, message, throwable)
+    }
+
     fun v(tag: String, message: String): Int {
-        return if (shouldLog(AndroidLog.VERBOSE)) AndroidLog.v(tag, message) else 0
+        if (!shouldLog(AndroidLog.VERBOSE)) return 0
+        forward(AndroidLog.VERBOSE, tag, message, null)
+        return AndroidLog.v(tag, message)
     }
 
     fun d(tag: String, message: String): Int {
-        return if (shouldLog(AndroidLog.DEBUG)) AndroidLog.d(tag, message) else 0
+        if (!shouldLog(AndroidLog.DEBUG)) return 0
+        forward(AndroidLog.DEBUG, tag, message, null)
+        return AndroidLog.d(tag, message)
     }
 
     fun i(tag: String, message: String): Int {
-        return if (shouldLog(AndroidLog.INFO)) AndroidLog.i(tag, message) else 0
+        if (!shouldLog(AndroidLog.INFO)) return 0
+        forward(AndroidLog.INFO, tag, message, null)
+        return AndroidLog.i(tag, message)
     }
 
     fun w(tag: String, message: String): Int {
-        return if (shouldLog(AndroidLog.WARN)) AndroidLog.w(tag, message) else 0
+        if (!shouldLog(AndroidLog.WARN)) return 0
+        forward(AndroidLog.WARN, tag, message, null)
+        return AndroidLog.w(tag, message)
     }
 
     fun w(tag: String, message: String, throwable: Throwable): Int {
-        return if (shouldLog(AndroidLog.WARN)) AndroidLog.w(tag, message, throwable) else 0
+        if (!shouldLog(AndroidLog.WARN)) return 0
+        forward(AndroidLog.WARN, tag, message, throwable)
+        return AndroidLog.w(tag, message, throwable)
     }
 
     fun e(tag: String, message: String): Int {
-        return if (shouldLog(AndroidLog.ERROR)) AndroidLog.e(tag, message) else 0
+        if (!shouldLog(AndroidLog.ERROR)) return 0
+        forward(AndroidLog.ERROR, tag, message, null)
+        return AndroidLog.e(tag, message)
     }
 
     fun e(tag: String, message: String, throwable: Throwable): Int {
-        return if (shouldLog(AndroidLog.ERROR)) AndroidLog.e(tag, message, throwable) else 0
+        if (!shouldLog(AndroidLog.ERROR)) return 0
+        forward(AndroidLog.ERROR, tag, message, throwable)
+        return AndroidLog.e(tag, message, throwable)
     }
 }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
@@ -28,6 +28,7 @@ import Foundation
 public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
   var eventSink: FlutterEventSink?
   var waveformStreamSink: FlutterEventSink?
+  var logSink: FlutterEventSink?
   private var activeRenderTasks: [String: RenderTask] = [:]
   private var activeAudioTasks: [String: AudioExtractTask] = [:]
   private var activeWaveformTasks: [String: WaveformTask] = [:]
@@ -45,11 +46,14 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
       name: "pro_video_editor_progress", binaryMessenger: messenger)
     let waveformStreamChannel = FlutterEventChannel(
       name: "pro_video_editor_waveform_stream", binaryMessenger: messenger)
+    let logChannel = FlutterEventChannel(
+      name: "pro_video_editor_logs", binaryMessenger: messenger)
 
     let instance = ProVideoEditorPlugin()
     registrar.addMethodCallDelegate(instance, channel: methodChannel)
     eventChannel.setStreamHandler(instance)
     waveformStreamChannel.setStreamHandler(WaveformStreamHandler(plugin: instance))
+    logChannel.setStreamHandler(LogStreamHandler(plugin: instance))
   }
 
   /// Routes incoming method calls to appropriate handlers.
@@ -261,6 +265,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
         }
       },
       onError: { error in
+        PluginLog.print("❌ Render failed: \(error.localizedDescription)")
         DispatchQueue.main.async {
           let task = self.activeRenderTasks.removeValue(forKey: id)
           let code = (task?.isCanceled == true) ? "CANCELED" : "RENDER_ERROR"
@@ -339,6 +344,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
         }
       },
       onError: { error in
+        PluginLog.print("❌ Audio extraction failed: \(error.localizedDescription)")
         DispatchQueue.main.async {
           let task = self.activeAudioTasks.removeValue(forKey: id)
           let code: String
@@ -585,6 +591,22 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
       self.eventSink?([
         "id": id,
         "progress": progress,
+      ])
+    }
+  }
+
+  /// Forwards a native log entry to Flutter via the log event channel.
+  ///
+  /// Log events are sent on the main thread with level, tag, message, and
+  /// timestamp (epoch milliseconds).
+  func postLog(level: PluginLogLevel, message: String) {
+    let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+    DispatchQueue.main.async {
+      self.logSink?([
+        "level": level.methodValue,
+        "tag": Tags.package,
+        "message": message,
+        "timestamp": timestamp,
       ])
     }
   }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/extensions/StreamHandler.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/extensions/StreamHandler.swift
@@ -60,3 +60,32 @@ class WaveformStreamHandler: NSObject, FlutterStreamHandler {
     return nil
   }
 }
+
+/// FlutterStreamHandler for native log events.
+///
+/// Manages the event channel that forwards native log entries to Dart and
+/// wires `PluginLog.sink` so every emitted log reaches the active listener.
+class LogStreamHandler: NSObject, FlutterStreamHandler {
+  private weak var plugin: ProVideoEditorPlugin?
+
+  init(plugin: ProVideoEditorPlugin) {
+    self.plugin = plugin
+    super.init()
+  }
+
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink)
+    -> FlutterError?
+  {
+    plugin?.logSink = events
+    PluginLog.sink = { [weak plugin] level, message in
+      plugin?.postLog(level: level, message: message)
+    }
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    PluginLog.sink = nil
+    plugin?.logSink = nil
+    return nil
+  }
+}

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/logging/PluginLog.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/logging/PluginLog.swift
@@ -16,6 +16,18 @@ enum PluginLogLevel: Int {
     #endif
   }
 
+  /// String value matching `NativeLogLevel.methodValue` on the Dart side.
+  var methodValue: String {
+    switch self {
+    case .verbose: return "verbose"
+    case .debug: return "debug"
+    case .info: return "info"
+    case .warning: return "warning"
+    case .error: return "error"
+    case .none: return "none"
+    }
+  }
+
   static func from(methodValue: String) throws -> PluginLogLevel {
     switch methodValue.lowercased() {
     case "verbose":
@@ -50,6 +62,12 @@ enum PluginLogError: LocalizedError {
 enum PluginLog {
   private static var minimumLevel = PluginLogLevel.default
 
+  /// Optional sink that forwards every emitted log entry to Flutter.
+  ///
+  /// Set by the plugin while a Dart listener is attached to the
+  /// `pro_video_editor_logs` event channel.
+  static var sink: ((_ level: PluginLogLevel, _ message: String) -> Void)?
+
   static func setMinimumLevel(_ methodValue: String) throws {
     minimumLevel = try .from(methodValue: methodValue)
   }
@@ -63,6 +81,7 @@ enum PluginLog {
     let level = inferredLevel(for: message)
     guard shouldLog(level) else { return }
     Swift.print(message, terminator: terminator)
+    sink?(level, message)
   }
 
   private static func shouldLog(_ level: PluginLogLevel) -> Bool {

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				642232DD6FBCF85C234898B8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -297,6 +298,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		642232DD6FBCF85C234898B8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9506B0E8B5EC425E95D394ED /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -18,6 +18,7 @@ import '/core/constants/example_constants.dart';
 import '/core/constants/example_filters.dart';
 import '/shared/utils/bytes_formatter.dart';
 import '/shared/widgets/filter_generator.dart';
+import '/shared/widgets/native_log_console.dart';
 
 /// A page that handles the video export workflow.
 ///
@@ -1134,7 +1135,11 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     String outputPath = '${directory.path}/my_video_$now.$extension';
 
     try {
-      await _pve.renderVideoToFile(outputPath, value.copyWith(id: _taskId));
+      await _pve.renderVideoToFile(
+        outputPath,
+        value.copyWith(id: _taskId),
+        nativeLogLevel: NativeLogLevel.debug,
+      );
     } on RenderCanceledException {
       setState(() => _isExporting = false);
       return;
@@ -1241,6 +1246,10 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
               ),
             ),
             _buildOptions(),
+            Padding(
+              padding: const .symmetric(horizontal: 16.0),
+              child: NativeLogConsole(logStream: _pve.logStream),
+            ),
           ],
         ),
       ),

--- a/example/lib/shared/widgets/native_log_console.dart
+++ b/example/lib/shared/widgets/native_log_console.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+/// Live console that displays native logs forwarded through
+/// [ProVideoEditor.logStream].
+///
+/// Demonstrates how a host app can capture renderer diagnostics in Dart. The
+/// widget subscribes to [logStream] itself, buffers the most recent entries
+/// (capped by [maxEntries]) and renders them color-coded by [NativeLogLevel].
+///
+/// Emit the rich renderer output by running the operation with
+/// `nativeLogLevel: NativeLogLevel.debug` (or higher).
+class NativeLogConsole extends StatefulWidget {
+  /// Creates a [NativeLogConsole].
+  const NativeLogConsole({
+    super.key,
+    required this.logStream,
+    this.maxEntries = 200,
+  });
+
+  /// Stream of native log entries to display, e.g.
+  /// `ProVideoEditor.instance.logStream`.
+  final Stream<NativeLogEntry> logStream;
+
+  /// Caps the in-memory buffer so the console cannot grow unbounded.
+  final int maxEntries;
+
+  @override
+  State<NativeLogConsole> createState() => _NativeLogConsoleState();
+}
+
+class _NativeLogConsoleState extends State<NativeLogConsole> {
+  final List<NativeLogEntry> _logs = [];
+  StreamSubscription<NativeLogEntry>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(NativeLogConsole oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.logStream != widget.logStream) {
+      _subscription?.cancel();
+      _subscribe();
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    _subscription = widget.logStream.listen((entry) {
+      if (!mounted) return;
+      setState(() {
+        _logs.add(entry);
+        if (_logs.length > widget.maxEntries) {
+          _logs.removeRange(0, _logs.length - widget.maxEntries);
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.terminal),
+            title: const Text('Native Logs'),
+            subtitle: Text('${_logs.length} entries · from logStream'),
+            trailing: IconButton(
+              tooltip: 'Clear',
+              icon: const Icon(Icons.delete_outline),
+              onPressed: _logs.isEmpty ? null : () => setState(_logs.clear),
+            ),
+          ),
+          const Divider(height: 1),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 220),
+            child: _logs.isEmpty
+                ? const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Text(
+                      'No native logs yet. Start a render to see entries '
+                      'forwarded from the native renderer.',
+                      style: TextStyle(color: Colors.grey),
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    reverse: true,
+                    itemCount: _logs.length,
+                    itemBuilder: (context, index) {
+                      final entry = _logs[_logs.length - 1 - index];
+                      return _NativeLogTile(entry: entry);
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single row in the [NativeLogConsole].
+class _NativeLogTile extends StatelessWidget {
+  const _NativeLogTile({required this.entry});
+
+  final NativeLogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _levelColor(entry.level);
+    final time = entry.timestamp;
+    final stamp = '${time.hour.toString().padLeft(2, '0')}:'
+        '${time.minute.toString().padLeft(2, '0')}:'
+        '${time.second.toString().padLeft(2, '0')}';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            margin: const EdgeInsets.only(top: 4, right: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              entry.level.name.toUpperCase(),
+              style: TextStyle(
+                color: color,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: '$stamp  ',
+                    style: const TextStyle(color: Colors.grey, fontSize: 11),
+                  ),
+                  if (entry.tag != null)
+                    TextSpan(
+                      text: '${entry.tag}: ',
+                      style: TextStyle(
+                        color: color,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  TextSpan(
+                    text: entry.message,
+                    style: const TextStyle(fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _levelColor(NativeLogLevel level) {
+    switch (level) {
+      case NativeLogLevel.error:
+        return Colors.red;
+      case NativeLogLevel.warning:
+        return Colors.orange;
+      case NativeLogLevel.info:
+        return Colors.blue;
+      case NativeLogLevel.debug:
+        return Colors.green;
+      case NativeLogLevel.verbose:
+        return Colors.grey;
+      case NativeLogLevel.none:
+        return Colors.grey;
+    }
+  }
+}

--- a/example/lib/shared/widgets/native_log_console.dart
+++ b/example/lib/shared/widgets/native_log_console.dart
@@ -123,7 +123,8 @@ class _NativeLogTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final color = _levelColor(entry.level);
     final time = entry.timestamp;
-    final stamp = '${time.hour.toString().padLeft(2, '0')}:'
+    final stamp =
+        '${time.hour.toString().padLeft(2, '0')}:'
         '${time.minute.toString().padLeft(2, '0')}:'
         '${time.second.toString().padLeft(2, '0')}';
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,15 +1,83 @@
 PODS:
+  - audioplayers_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - file_picker (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - fvp (0.36.1):
+    - Flutter
+    - FlutterMacOS
+    - mdk (~> 0.36.0)
+  - mdk (0.36.0)
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
+  - pro_image_editor (12.0.8):
+    - Flutter
+    - FlutterMacOS
+  - pro_video_editor (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - wakelock_plus (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
+  - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - fvp (from `Flutter/ephemeral/.symlinks/plugins/fvp/darwin`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - pro_image_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin`)
+  - pro_video_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
+  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
+
+SPEC REPOS:
+  trunk:
+    - mdk
 
 EXTERNAL SOURCES:
+  audioplayers_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
+  fvp:
+    :path: Flutter/ephemeral/.symlinks/plugins/fvp/darwin
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  pro_image_editor:
+    :path: Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin
+  pro_video_editor:
+    :path: Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  video_player_avfoundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
+  wakelock_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
+  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
+  file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  fvp: f8b3b61cf8c696ecaa5608ae0d282ba710e65ae9
+  mdk: 3bfb53e0bcc9643180eaa864360051f281e4c17b
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  pro_image_editor: e57a76b305fd8c2e06d57f92aec82b9c6a6e8d9f
+  pro_video_editor: 71c273c0a82a72996526e2bfc5c2fbd2bb35aaaa
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
+  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
 
 PODFILE CHECKSUM: d53808ad3e260398c64f5e8ffae8c72d2669e2a5
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				EEC91DBA2BF300121F464B73 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -415,6 +416,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EEC91DBA2BF300121F464B73 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/lib/core/models/platform/native_log_entry.dart
+++ b/lib/core/models/platform/native_log_entry.dart
@@ -1,0 +1,77 @@
+import 'native_log_level.dart';
+
+/// A single log entry forwarded from the native plugin implementation.
+///
+/// The native renderer (and the rest of the plugin) writes its diagnostics
+/// through a shared logging layer that, in addition to the platform console,
+/// streams every entry back to Dart. Host apps can listen to
+/// [ProVideoEditor.logStream] and pipe these entries into their own Dart
+/// logger so they can be exported and analyzed later.
+///
+/// Forwarding is gated by the same level as the native console output, so the
+/// entries you receive match the [NativeLogLevel] requested via the
+/// `nativeLogLevel` parameter of the individual operations.
+class NativeLogEntry {
+  /// Creates a [NativeLogEntry].
+  const NativeLogEntry({
+    required this.level,
+    required this.message,
+    required this.timestamp,
+    this.tag,
+    this.stackTrace,
+  });
+
+  /// Parses a [NativeLogEntry] from a platform channel event map.
+  ///
+  /// Missing or malformed fields degrade gracefully: an unknown level becomes
+  /// [NativeLogLevel.info], a missing message becomes an empty string, and a
+  /// missing timestamp falls back to the current time.
+  factory NativeLogEntry.fromMap(Map<dynamic, dynamic> map) {
+    final timestampMs = map['timestamp'];
+    final timestamp = timestampMs is int
+        ? DateTime.fromMillisecondsSinceEpoch(timestampMs)
+        : DateTime.now();
+
+    return NativeLogEntry(
+      level: NativeLogLevel.fromMethodValue(
+        (map['level'] as String?) ?? 'info',
+      ),
+      message: (map['message'] as String?) ?? '',
+      tag: map['tag'] as String?,
+      stackTrace: map['stackTrace'] as String?,
+      timestamp: timestamp,
+    );
+  }
+
+  /// Severity of the log entry.
+  final NativeLogLevel level;
+
+  /// The log message emitted by the native side.
+  final String message;
+
+  /// Optional source tag (e.g. `ProVideoEditor-Renderer`).
+  ///
+  /// Android logs always carry a tag. On Darwin a package-wide default tag is
+  /// used since the native logger does not track per-call tags.
+  final String? tag;
+
+  /// Optional stack trace, present when the native side forwarded a throwable.
+  final String? stackTrace;
+
+  /// Timestamp at which the entry was emitted natively.
+  final DateTime timestamp;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer()
+      ..write('[${level.methodValue.toUpperCase()}]');
+    if (tag != null && tag!.isNotEmpty) {
+      buffer.write(' $tag');
+    }
+    buffer.write(': $message');
+    if (stackTrace != null && stackTrace!.isNotEmpty) {
+      buffer.write('\n$stackTrace');
+    }
+    return buffer.toString();
+  }
+}

--- a/lib/core/models/platform/native_log_level.dart
+++ b/lib/core/models/platform/native_log_level.dart
@@ -22,4 +22,30 @@ enum NativeLogLevel {
 
   /// String value sent over the platform channel.
   final String methodValue;
+
+  /// Parses a [NativeLogLevel] from its [methodValue] string.
+  ///
+  /// Accepts the canonical [methodValue]s as well as the common `warn` alias
+  /// (mapped to [warning]). Unknown values fall back to [info] so that a log
+  /// entry is never dropped just because the native side used an unexpected
+  /// label.
+  static NativeLogLevel fromMethodValue(String value) {
+    switch (value.toLowerCase()) {
+      case 'none':
+        return NativeLogLevel.none;
+      case 'error':
+        return NativeLogLevel.error;
+      case 'warn':
+      case 'warning':
+        return NativeLogLevel.warning;
+      case 'info':
+        return NativeLogLevel.info;
+      case 'debug':
+        return NativeLogLevel.debug;
+      case 'verbose':
+        return NativeLogLevel.verbose;
+      default:
+        return NativeLogLevel.info;
+    }
+  }
 }

--- a/lib/core/platform/native_method_channel.dart
+++ b/lib/core/platform/native_method_channel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mime/mime.dart';
 import 'package:pro_video_editor/core/models/exceptions/audio_exceptions.dart';
+import 'package:pro_video_editor/core/models/platform/native_log_entry.dart';
 import 'package:pro_video_editor/core/models/platform/native_log_level.dart';
 
 import '/core/models/audio/audio_extract_configs_model.dart';
@@ -70,6 +71,13 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
   final _waveformStreamChannel = const EventChannel(
     'pro_video_editor_waveform_stream',
   );
+
+  /// Event channel for receiving log entries forwarded from native code.
+  ///
+  /// Emits [NativeLogEntry] events whenever the native plugin logs something
+  /// (gated by the active `nativeLogLevel`), allowing host apps to capture
+  /// renderer diagnostics in their own Dart logger.
+  final _logChannel = const EventChannel('pro_video_editor_logs');
 
   @override
   Future<String?> getPlatformVersion() async {
@@ -440,6 +448,22 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
         return const ProgressModel(id: 'error', progress: 0);
       }
     }).listen(progressCtrl.add);
+
+    // Subscribe to native log events
+    _logChannel.receiveBroadcastStream().listen(
+      (event) {
+        if (event is! Map) return;
+        try {
+          logCtrl.add(NativeLogEntry.fromMap(event));
+        } catch (e, stack) {
+          // Never let a malformed log entry break the stream.
+          debugPrint('Error parsing native log event: $e\n$stack');
+        }
+      },
+      onError: (Object error, StackTrace stack) {
+        debugPrint('Native log stream error: $error\n$stack');
+      },
+    );
   }
 
   /// Extracts file extension from path using MIME type detection.

--- a/lib/core/platform/platform_interface.dart
+++ b/lib/core/platform/platform_interface.dart
@@ -7,6 +7,7 @@ import '/core/models/audio/audio_extract_configs_model.dart';
 import '/core/models/audio/waveform_chunk_model.dart';
 import '/core/models/audio/waveform_configs_model.dart';
 import '/core/models/audio/waveform_data_model.dart';
+import '/core/models/platform/native_log_entry.dart';
 import '/core/models/platform/native_log_level.dart';
 import '/core/models/thumbnail/key_frames_configs_model.dart';
 import '/core/models/thumbnail/single_thumbnail_configs_model.dart';
@@ -76,6 +77,13 @@ abstract class ProVideoEditor extends PlatformInterface {
   /// exposed through [progressStream] and [progressStreamById].
   @protected
   final progressCtrl = StreamController<ProgressModel>.broadcast();
+
+  /// Broadcast stream controller for native log entries.
+  ///
+  /// Platform implementations forward log entries emitted by the native side
+  /// here, which are then exposed through [logStream].
+  @protected
+  final logCtrl = StreamController<NativeLogEntry>.broadcast();
 
   /// Retrieves the platform version.
   ///
@@ -550,4 +558,21 @@ abstract class ProVideoEditor extends PlatformInterface {
   /// individual video task independently.
   Stream<ProgressModel> progressStreamById(String taskId) =>
       progressStream.where((item) => item.id == taskId);
+
+  /// Stream of log entries forwarded from the native plugin implementation.
+  ///
+  /// Mirrors the native console output (gated by the `nativeLogLevel` of the
+  /// running operation) so host apps can capture renderer diagnostics in their
+  /// own Dart logger and export them.
+  ///
+  /// Currently emits on Android, iOS, and macOS. On Web, Windows, and Linux
+  /// the stream stays empty.
+  ///
+  /// Example:
+  /// ```dart
+  /// ProVideoEditor.instance.logStream.listen((entry) {
+  ///   myLogger.log(entry.level.name, entry.message);
+  /// });
+  /// ```
+  Stream<NativeLogEntry> get logStream => logCtrl.stream;
 }

--- a/lib/pro_video_editor.dart
+++ b/lib/pro_video_editor.dart
@@ -6,6 +6,7 @@ export '/core/models/audio/audio_track_model.dart';
 export '/core/models/audio/waveform_chunk_model.dart';
 export '/core/models/audio/waveform_configs_model.dart';
 export '/core/models/audio/waveform_data_model.dart';
+export '/core/models/platform/native_log_entry.dart';
 export '/core/models/platform/native_log_level.dart';
 export 'features/audio/widgets/audio_waveform.dart';
 export 'features/audio/models/waveform_style.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.18.0
+version: 1.19.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/platform/native_log_entry_test.dart
+++ b/test/core/models/platform/native_log_entry_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  group('NativeLogLevel.fromMethodValue', () {
+    test('parses every canonical methodValue back to its enum', () {
+      for (final level in NativeLogLevel.values) {
+        expect(
+          NativeLogLevel.fromMethodValue(level.methodValue),
+          level,
+          reason: 'round-trip failed for ${level.methodValue}',
+        );
+      }
+    });
+
+    test('maps the "warn" alias to warning', () {
+      expect(NativeLogLevel.fromMethodValue('warn'), NativeLogLevel.warning);
+    });
+
+    test('is case-insensitive', () {
+      expect(NativeLogLevel.fromMethodValue('ERROR'), NativeLogLevel.error);
+    });
+
+    test('falls back to info for unknown values', () {
+      expect(NativeLogLevel.fromMethodValue('totally-unknown'),
+          NativeLogLevel.info);
+    });
+  });
+
+  group('NativeLogEntry.fromMap', () {
+    test('parses all fields', () {
+      final entry = NativeLogEntry.fromMap({
+        'level': 'error',
+        'tag': 'ProVideoEditor-Renderer',
+        'message': 'Render failed',
+        'timestamp': 1718200000000,
+        'stackTrace': 'at Foo.bar(Foo.kt:42)',
+      });
+
+      expect(entry.level, NativeLogLevel.error);
+      expect(entry.tag, 'ProVideoEditor-Renderer');
+      expect(entry.message, 'Render failed');
+      expect(
+        entry.timestamp,
+        DateTime.fromMillisecondsSinceEpoch(1718200000000),
+      );
+      expect(entry.stackTrace, 'at Foo.bar(Foo.kt:42)');
+    });
+
+    test('degrades gracefully for missing/unknown fields', () {
+      final entry = NativeLogEntry.fromMap({'level': 'made-up'});
+
+      expect(entry.level, NativeLogLevel.info);
+      expect(entry.message, '');
+      expect(entry.tag, isNull);
+      expect(entry.stackTrace, isNull);
+      // Missing timestamp falls back to "now"-ish without throwing.
+      expect(entry.timestamp, isA<DateTime>());
+    });
+
+    test('toString includes level, tag and message', () {
+      final entry = NativeLogEntry.fromMap({
+        'level': 'warning',
+        'tag': 'ProVideoEditor',
+        'message': 'heads up',
+        'timestamp': 0,
+      });
+
+      expect(entry.toString(), '[WARNING] ProVideoEditor: heads up');
+    });
+  });
+}


### PR DESCRIPTION
## Description

Introduce a `logStream` feature in the ProVideoEditor plugin to forward native logs, including renderer diagnostics, to Dart. Implement `NativeLogEntry` and `NativeLogLevel` models for structured log data. Update Android and iOS implementations to support this feature and enhance documentation accordingly.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

