### PR TITLE
fix(darwin): resolve audio source duration from track when asset duration is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.19.1
+- **FIX**(iOS, macOS): Fix custom audio tracks being silently dropped when the source asset's duration fails to resolve. `AudioPreRenderer` previously fell back to a zero duration on `asset.load(.duration)` failure, which collapsed an open-ended trim (`audioEndTime == nil`) into a zero-length range and discarded the track with a misleading `invalid trim range … end=0.0s` log. The renderer now loads the audio track first and falls back to its `timeRange` duration (the real audio length), only aborting when neither source resolves. Android already decodes to the real end-of-stream for an open-ended trim, so no change was needed there.
+
 ## 1.19.0
 - **FEAT**(android, iOS, macOS): Forward native plugin logs back to Dart via `ProVideoEditor.instance.logStream`. Every entry written through the shared native logger (including the full renderer diagnostics) is now emitted as a `NativeLogEntry` (`level`, `tag`, `message`, `timestamp`, optional `stackTrace`), so host apps can pipe these into their own Dart logger and export them. Forwarding is gated by the same `nativeLogLevel` as the native console output. Web/Windows/Linux keep an empty stream.
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/AudioPreRenderer.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/AudioPreRenderer.swift
@@ -66,24 +66,8 @@ internal enum AudioPreRenderer {
     // Step 1: decode the trimmed range to PCM bytes.
     let asset = AVURLAsset(url: sourceURL)
 
-    // Resolve the source duration.
-    let sourceDuration: CMTime
-    if #available(macOS 12.0, iOS 15.0, *) {
-      sourceDuration = (try? await asset.load(.duration)) ?? .zero
-    } else {
-      sourceDuration = asset.duration
-    }
-
-    let effectiveStart = CMTimeMaximum(audioStartTime, .zero)
-    let effectiveEnd = CMTimeMinimum(audioEndTime ?? sourceDuration, sourceDuration)
-    let trimDuration = CMTimeSubtract(effectiveEnd, effectiveStart)
-    if CMTimeCompare(trimDuration, .zero) <= 0 {
-      PluginLog.print(
-        "⚠️ AudioPreRenderer: invalid trim range start=\(effectiveStart.seconds)s end=\(effectiveEnd.seconds)s"
-      )
-      return nil
-    }
-
+    // Load the audio track first — its time range gives us the real
+    // audio length even when asset-level duration resolution fails.
     let audioTracks: [AVAssetTrack]
     do {
       if #available(macOS 12.0, iOS 15.0, *) {
@@ -98,6 +82,44 @@ internal enum AudioPreRenderer {
 
     guard let audioTrack = audioTracks.first else {
       PluginLog.print("⚠️ AudioPreRenderer: no audio tracks in source")
+      return nil
+    }
+
+    // Resolve the source duration. Prefer the asset duration, but fall
+    // back to the audio track's own time range when the asset-level
+    // duration fails to load or resolves to zero — otherwise a perfectly
+    // valid file would be dropped with a misleading "invalid trim range".
+    var sourceDuration: CMTime
+    if #available(macOS 12.0, iOS 15.0, *) {
+      sourceDuration = (try? await asset.load(.duration)) ?? .zero
+    } else {
+      sourceDuration = asset.duration
+    }
+    if CMTimeCompare(sourceDuration, .zero) <= 0 {
+      let trackDuration: CMTime
+      if #available(macOS 12.0, iOS 15.0, *) {
+        trackDuration = (try? await audioTrack.load(.timeRange))?.duration ?? .zero
+      } else {
+        trackDuration = audioTrack.timeRange.duration
+      }
+      if CMTimeCompare(trackDuration, .zero) > 0 {
+        PluginLog.print(
+          "ℹ️ AudioPreRenderer: asset duration unavailable, using audio track duration \(trackDuration.seconds)s"
+        )
+        sourceDuration = trackDuration
+      } else {
+        PluginLog.print("⚠️ AudioPreRenderer: could not resolve source duration")
+        return nil
+      }
+    }
+
+    let effectiveStart = CMTimeMaximum(audioStartTime, .zero)
+    let effectiveEnd = CMTimeMinimum(audioEndTime ?? sourceDuration, sourceDuration)
+    let trimDuration = CMTimeSubtract(effectiveEnd, effectiveStart)
+    if CMTimeCompare(trimDuration, .zero) <= 0 {
+      PluginLog.print(
+        "⚠️ AudioPreRenderer: invalid trim range start=\(effectiveStart.seconds)s end=\(effectiveEnd.seconds)s"
+      )
       return nil
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.19.0
+version: 1.19.1
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Problem

On iOS/macOS, `AudioPreRenderer` resolved the source duration via `asset.load(.duration)` and silently fell back to `.zero` on failure:

```swift
sourceDuration = (try? await asset.load(.duration)) ?? .zero
```

Since the trim end is computed as `audioEndTime ?? sourceDuration`, a zero source duration collapses the trim range to zero length. A perfectly valid audio track with `audioEndTime == nil` then gets dropped with a misleading log:

```
⚠️ AudioPreRenderer: invalid trim range start=0.292s end=0.0s
```

The root cause is not the nullable `endTime` (which is correctly meant to resolve to "until source end") — it's the silent `?? .zero` fallback when the asset-level duration fails to load.

## Fix

- Load the audio track **before** resolving the duration.
- Keep `asset.duration` as the primary source, but fall back to the audio track's own `timeRange.duration` when the asset-level duration is unavailable or `<= 0` — i.e. use the **real audio length**.
- Only abort (with a clear `could not resolve source duration` log) when both sources resolve to zero, instead of producing a misleading zero-length trim.

## Android

No change needed. The Android `AudioPreRenderer` decodes to the real end-of-stream for a null end time (`val effectiveEndUs = endUs ?: Long.MAX_VALUE`) and never relies on a separately resolved source duration for the trim. This fix simply brings iOS/macOS in line with that behavior.

## Verification

- `swiftc -parse` of the changed file passes.
- A full standalone `swift build` is not possible in isolation (fails only on the `FlutterMacOS` module, which is provided by the Flutter embedder at app-build time) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
