### PR TITLE
feat: add clip transition functionality with overlap and dip transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.21.0
+- **FEAT**(android, iOS, macOS): Add clip transitions between adjacent `VideoSegment`s via a new `transition` field (`ClipTransition` with `type`, `duration`, `curve`, `direction`). Supports `dissolve`, `slide`, `push` and `wipe` (overlap and shorten the output) plus `fadeToBlack` and `fadeToWhite` (dip through a color, duration unchanged). Web/Windows/Linux ignore the field.
+
 ## 1.20.0
 - **FEAT**(android, iOS, macOS): Add stop-motion support to turn a sequence of still images into a video via `ProVideoEditor.instance.renderStopMotion` / `renderStopMotionToFile`. Each `StopMotionFrame` is held for `1 / frameRate` seconds (or a per-frame `duration` override) and encoded into a single silent video. The output size defaults to the first frame and frames are mapped onto it via `StopMotionFit` (`contain` / `cover` / `stretch`). Darwin encodes with `AVAssetWriter` + a pixel-buffer adaptor; Android uses Media3 Transformer image input with a `Presentation` effect. Progress and cancellation reuse the existing render task infrastructure. Audio is not mixed in — pass the result through `renderVideo` with `audioTracks` to add music. Web/Windows/Linux are not supported.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The ProVideoEditor is a Flutter widget designed for video editing within your ap
 - 🕐 **Timed Image Layers**: Position image overlays at specific coordinates with optional start/end times.
 - 📐 **Layer Size**: Scale image layers to custom dimensions via the `size` property.
 - 🎬 **Layer Animations**: Animate image layers with fade, slide, and scale effects, configurable easing curves, and in/out/inOut phases.
+- 🎞️ **Clip Transitions**: Add transitions between adjacent clips — `dissolve`, `fadeToBlack`, `fadeToWhite`, `slide`, `push`, and `wipe` — with configurable duration, easing curve, and direction.
 - 🧮 **Color Matrix**: Apply one or multiple 4x5 color matrices (e.g., for filters).
 - 💧 **Blur**: Add a blur effect to the video.
 - 📡 **Bitrate**: Set a custom video bitrate. If constant bitrate (CBR) isn't supported, it will gracefully fall back to the next available mode.
@@ -152,6 +153,7 @@ The ProVideoEditor is a Flutter widget designed for video editing within your ap
 | `Overlay Layers`           | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Timed Image Layers`       | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Layer Animations`          | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
+| `Clip Transitions`          | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Layer Size`                | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Multiple ColorMatrix 4x5` | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
 | `Cancel export task`       | ✅      | ✅  | ✅     | ❌      | ❌     | 🚫   |
@@ -316,6 +318,47 @@ var data = VideoRenderData(
 );
 
 Uint8List result = await ProVideoEditor.instance.renderVideo(data);
+```
+
+#### Clip Transitions Example
+```dart
+/// Add a transition between adjacent clips via `VideoSegment.transition`.
+/// The transition describes how a clip moves into the NEXT clip and is
+/// ignored on the last segment.
+///
+/// Overlap transitions (dissolve, slide, push, wipe) blend the two clips and
+/// shorten the total output by the transition duration. Dip transitions
+/// (fadeToBlack, fadeToWhite) dip through a color and keep the duration.
+var data = VideoRenderData(
+    videoSegments: [
+        VideoSegment(
+            video: EditorVideo.asset('assets/clip-a.mp4'),
+            endTime: const Duration(seconds: 5),
+            transition: const ClipTransition(
+                type: ClipTransitionType.dissolve,
+                duration: Duration(milliseconds: 800),
+                curve: AnimationCurve.easeInOut,
+            ),
+        ),
+        VideoSegment(
+            video: EditorVideo.asset('assets/clip-b.mp4'),
+            // A directional transition (slide / push / wipe) uses `direction`.
+            transition: const ClipTransition(
+                type: ClipTransitionType.wipe,
+                duration: Duration(milliseconds: 700),
+                direction: ClipTransitionDirection.right,
+            ),
+        ),
+        VideoSegment(video: EditorVideo.asset('assets/clip-c.mp4')),
+    ],
+    outputFormat: VideoOutputFormat.mp4,
+);
+
+Uint8List result = await ProVideoEditor.instance.renderVideo(data);
+
+/// Note: overlap transitions require the neighbouring clips to share the same
+/// dimensions (split clips from one source always do); otherwise the boundary
+/// falls back to a hard cut.
 ```
 
 #### Extract Audio Example
@@ -577,9 +620,13 @@ Represents a video clip segment for merging multiple videos.
 
 ```dart
 VideoSegment({
-  required EditorVideo video,  // Video source (file, asset, network, memory)
-  Duration? startTime,          // Optional: Start time for trimming
-  Duration? endTime,            // Optional: End time for trimming
+  required EditorVideo video,    // Video source (file, asset, network, memory)
+  Duration? startTime,           // Optional: Start time for trimming
+  Duration? endTime,             // Optional: End time for trimming
+  double? volume,                // Optional: Per-clip volume multiplier
+  double? playbackSpeed,         // Optional: Per-clip playback speed
+  bool reverseVideo = false,     // Optional: Play this clip backwards
+  ClipTransition? transition,    // Optional: Transition into the NEXT clip
 })
 ```
 
@@ -587,6 +634,10 @@ VideoSegment({
 - `video` (required): The video source using `EditorVideo.file()`, `EditorVideo.asset()`, `EditorVideo.network()`, or `EditorVideo.memory()`.
 - `startTime` (optional): The starting point for this clip. If omitted, starts from the beginning (0:00).
 - `endTime` (optional): The ending point for this clip. If omitted, uses the full video duration.
+- `volume` (optional): Per-clip audio volume multiplier (`0.0` = mute, `1.0` = original).
+- `playbackSpeed` (optional): Per-clip playback speed (e.g. `0.5` = half, `2.0` = double).
+- `reverseVideo` (optional): Renders this clip backwards when `true`.
+- `transition` (optional): A `ClipTransition` describing how this clip transitions into the **next** clip (dissolve, fade-to-black, slide, etc.). Ignored on the last segment.
 
 **Usage Example:**
 ```dart

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
@@ -22,6 +22,8 @@ import ch.waio.pro_video_editor.src.features.render.helpers.VolumeControlAudioMi
 import ch.waio.pro_video_editor.src.features.render.helpers.ConfigurableInAppMp4Muxer
 import ch.waio.pro_video_editor.src.features.render.helpers.VideoTranscoder
 import ch.waio.pro_video_editor.src.features.render.helpers.VideoReverser
+import ch.waio.pro_video_editor.src.features.render.helpers.ClipTransitionRenderer
+import ch.waio.pro_video_editor.src.features.render.helpers.MediaInfoExtractor
 import ch.waio.pro_video_editor.src.features.render.models.RenderConfig
 import ch.waio.pro_video_editor.src.features.render.models.RenderJobHandle
 import ch.waio.pro_video_editor.src.features.render.models.VideoClip
@@ -109,29 +111,40 @@ class RenderVideo(private val context: Context) {
         val mainHandler = Handler(Looper.getMainLooper())
         var transcodedFiles: List<String> = emptyList()
         var reversedFiles: List<String> = emptyList()
+        var transitionFiles: List<String> = emptyList()
         val transformerRef = AtomicReference<Transformer?>(null)
         val outputFileRef = AtomicReference<File?>(null)
 
         val needsPreTranscode = needsPreTranscoding(config)
         val needsPreReverse = config.videoClips.any { it.reverseVideo }
+        val needsPreTransitions = config.videoClips.size > 1 &&
+                config.videoClips.any { it.transition?.isOverlap == true }
 
-        // Progress split: reverse pre-render is the slowest stage, so it gets the
-        // largest share. Without reverse, the transformer owns the full bar.
-        val reverseShare = if (needsPreReverse) 0.6 else 0.0
-        val transformShare = 1.0 - reverseShare
+        // Progress split across the slow pre-render stages and the transformer.
+        // Reverse + overlap-transition pre-renders each get a share; whatever is
+        // left belongs to the transformer phase.
+        val reverseShare = if (needsPreReverse) 0.4 else 0.0
+        val transitionShare = if (needsPreTransitions) 0.4 else 0.0
+        val transformShare = 1.0 - reverseShare - transitionShare
         val reverseProgress: (Double) -> Unit = { p ->
             onProgress((p * reverseShare).coerceIn(0.0, 1.0))
         }
+        val transitionProgress: (Double) -> Unit = { p ->
+            onProgress((reverseShare + p * transitionShare).coerceIn(0.0, 1.0))
+        }
         val transformProgress: (Double) -> Unit = { p ->
-            onProgress((reverseShare + p * transformShare).coerceIn(0.0, 1.0))
+            onProgress(
+                (reverseShare + transitionShare + p * transformShare).coerceIn(0.0, 1.0)
+            )
         }
 
         val cleanupAllPreFiles: () -> Unit = {
             VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
             VideoReverser.cleanupReversedFiles(reversedFiles)
+            ClipTransitionRenderer.cleanupFiles(transitionFiles)
         }
 
-        if (!needsPreTranscode && !needsPreReverse) {
+        if (!needsPreTranscode && !needsPreReverse && !needsPreTransitions) {
             // Fast path: nothing to pre-process.
             renderInternal(
                 config = config,
@@ -166,14 +179,7 @@ class RenderVideo(private val context: Context) {
                         val updatedClips = workingConfig.videoClips.map { clip ->
                             val newPath = transcodeMap[clip.inputPath] ?: clip.inputPath
                             if (newPath != clip.inputPath) {
-                                VideoClip(
-                                    newPath,
-                                    clip.startUs,
-                                    clip.endUs,
-                                    clip.volume,
-                                    clip.playbackSpeed,
-                                    clip.reverseVideo
-                                )
+                                clip.copy(inputPath = newPath)
                             } else clip
                         }
                         workingConfig = workingConfig.copy(videoClips = updatedClips)
@@ -199,6 +205,23 @@ class RenderVideo(private val context: Context) {
                         // Make sure the bar fully fills the reverse share before
                         // the transformer phase starts.
                         reverseProgress(1.0)
+                    }
+
+                    // 3) Pre-render overlap transitions (dissolve/slide/push/wipe)
+                    //    into short blended clips spliced between the neighbours.
+                    if (needsPreTransitions && !shouldStopPolling.get()) {
+                        Log.d(RENDER_TAG, "Pre-rendering overlap clip transitions")
+                        val paths = mutableListOf<String>()
+                        val transitionedClips = preRenderTransitions(
+                            workingConfig.videoClips,
+                            enableAudio = workingConfig.enableAudio,
+                            shouldStop = shouldStopPolling,
+                            collectPath = { paths.add(it) },
+                            onProgress = { f -> transitionProgress(f.toDouble()) },
+                        )
+                        transitionFiles = paths
+                        workingConfig = workingConfig.copy(videoClips = transitionedClips)
+                        transitionProgress(1.0)
                     }
 
                     val finalConfig = workingConfig
@@ -240,6 +263,7 @@ class RenderVideo(private val context: Context) {
             transformerRef.get()?.cancel()
             VideoTranscoder.cleanupTranscodedFiles(transcodedFiles)
             VideoReverser.cleanupReversedFiles(reversedFiles)
+            ClipTransitionRenderer.cleanupFiles(transitionFiles)
             if (config.outputPath == null) {
                 outputFileRef.get()?.delete()
             }
@@ -285,12 +309,10 @@ class RenderVideo(private val context: Context) {
                     },
                 )
                 collectPath(reversed.outputPath)
-                result[clipIdx] = VideoClip(
+                result[clipIdx] = clip.copy(
                     inputPath = reversed.outputPath,
                     startUs = 0L,
                     endUs = reversed.durationUs.takeIf { it > 0 },
-                    volume = clip.volume,
-                    playbackSpeed = clip.playbackSpeed,
                     reverseVideo = false,
                 )
             } catch (e: Exception) {
@@ -302,6 +324,111 @@ class RenderVideo(private val context: Context) {
                 result[clipIdx] = clip.copy(reverseVideo = false)
             }
         }
+        return result
+    }
+
+    /**
+     * Pre-renders overlap transitions (dissolve/slide/push/wipe) into short
+     * blended MP4 clips and rewrites the clip list so the main pipeline sees
+     * plain forward clips:
+     *
+     * For a transition between clip *i* and *i+1*, clip *i* is shortened by the
+     * (clamped) transition duration `d`, the blended clip (`d`) is inserted, and
+     * clip *i+1*'s head is trimmed by `d`. Net timeline change: `-d` per
+     * transition. If a transition cannot be rendered (e.g. dimension mismatch,
+     * per-clip speed, or not enough content) it degrades to a hard cut.
+     */
+    private fun preRenderTransitions(
+        clips: List<VideoClip>,
+        enableAudio: Boolean,
+        shouldStop: AtomicBoolean,
+        collectPath: (String) -> Unit,
+        onProgress: (Float) -> Unit,
+    ): List<VideoClip> {
+        if (clips.size < 2) return clips
+        val total = (0 until clips.size - 1)
+            .count { clips[it].transition?.isOverlap == true }
+        if (total == 0) return clips
+
+        val work = clips.toMutableList()
+        val result = mutableListOf<VideoClip>()
+        var doneCount = 0
+        var i = 0
+
+        while (i < work.size) {
+            val current = work[i]
+            val next = work.getOrNull(i + 1)
+            val transition = current.transition
+
+            val canOverlap = next != null && transition != null && transition.isOverlap &&
+                    !current.reverseVideo && !next.reverseVideo &&
+                    (current.playbackSpeed == null || current.playbackSpeed == 1.0f) &&
+                    (next.playbackSpeed == null || next.playbackSpeed == 1.0f)
+
+            if (shouldStop.get() || !canOverlap) {
+                // Clear an overlap transition so it is not reinterpreted later.
+                result.add(if (transition?.isOverlap == true) current.copy(transition = null) else current)
+                i++
+                continue
+            }
+
+            val curStart = current.startUs ?: 0L
+            val curEnd = current.endUs ?: MediaInfoExtractor.getVideoDuration(current.inputPath)
+            val nextStart = next!!.startUs ?: 0L
+            val nextEnd = next.endUs ?: MediaInfoExtractor.getVideoDuration(next.inputPath)
+            val curDur = curEnd - curStart
+            val nextDur = nextEnd - nextStart
+            val d = transition!!.durationUs.coerceAtMost(minOf(curDur, nextDur))
+
+            if (d <= 0L || curDur - d <= 0L || nextDur - d <= 0L) {
+                Log.w(RENDER_TAG, "Transition: not enough content for boundary $i, hard cut")
+                result.add(current.copy(transition = null))
+                doneCount++
+                onProgress((doneCount.toFloat() / total).coerceIn(0f, 1f))
+                i++
+                continue
+            }
+
+            val rendered = ClipTransitionRenderer.renderSync(
+                context = context,
+                outgoingPath = current.inputPath,
+                outTailStartUs = curEnd - d,
+                outTailEndUs = curEnd,
+                incomingPath = next.inputPath,
+                inHeadStartUs = nextStart,
+                inHeadEndUs = nextStart + d,
+                type = transition.type,
+                direction = transition.direction,
+                curve = transition.curve,
+                includeAudio = enableAudio &&
+                        (current.volume ?: 1.0f) > 0f && (next.volume ?: 1.0f) > 0f,
+                onProgress = { f ->
+                    onProgress(((doneCount + f) / total).coerceIn(0f, 1f))
+                },
+            )
+
+            if (rendered != null) {
+                collectPath(rendered.outputPath)
+                result.add(current.copy(endUs = curEnd - d, transition = null))
+                result.add(
+                    VideoClip(
+                        inputPath = rendered.outputPath,
+                        startUs = 0L,
+                        endUs = rendered.durationUs.takeIf { it > 0 },
+                    )
+                )
+                // Trim the incoming head in place; it keeps its own transition.
+                work[i + 1] = next.copy(startUs = nextStart + d)
+            } else {
+                Log.w(RENDER_TAG, "Transition render failed for boundary $i, hard cut")
+                result.add(current.copy(transition = null))
+            }
+
+            doneCount++
+            onProgress((doneCount.toFloat() / total).coerceIn(0f, 1f))
+            i++
+        }
+
         return result
     }
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyClipTransition.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyClipTransition.kt
@@ -1,0 +1,88 @@
+package ch.waio.pro_video_editor.src.features.render.helpers
+
+import android.graphics.Bitmap
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.effect.BitmapOverlay
+import androidx.media3.effect.StaticOverlaySettings
+import kotlin.math.max
+
+/**
+ * Full-frame solid-color overlay used to implement "dip" clip transitions
+ * (fade-to-black / fade-to-white).
+ *
+ * A single instance is attached to a clip's effect pipeline. The overlay alpha
+ * is computed per frame from the clip-local presentation time:
+ * - [fadeInUs]  > 0: the clip fades **in from the dip color** over its first
+ *   window (alpha 1 → 0).
+ * - [fadeOutUs] > 0: the clip fades **out to the dip color** over its last
+ *   window (alpha 0 → 1).
+ *
+ * Timestamps are clip-local (each [androidx.media3.transformer.EditedMediaItem]
+ * in a sequence is processed with its own timeline), and the overlay is added
+ * **after** any per-clip [androidx.media3.effect.SpeedChangeEffect] so the
+ * windows are expressed in output-local time via [clipDurationUs].
+ *
+ * @param dipColor ARGB color the clip dips to/from (e.g. black or white).
+ */
+@UnstableApi
+internal class ClipFadeOverlay(
+    videoWidth: Int,
+    videoHeight: Int,
+    dipColor: Int,
+    private val clipDurationUs: Long,
+    private val fadeInUs: Long,
+    private val fadeOutUs: Long,
+    private val curve: String,
+) : BitmapOverlay() {
+
+    private val dipBitmap: Bitmap =
+        Bitmap.createBitmap(
+            max(1, videoWidth),
+            max(1, videoHeight),
+            Bitmap.Config.ARGB_8888,
+        ).apply { eraseColor(dipColor) }
+
+    private val settingsBuilder = StaticOverlaySettings.Builder()
+        .setOverlayFrameAnchor(0f, 0f)
+        .setBackgroundFrameAnchor(0f, 0f)
+
+    /**
+     * Smallest presentation timestamp seen so far. Media3 does **not** present
+     * clip-local 0-based timestamps to per-clip effects (a trimmed/non-first
+     * clip starts at its own offset), so we normalize against the first frame
+     * the overlay sees. This makes the windows clip-relative regardless of the
+     * underlying timestamp domain (source-based or cumulative).
+     */
+    private var firstTimeUs = Long.MIN_VALUE
+
+    override fun getBitmap(presentationTimeUs: Long): Bitmap = dipBitmap
+
+    override fun getOverlaySettings(presentationTimeUs: Long): StaticOverlaySettings {
+        if (firstTimeUs == Long.MIN_VALUE || presentationTimeUs < firstTimeUs) {
+            firstTimeUs = presentationTimeUs
+        }
+        val localUs = (presentationTimeUs - firstTimeUs).coerceAtLeast(0L)
+
+        var alpha = 0f
+
+        if (fadeInUs > 0 && localUs < fadeInUs) {
+            val p = (localUs.toDouble() / fadeInUs).coerceIn(0.0, 1.0)
+            // Fade in from black: opaque at start, transparent at the window end.
+            alpha = (1.0 - applyEasing(p, curve)).toFloat()
+        }
+
+        if (fadeOutUs > 0) {
+            val outStart = clipDurationUs - fadeOutUs
+            if (localUs > outStart) {
+                val p = ((localUs - outStart).toDouble() / fadeOutUs)
+                    .coerceIn(0.0, 1.0)
+                // Fade out to black: transparent at the window start, opaque at end.
+                alpha = max(alpha, applyEasing(p, curve).toFloat())
+            }
+        }
+
+        return settingsBuilder
+            .setAlphaScale(alpha.coerceIn(0f, 1f))
+            .build()
+    }
+}

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionRenderer.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionRenderer.kt
@@ -1,0 +1,846 @@
+package ch.waio.pro_video_editor.src.features.render.helpers
+
+import RENDER_TAG
+import android.content.Context
+import android.media.Image
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import androidx.media3.common.util.UnstableApi
+import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.nio.ByteBuffer
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Pre-renders an **overlap** clip transition (dissolve / slide / push / wipe)
+ * into a single short MP4 that the main render pipeline consumes as an ordinary
+ * forward clip.
+ *
+ * It decodes the **tail** of the outgoing clip and the **head** of the incoming
+ * clip into packed I420 frames, blends them per output frame according to the
+ * transition [type]/[direction], and re-encodes the result. The two segments
+ * must share the same dimensions (which split clips from one source always do);
+ * if they differ the renderer returns `null` so the caller can fall back to a
+ * hard cut.
+ *
+ * This mirrors [VideoReverser]'s MediaCodec decode → encode → mux approach and
+ * is intentionally isolated from the main composition so a failure degrades to
+ * a plain cut rather than crashing the render.
+ */
+@UnstableApi
+object ClipTransitionRenderer {
+
+    /** Result of [renderSync]. */
+    data class TransitionResult(val outputPath: String, val durationUs: Long)
+
+    private const val DECODER_TIMEOUT_US = 10_000L
+    private const val ENCODER_TIMEOUT_US = 10_000L
+    private const val DEFAULT_FPS = 30
+
+    /**
+     * Renders the blended transition segment.
+     *
+     * @param outTailStartUs Inclusive source start of the outgoing clip's tail.
+     * @param outTailEndUs Exclusive source end of the outgoing clip's tail.
+     * @param inHeadStartUs Inclusive source start of the incoming clip's head.
+     * @param inHeadEndUs Exclusive source end of the incoming clip's head.
+     * @return The rendered transition clip, or `null` if it could not be
+     *  produced (caller should fall back to a hard cut).
+     */
+    fun renderSync(
+        context: Context,
+        outgoingPath: String,
+        outTailStartUs: Long,
+        outTailEndUs: Long,
+        incomingPath: String,
+        inHeadStartUs: Long,
+        inHeadEndUs: Long,
+        type: String,
+        direction: String,
+        curve: String,
+        includeAudio: Boolean,
+        onProgress: (Float) -> Unit = {},
+    ): TransitionResult? {
+        val outputFile = File(context.cacheDir, "transition_${System.currentTimeMillis()}.mp4")
+        val workDir = File(context.cacheDir, "transition_work_${System.currentTimeMillis()}")
+        workDir.mkdirs()
+
+        Log.i(
+            RENDER_TAG,
+            "Transition pre-render: type=$type dir=$direction, " +
+                    "out=${outTailStartUs / 1000}..${outTailEndUs / 1000}ms, " +
+                    "in=${inHeadStartUs / 1000}..${inHeadEndUs / 1000}ms"
+        )
+
+        try {
+            // 1) Decode both segments to packed I420 frames.
+            val outSeg = decodeSegment(outgoingPath, outTailStartUs, outTailEndUs)
+            val inSeg = decodeSegment(incomingPath, inHeadStartUs, inHeadEndUs)
+
+            if (outSeg == null || inSeg == null ||
+                outSeg.frames.isEmpty() || inSeg.frames.isEmpty()
+            ) {
+                Log.w(RENDER_TAG, "Transition: failed to decode one of the segments")
+                return null
+            }
+            if (outSeg.width != inSeg.width || outSeg.height != inSeg.height) {
+                Log.w(
+                    RENDER_TAG,
+                    "Transition: dimension mismatch " +
+                            "(${outSeg.width}x${outSeg.height} vs ${inSeg.width}x${inSeg.height}); " +
+                            "falling back to hard cut"
+                )
+                return null
+            }
+
+            val width = outSeg.width
+            val height = outSeg.height
+            val frameCount = outSeg.frames.size
+            val tailDurationUs = (outTailEndUs - outTailStartUs).coerceAtLeast(1L)
+            val frameDurationUs = tailDurationUs / frameCount
+
+            // 2) Pre-encode the cross-faded audio (best effort, no muxer yet).
+            var audioPre: AudioPreEncoded? = null
+            if (includeAudio) {
+                try {
+                    audioPre = preEncodeCrossfadeAudio(
+                        outgoingPath, outTailStartUs, outTailEndUs,
+                        incomingPath, inHeadStartUs, inHeadEndUs,
+                        curve, workDir
+                    )
+                } catch (e: Exception) {
+                    Log.w(RENDER_TAG, "Transition audio crossfade failed: ${e.message}")
+                    audioPre = null
+                }
+            }
+
+            // 3) Encode the blended video frames into the shared muxer.
+            val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+            var muxerStarted = false
+            var audioTrackIdx = -1
+            var videoTrackIdx = -1
+            val encoder = createEncoder(width, height, frameDurationUs)
+            val encInfo = MediaCodec.BufferInfo()
+
+            try {
+                var nextEncoderFrame = 0
+                var outputDone = false
+
+                // Feed all blended frames, draining the encoder as we go.
+                while (!outputDone) {
+                    // Feed one frame if available.
+                    if (nextEncoderFrame < frameCount) {
+                        val inIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                        if (inIdx >= 0) {
+                            val progress = if (frameCount > 1) {
+                                nextEncoderFrame.toDouble() / (frameCount - 1)
+                            } else 1.0
+                            val eased = applyEasing(progress, curve)
+                            val bIdx = if (frameCount > 1) {
+                                (progress * (inSeg.frames.size - 1)).roundToInt()
+                            } else inSeg.frames.size - 1
+                            val blended = blendFrame(
+                                outSeg.frames[nextEncoderFrame],
+                                inSeg.frames[bIdx.coerceIn(0, inSeg.frames.size - 1)],
+                                width, height, eased, type, direction
+                            )
+                            val encImage = encoder.getInputImage(inIdx)
+                            if (encImage != null) {
+                                i420ToImage(blended, encImage, width, height)
+                                encoder.queueInputBuffer(
+                                    inIdx, 0, width * height * 3 / 2,
+                                    nextEncoderFrame * frameDurationUs, 0
+                                )
+                            } else {
+                                encoder.queueInputBuffer(
+                                    inIdx, 0, 0, nextEncoderFrame * frameDurationUs, 0
+                                )
+                            }
+                            nextEncoderFrame++
+                            onProgress((nextEncoderFrame.toFloat() / frameCount).coerceIn(0f, 1f))
+                            if (nextEncoderFrame == frameCount) {
+                                // Signal EOS after the final frame.
+                                val eosIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                                if (eosIdx >= 0) {
+                                    encoder.queueInputBuffer(
+                                        eosIdx, 0, 0,
+                                        nextEncoderFrame * frameDurationUs,
+                                        MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    // Drain available encoder output.
+                    val outIdx = encoder.dequeueOutputBuffer(encInfo, ENCODER_TIMEOUT_US)
+                    when {
+                        outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> { /* keep feeding */ }
+                        outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                            audioPre?.let { audioTrackIdx = muxer.addTrack(it.format) }
+                            videoTrackIdx = muxer.addTrack(encoder.outputFormat)
+                            muxer.start()
+                            muxerStarted = true
+                        }
+                        outIdx >= 0 -> {
+                            val outBuf = encoder.getOutputBuffer(outIdx)!!
+                            if ((encInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                                encInfo.size = 0
+                            }
+                            if (encInfo.size > 0 && muxerStarted && videoTrackIdx >= 0) {
+                                outBuf.position(encInfo.offset)
+                                outBuf.limit(encInfo.offset + encInfo.size)
+                                muxer.writeSampleData(videoTrackIdx, outBuf, encInfo)
+                            }
+                            encoder.releaseOutputBuffer(outIdx, false)
+                            if ((encInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                                outputDone = true
+                            }
+                        }
+                    }
+                }
+
+                // Replay buffered audio packets into the shared muxer.
+                audioPre?.let { pre ->
+                    if (muxerStarted && audioTrackIdx >= 0) {
+                        try {
+                            writeBufferedAudio(muxer, audioTrackIdx, pre.packetsFile)
+                        } catch (e: Exception) {
+                            Log.w(RENDER_TAG, "Transition audio remux failed: ${e.message}")
+                        }
+                    }
+                }
+            } finally {
+                try { encoder.stop() } catch (_: Exception) {}
+                try { encoder.release() } catch (_: Exception) {}
+                if (muxerStarted) {
+                    try { muxer.stop() } catch (_: Exception) {}
+                }
+                try { muxer.release() } catch (_: Exception) {}
+                try { audioPre?.packetsFile?.delete() } catch (_: Exception) {}
+            }
+
+            val durationUs = frameCount * frameDurationUs
+            Log.i(
+                RENDER_TAG,
+                "Transition pre-render done: ${outputFile.length()} bytes, " +
+                        "${durationUs / 1000}ms, $frameCount frames"
+            )
+            return TransitionResult(outputFile.absolutePath, durationUs)
+        } catch (e: Exception) {
+            Log.e(RENDER_TAG, "Transition pre-render failed: ${e.message}", e)
+            outputFile.delete()
+            return null
+        } finally {
+            workDir.deleteRecursively()
+        }
+    }
+
+    /** Deletes transition temp files (best effort). */
+    fun cleanupFiles(paths: Collection<String>) {
+        for (path in paths) {
+            try {
+                val f = File(path)
+                if (f.exists() && f.name.startsWith("transition_")) f.delete()
+            } catch (_: Exception) { /* ignore */ }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // VIDEO DECODE
+    // ---------------------------------------------------------------------
+
+    private class DecodedSegment(
+        val frames: MutableList<ByteArray>,
+        val width: Int,
+        val height: Int,
+    )
+
+    /**
+     * Decodes [path] within [[startUs]..[endUs]] into packed I420 frames.
+     */
+    private fun decodeSegment(path: String, startUs: Long, endUs: Long): DecodedSegment? {
+        val extractor = MediaExtractor().apply { setDataSource(path) }
+        val videoTrackIndex = findTrack(extractor, "video/") ?: run {
+            extractor.release(); return null
+        }
+        extractor.selectTrack(videoTrackIndex)
+        val inputFormat = extractor.getTrackFormat(videoTrackIndex)
+        val mime = inputFormat.getString(MediaFormat.KEY_MIME) ?: run {
+            extractor.release(); return null
+        }
+        val width = inputFormat.getInteger(MediaFormat.KEY_WIDTH)
+        val height = inputFormat.getInteger(MediaFormat.KEY_HEIGHT)
+
+        val decoderFormat = inputFormat.also {
+            it.setInteger(
+                MediaFormat.KEY_COLOR_FORMAT,
+                MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
+            )
+        }
+        val decoder = MediaCodec.createDecoderByType(mime)
+        decoder.configure(decoderFormat, null, null, 0)
+        decoder.start()
+
+        val frames = mutableListOf<ByteArray>()
+        val info = MediaCodec.BufferInfo()
+        var inputDone = false
+        var outputDone = false
+
+        extractor.seekTo(startUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+        try {
+            while (!outputDone) {
+                if (!inputDone) {
+                    val inIdx = decoder.dequeueInputBuffer(DECODER_TIMEOUT_US)
+                    if (inIdx >= 0) {
+                        val t = extractor.sampleTime
+                        if (t < 0 || t >= endUs) {
+                            decoder.queueInputBuffer(
+                                inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                            )
+                            inputDone = true
+                        } else {
+                            val buf = decoder.getInputBuffer(inIdx)!!
+                            buf.clear()
+                            val size = extractor.readSampleData(buf, 0)
+                            if (size < 0) {
+                                decoder.queueInputBuffer(
+                                    inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                                )
+                                inputDone = true
+                            } else {
+                                decoder.queueInputBuffer(inIdx, 0, size, t, extractor.sampleFlags)
+                                extractor.advance()
+                            }
+                        }
+                    }
+                }
+
+                val outIdx = decoder.dequeueOutputBuffer(info, DECODER_TIMEOUT_US)
+                when {
+                    outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> {}
+                    outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {}
+                    outIdx >= 0 -> {
+                        if (info.size > 0 && info.presentationTimeUs in startUs until endUs) {
+                            val image = decoder.getOutputImage(outIdx)
+                            if (image != null) {
+                                frames.add(imageToI420(image, width, height))
+                                image.close()
+                            }
+                        }
+                        decoder.releaseOutputBuffer(outIdx, false)
+                        if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                            outputDone = true
+                        }
+                    }
+                }
+            }
+        } finally {
+            try { decoder.stop() } catch (_: Exception) {}
+            try { decoder.release() } catch (_: Exception) {}
+            try { extractor.release() } catch (_: Exception) {}
+        }
+
+        return if (frames.isEmpty()) null else DecodedSegment(frames, width, height)
+    }
+
+    // ---------------------------------------------------------------------
+    // BLENDING
+    // ---------------------------------------------------------------------
+
+    /**
+     * Blends two packed I420 frames [a] (outgoing) and [b] (incoming) according
+     * to the transition [type]/[direction] at eased [p] (0 = fully outgoing,
+     * 1 = fully incoming).
+     */
+    private fun blendFrame(
+        a: ByteArray, b: ByteArray, w: Int, h: Int,
+        p: Double, type: String, direction: String,
+    ): ByteArray {
+        val out = ByteArray(a.size)
+        if (type == "dissolve") {
+            // Linear per-component blend across all three planes.
+            val inv = 1.0 - p
+            for (i in a.indices) {
+                val av = a[i].toInt() and 0xFF
+                val bv = b[i].toInt() and 0xFF
+                out[i] = (av * inv + bv * p).roundToInt().coerceIn(0, 255).toByte()
+            }
+            return out
+        }
+
+        val cw = w / 2
+        val ch = h / 2
+        val ySize = w * h
+        val cSize = cw * ch
+
+        // Y plane.
+        composePlane(a, b, out, 0, w, h, p, type, direction)
+        // U plane.
+        composePlane(a, b, out, ySize, cw, ch, p, type, direction)
+        // V plane.
+        composePlane(a, b, out, ySize + cSize, cw, ch, p, type, direction)
+        return out
+    }
+
+    /**
+     * Composes a single plane for geometric transitions (wipe/slide/push) by
+     * selecting, per output pixel, a source ([a] or [b]) and a source
+     * coordinate.
+     */
+    private fun composePlane(
+        a: ByteArray, b: ByteArray, out: ByteArray, offset: Int,
+        pw: Int, ph: Int, p: Double, type: String, direction: String,
+    ) {
+        val shiftX = (p * pw).roundToInt()
+        val shiftY = (p * ph).roundToInt()
+        for (y in 0 until ph) {
+            for (x in 0 until pw) {
+                val o = offset + y * pw + x
+                var useIncoming = false
+                var sx = x
+                var sy = y
+                when (type) {
+                    "wipe" -> {
+                        useIncoming = when (direction) {
+                            "right" -> x < shiftX
+                            "left" -> x >= pw - shiftX
+                            "down" -> y < shiftY
+                            "up" -> y >= ph - shiftY
+                            else -> x < shiftX
+                        }
+                    }
+                    "slide" -> {
+                        // Incoming slides in over a stationary outgoing.
+                        when (direction) {
+                            "left" -> {
+                                val edge = pw - shiftX
+                                if (x >= edge) { useIncoming = true; sx = x - edge }
+                            }
+                            "right" -> {
+                                if (x < shiftX) { useIncoming = true; sx = x + (pw - shiftX) }
+                            }
+                            "up" -> {
+                                val edge = ph - shiftY
+                                if (y >= edge) { useIncoming = true; sy = y - edge }
+                            }
+                            "down" -> {
+                                if (y < shiftY) { useIncoming = true; sy = y + (ph - shiftY) }
+                            }
+                        }
+                    }
+                    "push" -> {
+                        // Both clips move together.
+                        when (direction) {
+                            "left" -> {
+                                if (x < pw - shiftX) { sx = x + shiftX }
+                                else { useIncoming = true; sx = x - (pw - shiftX) }
+                            }
+                            "right" -> {
+                                if (x >= shiftX) { sx = x - shiftX }
+                                else { useIncoming = true; sx = x + (pw - shiftX) }
+                            }
+                            "up" -> {
+                                if (y < ph - shiftY) { sy = y + shiftY }
+                                else { useIncoming = true; sy = y - (ph - shiftY) }
+                            }
+                            "down" -> {
+                                if (y >= shiftY) { sy = y - shiftY }
+                                else { useIncoming = true; sy = y + (ph - shiftY) }
+                            }
+                        }
+                    }
+                }
+                sx = sx.coerceIn(0, pw - 1)
+                sy = sy.coerceIn(0, ph - 1)
+                val src = if (useIncoming) b else a
+                out[o] = src[offset + sy * pw + sx]
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // I420 <-> Image
+    // ---------------------------------------------------------------------
+
+    /** Converts a decoder [Image] (YUV420 flexible) to a packed I420 array. */
+    private fun imageToI420(image: Image, width: Int, height: Int): ByteArray {
+        val out = ByteArray(width * height * 3 / 2)
+        val cw = width / 2
+        val ch = height / 2
+        readPlane(image.planes[0], out, 0, width, height)
+        readPlane(image.planes[1], out, width * height, cw, ch)
+        readPlane(image.planes[2], out, width * height + cw * ch, cw, ch)
+        return out
+    }
+
+    private fun readPlane(
+        plane: Image.Plane, dst: ByteArray, dstOffset: Int, pw: Int, ph: Int,
+    ) {
+        val buf = plane.buffer
+        val rowStride = plane.rowStride
+        val pixelStride = plane.pixelStride
+        val row = ByteArray(rowStride)
+        for (r in 0 until ph) {
+            val pos = r * rowStride
+            if (pos >= buf.limit()) break
+            buf.position(pos)
+            val toRead = min(rowStride, buf.remaining())
+            buf.get(row, 0, toRead)
+            val base = dstOffset + r * pw
+            if (pixelStride == 1) {
+                System.arraycopy(row, 0, dst, base, min(pw, toRead))
+            } else {
+                var c = 0
+                while (c < pw && c * pixelStride < toRead) {
+                    dst[base + c] = row[c * pixelStride]
+                    c++
+                }
+            }
+        }
+    }
+
+    /** Writes a packed I420 array into an encoder input [Image]. */
+    private fun i420ToImage(src: ByteArray, image: Image, width: Int, height: Int) {
+        val cw = width / 2
+        val ch = height / 2
+        writePlane(src, 0, image.planes[0], width, height)
+        writePlane(src, width * height, image.planes[1], cw, ch)
+        writePlane(src, width * height + cw * ch, image.planes[2], cw, ch)
+    }
+
+    private fun writePlane(
+        src: ByteArray, srcOffset: Int, plane: Image.Plane, pw: Int, ph: Int,
+    ) {
+        val buf = plane.buffer
+        val rowStride = plane.rowStride
+        val pixelStride = plane.pixelStride
+        for (r in 0 until ph) {
+            val pos = r * rowStride
+            if (pos >= buf.limit()) break
+            val base = srcOffset + r * pw
+            if (pixelStride == 1) {
+                buf.position(pos)
+                buf.put(src, base, min(pw, buf.remaining()))
+            } else {
+                val rowLen = min(rowStride, buf.limit() - pos)
+                val rowBytes = ByteArray(rowLen)
+                buf.position(pos)
+                buf.get(rowBytes)
+                var c = 0
+                while (c < pw && c * pixelStride < rowLen) {
+                    rowBytes[c * pixelStride] = src[base + c]
+                    c++
+                }
+                buf.position(pos)
+                buf.put(rowBytes)
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // ENCODER
+    // ---------------------------------------------------------------------
+
+    private fun createEncoder(width: Int, height: Int, frameDurationUs: Long): MediaCodec {
+        val mime = "video/avc"
+        val fps = if (frameDurationUs > 0) {
+            (1_000_000.0 / frameDurationUs).roundToInt().coerceIn(1, 120)
+        } else DEFAULT_FPS
+        val range = avcBitrateRange()
+        val candidates = listOf(width * height * 6, width * height * 4, width * height * 2)
+            .map { if (range != null) it.coerceIn(range.lower, range.upper) else it }
+            .filter { it > 0 }
+            .distinct()
+        var lastError: Exception? = null
+        for (bitrate in candidates) {
+            val format = MediaFormat.createVideoFormat(mime, width, height).apply {
+                setInteger(
+                    MediaFormat.KEY_COLOR_FORMAT,
+                    MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible
+                )
+                setInteger(MediaFormat.KEY_BIT_RATE, bitrate)
+                setInteger(MediaFormat.KEY_FRAME_RATE, fps)
+                setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 1)
+            }
+            val encoder = MediaCodec.createEncoderByType(mime)
+            try {
+                encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+                encoder.start()
+                return encoder
+            } catch (e: Exception) {
+                try { encoder.release() } catch (_: Exception) {}
+                lastError = e
+            }
+        }
+        throw IllegalStateException("Failed to configure transition encoder", lastError)
+    }
+
+    private fun avcBitrateRange(): android.util.Range<Int>? = try {
+        MediaCodecList(MediaCodecList.REGULAR_CODECS)
+            .codecInfos
+            .firstOrNull { it.isEncoder && it.supportedTypes.any { t -> t.equals("video/avc", true) } }
+            ?.getCapabilitiesForType("video/avc")
+            ?.videoCapabilities
+            ?.bitrateRange
+    } catch (_: Exception) {
+        null
+    }
+
+    // ---------------------------------------------------------------------
+    // AUDIO CROSSFADE
+    // ---------------------------------------------------------------------
+
+    private data class AudioPreEncoded(val format: MediaFormat, val packetsFile: File)
+
+    /**
+     * Decodes both segments' audio to PCM, cross-fades them sample-by-sample
+     * (outgoing gain 1→0, incoming gain 0→1, eased), and re-encodes AAC into a
+     * packet file (so it can be muxed after the video track is known).
+     */
+    private fun preEncodeCrossfadeAudio(
+        outgoingPath: String, outStartUs: Long, outEndUs: Long,
+        incomingPath: String, inStartUs: Long, inEndUs: Long,
+        curve: String, workDir: File,
+    ): AudioPreEncoded? {
+        val outPcm = decodePcm(outgoingPath, outStartUs, outEndUs) ?: return null
+        val inPcm = decodePcm(incomingPath, inStartUs, inEndUs) ?: return null
+        if (outPcm.sampleRate != inPcm.sampleRate || outPcm.channelCount != inPcm.channelCount) {
+            Log.w(RENDER_TAG, "Transition audio format mismatch; skipping crossfade")
+            return null
+        }
+
+        val sampleRate = outPcm.sampleRate
+        val channelCount = outPcm.channelCount
+        val frameSize = channelCount * 2
+        val totalFrames = max(outPcm.pcm.size, inPcm.pcm.size) / frameSize
+        if (totalFrames <= 0) return null
+
+        // Mix into a single PCM buffer with an eased gain ramp.
+        val mixed = ByteArray(totalFrames * frameSize)
+        for (f in 0 until totalFrames) {
+            val p = applyEasing(
+                if (totalFrames > 1) f.toDouble() / (totalFrames - 1) else 1.0,
+                curve
+            )
+            val gOut = (1.0 - p)
+            val gIn = p
+            for (c in 0 until channelCount) {
+                val idx = (f * channelCount + c) * 2
+                val aSample = readSample(outPcm.pcm, idx)
+                val bSample = readSample(inPcm.pcm, idx)
+                val mixedSample = (aSample * gOut + bSample * gIn)
+                    .roundToInt().coerceIn(-32768, 32767)
+                mixed[idx] = (mixedSample and 0xFF).toByte()
+                mixed[idx + 1] = ((mixedSample shr 8) and 0xFF).toByte()
+            }
+        }
+
+        return encodeAac(mixed, sampleRate, channelCount, workDir)
+    }
+
+    private fun readSample(pcm: ByteArray, idx: Int): Int {
+        if (idx + 1 >= pcm.size) return 0
+        val lo = pcm[idx].toInt() and 0xFF
+        val hi = pcm[idx + 1].toInt()
+        return (hi shl 8) or lo
+    }
+
+    private class DecodedPcm(val pcm: ByteArray, val sampleRate: Int, val channelCount: Int)
+
+    private fun decodePcm(path: String, startUs: Long, endUs: Long): DecodedPcm? {
+        val extractor = MediaExtractor().apply { setDataSource(path) }
+        val trackIndex = findTrack(extractor, "audio/") ?: run {
+            extractor.release(); return null
+        }
+        extractor.selectTrack(trackIndex)
+        val format = extractor.getTrackFormat(trackIndex)
+        val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        val mime = format.getString(MediaFormat.KEY_MIME) ?: run {
+            extractor.release(); return null
+        }
+        val decoder = MediaCodec.createDecoderByType(mime)
+        decoder.configure(format, null, null, 0)
+        decoder.start()
+
+        val out = java.io.ByteArrayOutputStream()
+        val info = MediaCodec.BufferInfo()
+        var inputDone = false
+        var outputDone = false
+        extractor.seekTo(startUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+        try {
+            while (!outputDone) {
+                if (!inputDone) {
+                    val inIdx = decoder.dequeueInputBuffer(DECODER_TIMEOUT_US)
+                    if (inIdx >= 0) {
+                        val t = extractor.sampleTime
+                        if (t < 0 || t >= endUs) {
+                            decoder.queueInputBuffer(inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                            inputDone = true
+                        } else {
+                            val buf = decoder.getInputBuffer(inIdx)!!
+                            buf.clear()
+                            val size = extractor.readSampleData(buf, 0)
+                            if (size < 0) {
+                                decoder.queueInputBuffer(inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                                inputDone = true
+                            } else {
+                                decoder.queueInputBuffer(inIdx, 0, size, t, 0)
+                                extractor.advance()
+                            }
+                        }
+                    }
+                }
+                val outIdx = decoder.dequeueOutputBuffer(info, DECODER_TIMEOUT_US)
+                when {
+                    outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> {}
+                    outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {}
+                    outIdx >= 0 -> {
+                        if (info.size > 0 && info.presentationTimeUs in startUs until endUs) {
+                            val buf = decoder.getOutputBuffer(outIdx)!!
+                            buf.position(info.offset)
+                            buf.limit(info.offset + info.size)
+                            val tmp = ByteArray(info.size)
+                            buf.get(tmp)
+                            out.write(tmp)
+                        }
+                        decoder.releaseOutputBuffer(outIdx, false)
+                        if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) outputDone = true
+                    }
+                }
+            }
+        } finally {
+            try { decoder.stop() } catch (_: Exception) {}
+            try { decoder.release() } catch (_: Exception) {}
+            try { extractor.release() } catch (_: Exception) {}
+        }
+        val pcm = out.toByteArray()
+        return if (pcm.isEmpty()) null else DecodedPcm(pcm, sampleRate, channelCount)
+    }
+
+    private fun encodeAac(
+        pcm: ByteArray, sampleRate: Int, channelCount: Int, workDir: File,
+    ): AudioPreEncoded? {
+        val mime = "audio/mp4a-latm"
+        val format = MediaFormat.createAudioFormat(mime, sampleRate, channelCount).apply {
+            setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+            setInteger(MediaFormat.KEY_BIT_RATE, 128_000)
+            setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 16384)
+        }
+        val encoder = MediaCodec.createEncoderByType(mime)
+        encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        encoder.start()
+
+        val packetsFile = File(workDir, "transition_audio_packets.bin")
+        val packetsOut = DataOutputStream(packetsFile.outputStream().buffered())
+        var capturedFormat: MediaFormat? = null
+        val info = MediaCodec.BufferInfo()
+        val frameSize = channelCount * 2
+        val sampleDurationUs = 1_000_000L / sampleRate
+
+        fun drain(eos: Boolean) {
+            while (true) {
+                val idx = encoder.dequeueOutputBuffer(info, ENCODER_TIMEOUT_US)
+                when {
+                    idx == MediaCodec.INFO_TRY_AGAIN_LATER -> if (!eos) return
+                    idx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> capturedFormat = encoder.outputFormat
+                    idx >= 0 -> {
+                        val outBuf = encoder.getOutputBuffer(idx)!!
+                        val isConfig = (info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0
+                        if (!isConfig && info.size > 0) {
+                            outBuf.position(info.offset)
+                            outBuf.limit(info.offset + info.size)
+                            val bytes = ByteArray(info.size)
+                            outBuf.get(bytes)
+                            packetsOut.writeInt(info.size)
+                            packetsOut.writeLong(info.presentationTimeUs)
+                            packetsOut.writeInt(info.flags)
+                            packetsOut.write(bytes)
+                        }
+                        encoder.releaseOutputBuffer(idx, false)
+                        if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) return
+                    }
+                }
+            }
+        }
+
+        try {
+            var offset = 0
+            var framePos = 0L
+            while (offset < pcm.size) {
+                val inIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                if (inIdx < 0) { drain(false); continue }
+                val buf = encoder.getInputBuffer(inIdx)!!
+                buf.clear()
+                val toWrite = min(buf.capacity(), pcm.size - offset)
+                val aligned = (toWrite / frameSize) * frameSize
+                if (aligned == 0) { encoder.queueInputBuffer(inIdx, 0, 0, 0, 0); break }
+                buf.put(pcm, offset, aligned)
+                encoder.queueInputBuffer(inIdx, 0, aligned, framePos * sampleDurationUs, 0)
+                framePos += aligned / frameSize
+                offset += aligned
+                drain(false)
+            }
+            while (true) {
+                val inIdx = encoder.dequeueInputBuffer(ENCODER_TIMEOUT_US)
+                if (inIdx >= 0) {
+                    encoder.queueInputBuffer(
+                        inIdx, 0, 0, framePos * sampleDurationUs,
+                        MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                    )
+                    break
+                }
+                drain(false)
+            }
+            drain(true)
+        } finally {
+            try { encoder.stop() } catch (_: Exception) {}
+            try { encoder.release() } catch (_: Exception) {}
+            try { packetsOut.close() } catch (_: Exception) {}
+        }
+
+        val fmt = capturedFormat
+        if (fmt == null || packetsFile.length() == 0L) {
+            packetsFile.delete()
+            return null
+        }
+        return AudioPreEncoded(fmt, packetsFile)
+    }
+
+    private fun writeBufferedAudio(muxer: MediaMuxer, audioTrackIndex: Int, packets: File) {
+        val info = MediaCodec.BufferInfo()
+        DataInputStream(packets.inputStream().buffered()).use { input ->
+            while (true) {
+                val size = try { input.readInt() } catch (_: Exception) { break }
+                val ptsUs = input.readLong()
+                val flags = input.readInt()
+                val bytes = ByteArray(size)
+                input.readFully(bytes)
+                val buf = ByteBuffer.allocate(size).apply { put(bytes); flip() }
+                info.set(0, size, ptsUs, flags)
+                muxer.writeSampleData(audioTrackIndex, buf, info)
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // SHARED
+    // ---------------------------------------------------------------------
+
+    private fun findTrack(extractor: MediaExtractor, mimePrefix: String): Int? {
+        for (i in 0 until extractor.trackCount) {
+            val mime = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME) ?: continue
+            if (mime.startsWith(mimePrefix)) return i
+        }
+        return null
+    }
+}

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.audio.ChannelMixingAudioProcessor
 import androidx.media3.common.audio.ChannelMixingMatrix
 import androidx.media3.common.audio.SonicAudioProcessor
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.effect.OverlayEffect
 import androidx.media3.effect.SpeedChangeEffect
 import androidx.media3.transformer.EditedMediaItem
 import androidx.media3.transformer.EditedMediaItemSequence
@@ -275,9 +276,12 @@ class VideoSequenceBuilder(
             audioEffects.toList()
         }
 
+        // Compute per-clip fade-to-black windows from clip transitions.
+        val fadeInfos = computeFadeInfos(timelineClips)
+
         // Build EditedMediaItems for each clip
         val editedMediaItems = timelineClips.mapIndexed { index, clip ->
-            buildEditedMediaItem(index, clip, normalizedAudioEffects)
+            buildEditedMediaItem(index, clip, normalizedAudioEffects, fadeInfos[index])
         }
 
         Log.d(RENDER_TAG, "Total EditedMediaItems created: ${editedMediaItems.size}")
@@ -396,12 +400,102 @@ class VideoSequenceBuilder(
     }
 
     /**
+     * Per-clip dip (fade-to-black / fade-to-white) windows, expressed in
+     * output-local time.
+     *
+     * @property clipDurationUs Output duration of the clip (after per-clip speed)
+     * @property fadeInUs Fade-in-from-color window at the clip's head (0 = none)
+     * @property fadeOutUs Fade-out-to-color window at the clip's tail (0 = none)
+     * @property curve Easing curve for the fade
+     * @property dipColor ARGB color the clip dips to/from
+     */
+    private data class ClipFadeInfo(
+        val clipDurationUs: Long,
+        val fadeInUs: Long,
+        val fadeOutUs: Long,
+        val curve: String,
+        val dipColor: Int
+    )
+
+    /** Returns the dip color for a "fadeTo*" transition, or null otherwise. */
+    private fun dipColorFor(transition: ch.waio.pro_video_editor.src.features
+        .render.models.TransitionConfig?): Int? = when (transition?.type) {
+        "fadeToBlack" -> android.graphics.Color.BLACK
+        "fadeToWhite" -> android.graphics.Color.WHITE
+        else -> null
+    }
+
+    /**
+     * Source duration of a clip after trimming (microseconds).
+     */
+    private fun clipSourceDurationUs(clip: VideoClip): Long {
+        return when {
+            clip.endUs != null && clip.startUs != null -> clip.endUs - clip.startUs
+            clip.endUs != null -> clip.endUs
+            else -> MediaInfoExtractor.getVideoDuration(clip.inputPath)
+        }.coerceAtLeast(0L)
+    }
+
+    /**
+     * Output duration of a clip after per-clip playback speed (microseconds).
+     */
+    private fun clipOutputDurationUs(clip: VideoClip): Long {
+        val src = clipSourceDurationUs(clip)
+        val speed = clip.playbackSpeed?.takeIf { it > 0f } ?: 1.0f
+        return (src / speed).toLong()
+    }
+
+    /**
+     * Computes dip (fade-to-black / fade-to-white) windows for each timeline
+     * clip.
+     *
+     * A `fadeToBlack`/`fadeToWhite` transition on clip *i* dips the boundary
+     * between clip *i* and *i+1*: clip *i* fades out to the color over its last
+     * `duration/2`, and clip *i+1* fades in from the color over its first
+     * `duration/2`. Overlap transitions (dissolve/slide/push/wipe) are handled
+     * separately by [ClipTransitionRenderer] and never reach this method.
+     */
+    private fun computeFadeInfos(clips: List<VideoClip>): List<ClipFadeInfo?> {
+        return clips.indices.map { i ->
+            val clip = clips[i]
+            val prev = clips.getOrNull(i - 1)
+
+            val outgoingColor = dipColorFor(clip.transition)
+            val incomingColor = dipColorFor(prev?.transition)
+
+            val outgoingUs = if (outgoingColor != null) clip.transition!!.durationUs else 0L
+            val incomingUs = if (incomingColor != null) prev!!.transition!!.durationUs else 0L
+
+            if (outgoingColor == null && incomingColor == null) {
+                null
+            } else {
+                val outDur = clipOutputDurationUs(clip)
+                // When a clip both ends and starts with a dip, the outgoing
+                // (this clip's) transition wins for color/curve.
+                val curve = if (outgoingColor != null) {
+                    clip.transition!!.curve
+                } else {
+                    prev!!.transition!!.curve
+                }
+                ClipFadeInfo(
+                    clipDurationUs = outDur,
+                    fadeInUs = (incomingUs / 2).coerceAtMost(outDur),
+                    fadeOutUs = (outgoingUs / 2).coerceAtMost(outDur),
+                    curve = curve,
+                    dipColor = outgoingColor ?: incomingColor!!
+                )
+            }
+        }
+    }
+
+    /**
      * Builds an EditedMediaItem for a single video clip with all effects.
      */
     private fun buildEditedMediaItem(
         index: Int,
         clip: VideoClip,
-        normalizedAudioEffects: List<AudioProcessor>
+        normalizedAudioEffects: List<AudioProcessor>,
+        fadeInfo: ClipFadeInfo?
     ): EditedMediaItem {
         Log.d(RENDER_TAG, "Processing clip $index: ${clip.inputPath}")
         val inputFile = File(clip.inputPath)
@@ -541,6 +635,36 @@ class VideoSequenceBuilder(
             perClipAudioProcessors
         }
 
+        // Attach the dip (fade-to-black/white) overlay LAST so the entire
+        // composed frame — including any image-layer overlays — dips to the
+        // transition color at the clip boundary. The overlay is added after
+        // scale, so size the solid-color bitmap to cover the post-scale frame
+        // (centered, oversized overflow is clipped by Media3).
+        fadeInfo?.let { info ->
+            val sx = scaleX ?: 1f
+            val sy = scaleY ?: 1f
+            val dipW = maxOf(videoWidth, (videoWidth * sx).toInt())
+            val dipH = maxOf(videoHeight, (videoHeight * sy).toInt())
+            clipVideoEffects += OverlayEffect(
+                listOf(
+                    ClipFadeOverlay(
+                        videoWidth = dipW,
+                        videoHeight = dipH,
+                        dipColor = info.dipColor,
+                        clipDurationUs = info.clipDurationUs,
+                        fadeInUs = info.fadeInUs,
+                        fadeOutUs = info.fadeOutUs,
+                        curve = info.curve,
+                    )
+                )
+            )
+            Log.d(
+                RENDER_TAG,
+                "Clip $index dip transition: fadeInUs=${info.fadeInUs}, " +
+                        "fadeOutUs=${info.fadeOutUs}, color=${info.dipColor}"
+            )
+        }
+
         val effects = Effects(finalAudioEffects, clipVideoEffects)
 
         // Determine if audio should be removed
@@ -660,13 +784,9 @@ class VideoSequenceBuilder(
                 // Only add if there's still content left
                 if (newEndInSource > newStartInSource) {
                     result.add(
-                        VideoClip(
-                            inputPath = clip.inputPath,
+                        clip.copy(
                             startUs = newStartInSource,
-                            endUs = newEndInSource,
-                            volume = clip.volume,
-                            playbackSpeed = clip.playbackSpeed,
-                            reverseVideo = clip.reverseVideo
+                            endUs = newEndInSource
                         )
                     )
                     val trimmedDuration = newEndInSource - newStartInSource
@@ -742,12 +862,10 @@ class VideoSequenceBuilder(
                 )
                 temporaryFiles.add(java.io.File(reversed.outputPath))
                 result.add(
-                    VideoClip(
+                    clip.copy(
                         inputPath = reversed.outputPath,
                         startUs = 0L,
                         endUs = reversed.durationUs.takeIf { it > 0 },
-                        volume = clip.volume,
-                        playbackSpeed = clip.playbackSpeed,
                         reverseVideo = false
                     )
                 )

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -5,14 +5,48 @@ import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
 import io.flutter.plugin.common.MethodCall
 
 /**
+ * Represents the transition played between a clip and the next one.
+ *
+ * @property type Transition kind: "dissolve", "fadeToBlack", "fadeToWhite",
+ *  "slide", "push" or "wipe"
+ * @property durationUs Transition duration in microseconds
+ * @property curve Easing curve name (e.g. "linear", "easeInOut")
+ * @property direction Direction for directional transitions: "left", "right",
+ *  "up" or "down"
+ */
+data class TransitionConfig(
+    val type: String,
+    val durationUs: Long,
+    val curve: String = "linear",
+    val direction: String = "left"
+) {
+    /** True when this transition overlaps and blends the two clips. */
+    val isOverlap: Boolean
+        get() = type == "dissolve" || type == "slide" || type == "push" ||
+                type == "wipe"
+
+    companion object {
+        fun fromMap(map: Map<String, Any?>): TransitionConfig {
+            return TransitionConfig(
+                type = map["type"] as String,
+                durationUs = (map["durationUs"] as Number).toLong(),
+                curve = map["curve"] as? String ?: "linear",
+                direction = map["direction"] as? String ?: "left"
+            )
+        }
+    }
+}
+
+/**
  * Represents a video clip segment with optional trimming.
- * 
+ *
  * @property inputPath Absolute path to video file
  * @property startUs Start time in microseconds (null = from beginning)
  * @property endUs End time in microseconds (null = until end)
  * @property volume Volume multiplier for this clip (null = unchanged, 0.0=mute, 1.0=original)
  * @property playbackSpeed Speed multiplier for this clip (null = unchanged, 0.5=half, 2.0=double)
  * @property reverseVideo Whether to render this clip backwards
+ * @property transition Transition into the next clip (null = hard cut). Ignored on the last clip.
  */
 data class VideoClip(
     val inputPath: String,
@@ -20,7 +54,8 @@ data class VideoClip(
     val endUs: Long?,
     val volume: Float? = null,
     val playbackSpeed: Float? = null,
-    val reverseVideo: Boolean = false
+    val reverseVideo: Boolean = false,
+    val transition: TransitionConfig? = null
 )
 
 /**
@@ -231,17 +266,20 @@ data class RenderConfig(
             }
 
             val videoClips: List<VideoClip> = videoClipsRaw.mapIndexed { index, clipMap ->
+                @Suppress("UNCHECKED_CAST")
+                val transitionRaw = clipMap["transition"] as? Map<String, Any?>
                 val clip = VideoClip(
                     inputPath = clipMap["inputPath"] as String,
                     startUs = (clipMap["startUs"] as? Number)?.toLong(),
                     endUs = (clipMap["endUs"] as? Number)?.toLong(),
                     volume = (clipMap["volume"] as? Number)?.toFloat(),
                     playbackSpeed = (clipMap["playbackSpeed"] as? Number)?.toFloat(),
-                    reverseVideo = clipMap["reverseVideo"] as? Boolean ?: false
+                    reverseVideo = clipMap["reverseVideo"] as? Boolean ?: false,
+                    transition = transitionRaw?.let { TransitionConfig.fromMap(it) }
                 )
                 Log.d(
                     PACKAGE_TAG,
-                    "Clip $index: path=${clip.inputPath}, start=${clip.startUs}, end=${clip.endUs}, volume=${clip.volume}, speed=${clip.playbackSpeed}, reverse=${clip.reverseVideo}"
+                    "Clip $index: path=${clip.inputPath}, start=${clip.startUs}, end=${clip.endUs}, volume=${clip.volume}, speed=${clip.playbackSpeed}, reverse=${clip.reverseVideo}, transition=${clip.transition?.type}"
                 )
                 clip
             }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
@@ -69,7 +69,8 @@ class RenderVideo {
                 endUs: clip.endUs,
                 volume: clip.volume,
                 playbackSpeed: clip.playbackSpeed,
-                reverseVideo: clip.reverseVideo
+                reverseVideo: clip.reverseVideo,
+                transition: clip.transition
               )
             }
             return clip
@@ -81,6 +82,7 @@ class RenderVideo {
 
         var outputURL: URL!
         var temporaryAudioURLs: [URL] = []
+        var transitionURLs: [URL] = []
 
         let finalize: () -> Void = {
           try? cleanup(config.outputPath == nil ? [outputURL] : [])
@@ -91,6 +93,11 @@ class RenderVideo {
             try? FileManager.default.removeItem(at: url)
             PluginLog.print("🧹 Removed pre-rendered audio: \(url.lastPathComponent)")
           }
+          // Clean up pre-rendered overlap transition clips
+          for url in transitionURLs {
+            try? FileManager.default.removeItem(at: url)
+            PluginLog.print("🧹 Removed transition clip: \(url.lastPathComponent)")
+          }
         }
 
         let handleCompletion: (Result<Data?, Error>) -> Void = { result in
@@ -99,6 +106,20 @@ class RenderVideo {
           case .failure(let error): onError(error)
           }
           finalize()
+        }
+
+        // Pre-render overlap clip transitions (dissolve/slide/push/wipe) into
+        // short blended clips spliced between the neighbours, so the main
+        // composition still sees plain forward clips.
+        if workingConfig.videoClips.count > 1,
+          workingConfig.videoClips.contains(where: { $0.transition?.isOverlap == true })
+        {
+          let (newClips, urls) = await preRenderTransitions(
+            clips: workingConfig.videoClips,
+            enableAudio: workingConfig.enableAudio,
+            outputFormat: workingConfig.outputFormat)
+          workingConfig = workingConfig.copyWith(videoClips: newClips)
+          transitionURLs = urls
         }
 
         do {
@@ -139,7 +160,10 @@ class RenderVideo {
           var effectsConfig = VideoCompositorConfig()
 
           // Use composition helper to merge multiple video clips
-          let (composition, videoCompData, renderSize, audioMix, sourceTrackID, audioTempURLs) =
+          let (
+            composition, videoCompData, renderSize, audioMix, sourceTrackID, audioTempURLs,
+            fadeWindows
+          ) =
             try await applyComposition(
               videoClips: workingConfig.videoClips,
               videoEffects: effectsConfig,
@@ -151,6 +175,9 @@ class RenderVideo {
 
           // Set source track ID for fallback on older platform variations
           effectsConfig.sourceTrackID = sourceTrackID
+
+          // Dip-to-color (fade-to-black / fade-to-white) clip transitions.
+          effectsConfig.fadeWindows = fadeWindows
 
           // Apply playback speed to the entire composition
           videoCompConfig.instructions = applyPlaybackSpeed(
@@ -301,6 +328,124 @@ class RenderVideo {
   private static func temporaryURL(for format: String) -> URL {
     let filename = uniqueFilename(prefix: "output", extension: format)
     return FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+  }
+
+  // MARK: - Overlap transition pre-render
+
+  /// Pre-renders overlap transitions (dissolve/slide/push/wipe) into short
+  /// blended clips and rewrites the clip list, mirroring the Android pipeline.
+  ///
+  /// For a transition between clip *i* and *i+1*, clip *i* is shortened by the
+  /// (clamped) transition duration `d`, the blended clip (`d`) is inserted, and
+  /// clip *i+1*'s head is trimmed by `d`. Net timeline change: `-d` per
+  /// transition. Falls back to a hard cut when a transition cannot be rendered
+  /// (e.g. a neighbour is reversed, has per-clip speed, or has too little
+  /// content) — those cases are handled live by the main pipeline.
+  private static func preRenderTransitions(
+    clips: [VideoClip], enableAudio: Bool, outputFormat: String
+  ) async -> ([VideoClip], [URL]) {
+    var work = clips
+    var result: [VideoClip] = []
+    var urls: [URL] = []
+    var i = 0
+
+    while i < work.count {
+      let current = work[i]
+      let next: VideoClip? = (i + 1 < work.count) ? work[i + 1] : nil
+      let t = current.transition
+
+      let canOverlap =
+        next != nil && (t?.isOverlap ?? false)
+        && !current.reverseVideo && !(next!.reverseVideo)
+        && (current.playbackSpeed == nil || current.playbackSpeed == 1.0)
+        && (next!.playbackSpeed == nil || next!.playbackSpeed == 1.0)
+
+      if !canOverlap {
+        result.append(clearedOverlap(current))
+        i += 1
+        continue
+      }
+
+      let curStart = current.startUs ?? 0
+      let curEnd: Int64
+      if let e = current.endUs {
+        curEnd = e
+      } else {
+        curEnd = await clipDurationUs(current.inputPath)
+      }
+      let nextStart = next!.startUs ?? 0
+      let nextEnd: Int64
+      if let e = next!.endUs {
+        nextEnd = e
+      } else {
+        nextEnd = await clipDurationUs(next!.inputPath)
+      }
+      let curDur = curEnd - curStart
+      let nextDur = nextEnd - nextStart
+      let d = min(t!.durationUs, min(curDur, nextDur))
+
+      if d <= 0 || curDur - d <= 0 || nextDur - d <= 0 {
+        PluginLog.print("⚠️ Transition: not enough content at boundary \(i); hard cut")
+        result.append(clearedOverlap(current))
+        i += 1
+        continue
+      }
+
+      let includeAudio =
+        enableAudio && (current.volume ?? 1.0) > 0 && (next!.volume ?? 1.0) > 0
+      let rendered = await ClipTransitionRenderer.render(
+        outgoingPath: current.inputPath,
+        outTailStartUs: curEnd - d, outTailEndUs: curEnd,
+        incomingPath: next!.inputPath,
+        inHeadStartUs: nextStart, inHeadEndUs: nextStart + d,
+        type: t!.type, direction: t!.direction, curve: t!.curve,
+        includeAudio: includeAudio, outputFormat: outputFormat)
+
+      if let rendered = rendered {
+        urls.append(rendered.outputURL)
+        result.append(
+          VideoClip(
+            inputPath: current.inputPath, startUs: curStart, endUs: curEnd - d,
+            volume: current.volume, playbackSpeed: current.playbackSpeed,
+            reverseVideo: false, transition: nil))
+        result.append(
+          VideoClip(
+            inputPath: rendered.outputURL.path, startUs: 0, endUs: rendered.durationUs))
+        // Trim the incoming head in place; it keeps its own transition.
+        work[i + 1] = VideoClip(
+          inputPath: next!.inputPath, startUs: nextStart + d, endUs: nextEnd,
+          volume: next!.volume, playbackSpeed: next!.playbackSpeed,
+          reverseVideo: next!.reverseVideo, transition: next!.transition)
+      } else {
+        PluginLog.print("⚠️ Transition render failed at boundary \(i); hard cut")
+        result.append(clearedOverlap(current))
+      }
+      i += 1
+    }
+
+    return (result, urls)
+  }
+
+  /// Clears an overlap transition (already consumed / unsupported) so it is not
+  /// reinterpreted downstream; dip transitions are left untouched.
+  private static func clearedOverlap(_ clip: VideoClip) -> VideoClip {
+    guard clip.transition?.isOverlap == true else { return clip }
+    return VideoClip(
+      inputPath: clip.inputPath, startUs: clip.startUs, endUs: clip.endUs,
+      volume: clip.volume, playbackSpeed: clip.playbackSpeed,
+      reverseVideo: clip.reverseVideo, transition: nil)
+  }
+
+  /// Loads a clip's total duration in microseconds.
+  private static func clipDurationUs(_ path: String) async -> Int64 {
+    let asset = AVURLAsset(url: URL(fileURLWithPath: path))
+    let dur: CMTime
+    if #available(iOS 15.0, macOS 13.0, *) {
+      dur = (try? await asset.load(.duration)) ?? .zero
+    } else {
+      dur = asset.duration
+    }
+    return Int64(CMTimeGetSeconds(dur) * 1_000_000)
   }
 
   private static func loadVideoTrack(from asset: AVAsset) async throws -> AVAssetTrack {

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ApplyComposition.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ApplyComposition.swift
@@ -20,6 +20,7 @@ import Foundation
 ///   - AVAudioMix?: Audio mix with volume controls (nil if no audio mixing needed)
 ///   - CMPersistentTrackID: The track ID of the video composition track (for fallback on older iOS)
 ///   - [URL]: Temporary file URLs (e.g. pre-rendered audio WAVs) the caller MUST delete after export
+///   - [FadeWindow]: Dip-to-color windows for fadeToBlack / fadeToWhite transitions
 ///
 /// - Throws: NSError if video clips are empty, files don't exist, or tracks can't be loaded.
 func applyComposition(
@@ -28,7 +29,8 @@ func applyComposition(
   enableAudio: Bool,
   audioTracks: [AudioTrackConfig]
 ) async throws -> (
-  AVMutableComposition, VideoCompositionData, CGSize, AVAudioMix?, CMPersistentTrackID, [URL]
+  AVMutableComposition, VideoCompositionData, CGSize, AVAudioMix?, CMPersistentTrackID, [URL],
+  [FadeWindow]
 ) {
   return try await CompositionBuilder(videoClips: videoClips, videoEffects: videoEffects)
     .setEnableAudio(enableAudio)

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ClipTransitionRenderer.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ClipTransitionRenderer.swift
@@ -1,0 +1,350 @@
+import AVFoundation
+import CoreGraphics
+import Foundation
+
+/// Pre-renders an **overlap** clip transition (dissolve / slide / push / wipe)
+/// into a single short clip that the main render pipeline consumes as an
+/// ordinary forward clip.
+///
+/// It builds a tiny two-track `AVMutableComposition` (outgoing tail on track A,
+/// incoming head on track B, fully overlapping for the transition duration) and
+/// drives the transition with native `AVMutableVideoCompositionLayerInstruction`
+/// ramps:
+/// - **dissolve** → opacity ramp on the top layer,
+/// - **slide** → transform ramp on the incoming layer,
+/// - **push** → transform ramps on both layers,
+/// - **wipe** → crop-rectangle ramp on the incoming layer.
+///
+/// The ramps are applied piecewise so the requested easing [curve] is honored.
+/// Audio is cross-faded via an `AVMutableAudioMix`. The result is exported with
+/// `AVAssetExportSession`.
+///
+/// Mirrors the Android `ClipTransitionRenderer` pre-render strategy and keeps
+/// the main composition pipeline single-track. Returns `nil` on failure so the
+/// caller can fall back to a hard cut.
+internal enum ClipTransitionRenderer {
+
+  /// Number of piecewise steps used to approximate an easing curve in the
+  /// linear AVFoundation ramps.
+  private static let easingSteps = 30
+
+  struct RenderResult {
+    let outputURL: URL
+    let durationUs: Int64
+  }
+
+  static func render(
+    outgoingPath: String,
+    outTailStartUs: Int64,
+    outTailEndUs: Int64,
+    incomingPath: String,
+    inHeadStartUs: Int64,
+    inHeadEndUs: Int64,
+    type: String,
+    direction: String,
+    curve: String,
+    includeAudio: Bool,
+    outputFormat: String
+  ) async -> RenderResult? {
+    do {
+      let outAsset = AVURLAsset(url: URL(fileURLWithPath: outgoingPath))
+      let inAsset = AVURLAsset(url: URL(fileURLWithPath: incomingPath))
+
+      let outVideo = try await MediaInfoExtractor.loadVideoTrack(from: outAsset)
+      let inVideo = try await MediaInfoExtractor.loadVideoTrack(from: inAsset)
+
+      let dUs = max(outTailEndUs - outTailStartUs, inHeadEndUs - inHeadStartUs)
+      guard dUs > 0 else { return nil }
+      let d = CMTime(value: dUs, timescale: 1_000_000)
+
+      let composition = AVMutableComposition()
+      guard
+        let trackA = composition.addMutableTrack(
+          withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid),
+        let trackB = composition.addMutableTrack(
+          withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+      else { return nil }
+
+      let outStart = CMTime(value: outTailStartUs, timescale: 1_000_000)
+      let inStart = CMTime(value: inHeadStartUs, timescale: 1_000_000)
+      try trackA.insertTimeRange(
+        CMTimeRange(start: outStart, duration: d), of: outVideo, at: .zero)
+      try trackB.insertTimeRange(
+        CMTimeRange(start: inStart, duration: d), of: inVideo, at: .zero)
+
+      let transformA = try await loadPreferredTransform(outVideo)
+      let transformB = try await loadPreferredTransform(inVideo)
+      let naturalA = try await loadNaturalSize(outVideo)
+      let naturalB = try await loadNaturalSize(inVideo)
+
+      let displayA = naturalA.applying(transformA)
+      let renderSize = CGSize(width: abs(displayA.width), height: abs(displayA.height))
+
+      // Optional cross-faded audio.
+      var audioMix: AVMutableAudioMix?
+      if includeAudio {
+        audioMix = try await buildAudioMix(
+          composition: composition,
+          outAsset: outAsset, outStart: outStart,
+          inAsset: inAsset, inStart: inStart,
+          duration: d, curve: curve)
+      }
+
+      // Build the layer instructions with eased ramps.
+      let layerA = AVMutableVideoCompositionLayerInstruction(assetTrack: trackA)
+      let layerB = AVMutableVideoCompositionLayerInstruction(assetTrack: trackB)
+      layerA.setTransform(transformA, at: .zero)
+      layerB.setTransform(transformB, at: .zero)
+
+      applyRamps(
+        type: type, direction: direction, curve: curve,
+        layerA: layerA, layerB: layerB,
+        transformA: transformA, transformB: transformB,
+        renderSize: renderSize, naturalB: naturalB, duration: d)
+
+      let instruction = AVMutableVideoCompositionInstruction()
+      instruction.timeRange = CMTimeRange(start: .zero, duration: d)
+      // First layer instruction is composited on top.
+      instruction.layerInstructions = orderedLayers(
+        type: type, layerA: layerA, layerB: layerB)
+
+      let videoComposition = AVMutableVideoComposition()
+      videoComposition.renderSize = renderSize
+      let fps = try await loadFrameRate(outVideo)
+      videoComposition.frameDuration = CMTime(
+        value: 1, timescale: CMTimeScale(max(1, Int(fps.rounded()))))
+      videoComposition.instructions = [instruction]
+
+      // Export.
+      let outputURL = temporaryURL(for: outputFormat)
+      guard
+        let export = AVAssetExportSession(
+          asset: composition, presetName: AVAssetExportPresetHighestQuality)
+      else { return nil }
+      export.outputURL = outputURL
+      export.outputFileType = (outputFormat.lowercased() == "mov") ? .mov : .mp4
+      export.videoComposition = videoComposition
+      if let audioMix = audioMix {
+        export.audioMix = audioMix
+      }
+      export.shouldOptimizeForNetworkUse = false
+
+      try await runExport(export)
+
+      PluginLog.print(
+        "🎞️ Transition pre-render done (\(type)/\(direction)): "
+          + "\(outputURL.lastPathComponent), \(dUs / 1000)ms")
+      return RenderResult(outputURL: outputURL, durationUs: dUs)
+    } catch {
+      PluginLog.print("⚠️ Transition pre-render failed (\(type)): \(error)")
+      return nil
+    }
+  }
+
+  // MARK: - Ramps
+
+  private static func orderedLayers(
+    type: String,
+    layerA: AVMutableVideoCompositionLayerInstruction,
+    layerB: AVMutableVideoCompositionLayerInstruction
+  ) -> [AVMutableVideoCompositionLayerInstruction] {
+    switch type {
+    case "dissolve":
+      // Outgoing (A) on top, fading out to reveal incoming (B) behind.
+      return [layerA, layerB]
+    default:
+      // Incoming (B) on top (slides/wipes/pushes in over A).
+      return [layerB, layerA]
+    }
+  }
+
+  private static func applyRamps(
+    type: String, direction: String, curve: String,
+    layerA: AVMutableVideoCompositionLayerInstruction,
+    layerB: AVMutableVideoCompositionLayerInstruction,
+    transformA: CGAffineTransform, transformB: CGAffineTransform,
+    renderSize: CGSize, naturalB: CGSize, duration d: CMTime
+  ) {
+    let steps = easingSteps
+    for k in 0..<steps {
+      let f0 = Double(k) / Double(steps)
+      let f1 = Double(k + 1) / Double(steps)
+      let p0 = applyEasing(f0, curve: curve)
+      let p1 = applyEasing(f1, curve: curve)
+      let subRange = CMTimeRange(
+        start: CMTimeMultiplyByFloat64(d, multiplier: f0),
+        duration: CMTimeMultiplyByFloat64(d, multiplier: f1 - f0))
+
+      switch type {
+      case "dissolve":
+        layerA.setOpacityRamp(
+          fromStartOpacity: Float(1.0 - p0),
+          toEndOpacity: Float(1.0 - p1),
+          timeRange: subRange)
+      case "slide":
+        layerB.setTransformRamp(
+          fromStart: incomingTransform(transformB, direction, renderSize, p0),
+          toEnd: incomingTransform(transformB, direction, renderSize, p1),
+          timeRange: subRange)
+      case "push":
+        layerB.setTransformRamp(
+          fromStart: incomingTransform(transformB, direction, renderSize, p0),
+          toEnd: incomingTransform(transformB, direction, renderSize, p1),
+          timeRange: subRange)
+        layerA.setTransformRamp(
+          fromStart: outgoingTransform(transformA, direction, renderSize, p0),
+          toEnd: outgoingTransform(transformA, direction, renderSize, p1),
+          timeRange: subRange)
+      case "wipe":
+        layerB.setCropRectangleRamp(
+          fromStartCropRectangle: wipeCrop(naturalB, direction, p0),
+          toEndCropRectangle: wipeCrop(naturalB, direction, p1),
+          timeRange: subRange)
+      default:
+        break
+      }
+    }
+  }
+
+  /// Translation (in render space) applied to the incoming clip at progress [p].
+  private static func incomingTransform(
+    _ base: CGAffineTransform, _ direction: String, _ size: CGSize, _ p: Double
+  ) -> CGAffineTransform {
+    let inv = CGFloat(1.0 - p)
+    var tx: CGFloat = 0
+    var ty: CGFloat = 0
+    switch direction {
+    case "left": tx = size.width * inv  // enters from the right
+    case "right": tx = -size.width * inv  // enters from the left
+    case "up": ty = size.height * inv  // enters from the bottom
+    case "down": ty = -size.height * inv  // enters from the top
+    default: tx = size.width * inv
+    }
+    return base.concatenating(CGAffineTransform(translationX: tx, y: ty))
+  }
+
+  /// Translation (in render space) applied to the outgoing clip at progress [p].
+  private static func outgoingTransform(
+    _ base: CGAffineTransform, _ direction: String, _ size: CGSize, _ p: Double
+  ) -> CGAffineTransform {
+    let prog = CGFloat(p)
+    var tx: CGFloat = 0
+    var ty: CGFloat = 0
+    switch direction {
+    case "left": tx = -size.width * prog  // exits to the left
+    case "right": tx = size.width * prog  // exits to the right
+    case "up": ty = -size.height * prog  // exits to the top
+    case "down": ty = size.height * prog  // exits to the bottom
+    default: tx = -size.width * prog
+    }
+    return base.concatenating(CGAffineTransform(translationX: tx, y: ty))
+  }
+
+  /// Crop rectangle (in source coordinates) revealing the incoming clip at [p].
+  private static func wipeCrop(_ size: CGSize, _ direction: String, _ p: Double)
+    -> CGRect
+  {
+    let w = size.width
+    let h = size.height
+    let prog = CGFloat(p)
+    switch direction {
+    case "right": return CGRect(x: 0, y: 0, width: w * prog, height: h)
+    case "left": return CGRect(x: w * (1 - prog), y: 0, width: w * prog, height: h)
+    case "down": return CGRect(x: 0, y: 0, width: w, height: h * prog)
+    case "up": return CGRect(x: 0, y: h * (1 - prog), width: w, height: h * prog)
+    default: return CGRect(x: 0, y: 0, width: w * prog, height: h)
+    }
+  }
+
+  // MARK: - Audio
+
+  private static func buildAudioMix(
+    composition: AVMutableComposition,
+    outAsset: AVURLAsset, outStart: CMTime,
+    inAsset: AVURLAsset, inStart: CMTime,
+    duration d: CMTime, curve: String
+  ) async throws -> AVMutableAudioMix? {
+    guard
+      let outAudio = try? await MediaInfoExtractor.loadAudioTrack(from: outAsset),
+      let inAudio = try? await MediaInfoExtractor.loadAudioTrack(from: inAsset),
+      let trackA = composition.addMutableTrack(
+        withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid),
+      let trackB = composition.addMutableTrack(
+        withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+    else { return nil }
+
+    try trackA.insertTimeRange(CMTimeRange(start: outStart, duration: d), of: outAudio, at: .zero)
+    try trackB.insertTimeRange(CMTimeRange(start: inStart, duration: d), of: inAudio, at: .zero)
+
+    let paramsA = AVMutableAudioMixInputParameters(track: trackA)
+    let paramsB = AVMutableAudioMixInputParameters(track: trackB)
+    let fullRange = CMTimeRange(start: .zero, duration: d)
+    // Linear cross-fade is a good approximation; the visual curve drives feel.
+    paramsA.setVolumeRamp(fromStartVolume: 1.0, toEndVolume: 0.0, timeRange: fullRange)
+    paramsB.setVolumeRamp(fromStartVolume: 0.0, toEndVolume: 1.0, timeRange: fullRange)
+
+    let mix = AVMutableAudioMix()
+    mix.inputParameters = [paramsA, paramsB]
+    return mix
+  }
+
+  // MARK: - Export
+
+  private static func runExport(_ export: AVAssetExportSession) async throws {
+    if #available(iOS 18.0, macOS 15.0, *) {
+      try await export.export(to: export.outputURL!, as: export.outputFileType!)
+    } else {
+      try await withCheckedThrowingContinuation {
+        (cont: CheckedContinuation<Void, Error>) in
+        export.exportAsynchronously {
+          if export.status == .completed {
+            cont.resume()
+          } else {
+            cont.resume(
+              throwing: export.error
+                ?? NSError(
+                  domain: "ClipTransitionRenderer", code: 1,
+                  userInfo: [
+                    NSLocalizedDescriptionKey:
+                      "Transition export failed (status \(export.status.rawValue))"
+                  ]))
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Track property loading
+
+  private static func loadPreferredTransform(_ track: AVAssetTrack) async throws
+    -> CGAffineTransform
+  {
+    if #available(iOS 15.0, macOS 13.0, *) {
+      return try await track.load(.preferredTransform)
+    }
+    return track.preferredTransform
+  }
+
+  private static func loadNaturalSize(_ track: AVAssetTrack) async throws -> CGSize {
+    if #available(iOS 15.0, macOS 13.0, *) {
+      return try await track.load(.naturalSize)
+    }
+    return track.naturalSize
+  }
+
+  private static func loadFrameRate(_ track: AVAssetTrack) async throws -> Float {
+    let rate: Float
+    if #available(iOS 15.0, macOS 13.0, *) {
+      rate = (try? await track.load(.nominalFrameRate)) ?? 30
+    } else {
+      rate = track.nominalFrameRate
+    }
+    return rate > 0 ? rate : 30
+  }
+
+  private static func temporaryURL(for format: String) -> URL {
+    let ext = format.lowercased() == "mov" ? "mov" : "mp4"
+    let name = "transition_\(Int(Date().timeIntervalSince1970 * 1000))_\(UInt32.random(in: 0...UInt32.max)).\(ext)"
+    return FileManager.default.temporaryDirectory.appendingPathComponent(name)
+  }
+}

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/CompositionBuilder.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/CompositionBuilder.swift
@@ -47,7 +47,8 @@ internal class CompositionBuilder {
   /// - Returns: Tuple containing composition, video composition, render size, audio mix, source track ID, and temporary file URLs to clean up after export
   /// - Throws: Error if composition creation fails
   func build() async throws -> (
-    AVMutableComposition, VideoCompositionData, CGSize, AVAudioMix?, CMPersistentTrackID, [URL]
+    AVMutableComposition, VideoCompositionData, CGSize, AVAudioMix?, CMPersistentTrackID, [URL],
+    [FadeWindow]
   ) {
     guard !videoClips.isEmpty else {
       throw NSError(
@@ -180,10 +181,60 @@ internal class CompositionBuilder {
     // Return the track ID for fallback on older system environments
     let sourceTrackID = videoResult.videoTrack.trackID
 
+    // Compute dip-to-color windows for fadeToBlack / fadeToWhite transitions.
+    let fadeWindows = computeFadeWindows(clipInstructions: videoResult.clipInstructions)
+
     return (
       composition, videoCompositionData, videoResult.renderSize, audioMix, sourceTrackID,
-      temporaryAudioURLs
+      temporaryAudioURLs, fadeWindows
     )
+  }
+
+  /// Builds the dip-to-color windows for `fadeToBlack` / `fadeToWhite`
+  /// transitions from the per-clip instruction time ranges.
+  ///
+  /// For a dip transition on clip *i*, the boundary between clip *i* and *i+1*
+  /// dips: clip *i* fades out to the color over its last `duration/2`, and clip
+  /// *i+1* fades in from the color over its first `duration/2`. Overlap
+  /// transitions are handled by the pre-render and never reach this method.
+  private func computeFadeWindows(clipInstructions: [ClipInstruction]) -> [FadeWindow] {
+    var windows: [FadeWindow] = []
+    for (i, clip) in videoClips.enumerated() {
+      guard i + 1 < clipInstructions.count, let transition = clip.transition else { continue }
+      let toWhite: Bool
+      switch transition.type {
+      case "fadeToBlack": toWhite = false
+      case "fadeToWhite": toWhite = true
+      default: continue
+      }
+
+      let dHalfUs = transition.durationUs / 2
+      let instr = clipInstructions[i]
+      let clipStartUs = Int64(CMTimeGetSeconds(instr.timeRange.start) * 1_000_000)
+      let boundaryUs = Int64(CMTimeGetSeconds(CMTimeRangeGetEnd(instr.timeRange)) * 1_000_000)
+      let nextEndUs = Int64(
+        CMTimeGetSeconds(CMTimeRangeGetEnd(clipInstructions[i + 1].timeRange)) * 1_000_000)
+
+      // Fade out (to color) over the tail of clip i.
+      windows.append(
+        FadeWindow(
+          startUs: max(clipStartUs, boundaryUs - dHalfUs),
+          endUs: boundaryUs,
+          fadeIn: false,
+          curve: transition.curve,
+          toWhite: toWhite
+        ))
+      // Fade in (from color) over the head of clip i+1.
+      windows.append(
+        FadeWindow(
+          startUs: boundaryUs,
+          endUs: min(nextEndUs, boundaryUs + dHalfUs),
+          fadeIn: true,
+          curve: transition.curve,
+          toWhite: toWhite
+        ))
+    }
+    return windows
   }
 
   /// Creates audio mix with per-clip and per-track volume parameters.

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
@@ -39,6 +39,37 @@ struct LayerAnimationConfig {
   }
 }
 
+/// Configuration for a transition played between a clip and the next one.
+struct ClipTransitionConfig {
+  /// Transition kind: "dissolve", "fadeToBlack", "fadeToWhite", "slide",
+  /// "push" or "wipe".
+  let type: String
+  /// Transition duration in microseconds.
+  let durationUs: Int64
+  /// Easing curve: "linear", "easeIn", "easeOut", "easeInOut", …
+  let curve: String
+  /// Direction for directional transitions: "left", "right", "up", "down".
+  let direction: String
+
+  /// True when this transition overlaps and blends the two clips.
+  var isOverlap: Bool {
+    type == "dissolve" || type == "slide" || type == "push" || type == "wipe"
+  }
+
+  static func fromArguments(_ args: [String: Any]?) -> ClipTransitionConfig? {
+    guard let args = args,
+      let type = args["type"] as? String,
+      let durationUs = (args["durationUs"] as? NSNumber)?.int64Value
+    else { return nil }
+    return ClipTransitionConfig(
+      type: type,
+      durationUs: durationUs,
+      curve: args["curve"] as? String ?? "linear",
+      direction: args["direction"] as? String ?? "left"
+    )
+  }
+}
+
 public struct ImageLayerConfig: Sendable {
   let imageData: Data
   let startUs: Int64
@@ -276,7 +307,10 @@ struct RenderConfig: Sendable {
           endUs: (clipMap["endUs"] as? NSNumber)?.int64Value,
           volume: (clipMap["volume"] as? NSNumber)?.floatValue,
           playbackSpeed: (clipMap["playbackSpeed"] as? NSNumber)?.floatValue,
-          reverseVideo: clipMap["reverseVideo"] as? Bool ?? false
+          reverseVideo: clipMap["reverseVideo"] as? Bool ?? false,
+          transition: ClipTransitionConfig.fromArguments(
+            clipMap["transition"] as? [String: Any]
+          )
         )
       }
     }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/VideoClip.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/VideoClip.swift
@@ -8,6 +8,8 @@ internal struct VideoClip: Sendable {
   let volume: Float?
   let playbackSpeed: Float?
   let reverseVideo: Bool
+  /// Transition into the next clip (nil = hard cut). Ignored on the last clip.
+  let transition: ClipTransitionConfig?
 
   init(
     inputPath: String,
@@ -15,7 +17,8 @@ internal struct VideoClip: Sendable {
     endUs: Int64? = nil,
     volume: Float? = nil,
     playbackSpeed: Float? = nil,
-    reverseVideo: Bool = false
+    reverseVideo: Bool = false,
+    transition: ClipTransitionConfig? = nil
   ) {
     self.inputPath = inputPath
     self.startUs = startUs
@@ -23,5 +26,6 @@ internal struct VideoClip: Sendable {
     self.volume = volume
     self.playbackSpeed = playbackSpeed
     self.reverseVideo = reverseVideo
+    self.transition = transition
   }
 }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/VideoCompositorConfig.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/VideoCompositorConfig.swift
@@ -2,6 +2,24 @@ import AVFoundation
 import CoreImage
 import Foundation
 
+/// A dip-to-color (fade-to-black / fade-to-white) window in composition time.
+///
+/// Used by the custom compositor to darken/whiten frames at clip boundaries for
+/// `fadeToBlack` / `fadeToWhite` transitions.
+public struct FadeWindow: Sendable {
+  /// Inclusive start of the window in composition microseconds.
+  let startUs: Int64
+  /// Exclusive end of the window in composition microseconds.
+  let endUs: Int64
+  /// `true` = fade **in** from the dip color (color → video); `false` = fade
+  /// **out** to the dip color (video → color).
+  let fadeIn: Bool
+  /// Easing curve name (e.g. "linear", "easeInOut").
+  let curve: String
+  /// `true` dips through white, `false` dips through black.
+  let toWhite: Bool
+}
+
 /// Configuration properties used by a custom video compositor to apply visual effects.
 ///
 /// Holds properties for geometry adjustments (rotation, scale, crop, flips), spatial blurring,
@@ -25,6 +43,9 @@ public struct VideoCompositorConfig {
 
   /// Color filter configs with optional time ranges for per-frame LUT switching.
   var colorFilterConfigs: [ColorFilterConfig] = []
+
+  /// Dip-to-color windows for `fadeToBlack` / `fadeToWhite` clip transitions.
+  var fadeWindows: [FadeWindow] = []
 
   var videoRotationDegrees: Double = 0.0
   var shouldApplyOrientationCorrection: Bool = false

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/utils/VideoCompositor.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/utils/VideoCompositor.swift
@@ -49,6 +49,9 @@ class VideoCompositor: NSObject, AVVideoCompositing {
   /// Color filter configs for per-frame LUT computation
   private var colorFilterConfigs: [ColorFilterConfig] = []
 
+  /// Dip-to-color windows for fadeToBlack / fadeToWhite clip transitions
+  private var fadeWindows: [FadeWindow] = []
+
   /// Cache for computed LUTs keyed by active filter indices
   private let lutCacheQueue = DispatchQueue(label: "lut.cache.queue")
   private var lutCache: [String: (data: Data, size: Int)] = [:]
@@ -86,6 +89,40 @@ class VideoCompositor: NSObject, AVVideoCompositing {
 
     self.setOverlayImageLayers(from: config.imageLayerConfigs)
     self.colorFilterConfigs = config.colorFilterConfigs
+    self.fadeWindows = config.fadeWindows
+  }
+
+  /// Applies a dip-to-color (fade-to-black / fade-to-white) at the given
+  /// composition time, if any fade window is active. The video is mixed toward
+  /// the dip color by `dipAmount` (0 = full video, 1 = full color).
+  private func applyFadeDip(to image: CIImage, at compositionTime: CMTime) -> CIImage {
+    guard !fadeWindows.isEmpty else { return image }
+    let tUs = Int64(CMTimeGetSeconds(compositionTime) * 1_000_000)
+
+    var dipAmount = 0.0
+    var toWhite = false
+    for w in fadeWindows where w.endUs > w.startUs && tUs >= w.startUs && tUs < w.endUs {
+      let raw = Double(tUs - w.startUs) / Double(w.endUs - w.startUs)
+      let eased = applyEasing(max(0, min(1, raw)), curve: w.curve)
+      let amt = w.fadeIn ? (1.0 - eased) : eased
+      if amt > dipAmount {
+        dipAmount = amt
+        toWhite = w.toWhite
+      }
+    }
+
+    guard dipAmount > 0 else { return image }
+    let s = CGFloat(1.0 - dipAmount)
+    let b = toWhite ? CGFloat(dipAmount) : 0
+    return image.applyingFilter(
+      "CIColorMatrix",
+      parameters: [
+        "inputRVector": CIVector(x: s, y: 0, z: 0, w: 0),
+        "inputGVector": CIVector(x: 0, y: s, z: 0, w: 0),
+        "inputBVector": CIVector(x: 0, y: 0, z: s, w: 0),
+        "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+        "inputBiasVector": CIVector(x: b, y: b, z: b, w: 0),
+      ])
   }
 
   func setOverlayImageLayers(from layers: [ImageLayerConfig]) {
@@ -514,6 +551,10 @@ class VideoCompositor: NSObject, AVVideoCompositing {
         }
       }
     }
+
+    // Apply dip-to-color (fade-to-black / fade-to-white) clip transitions last,
+    // so the entire composed frame (including overlays) dips uniformly.
+    outputImage = applyFadeDip(to: outputImage, at: request.compositionTime)
 
     guard let outputBuffer = request.renderContext.newPixelBuffer() else {
       request.finish(with: NSError(domain: "VideoCompositor", code: -2, userInfo: nil))

--- a/example/integration_test/clip_transition_test.dart
+++ b/example/integration_test/clip_transition_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final inputVideo = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+  // Each demo clip is 5s; transitions use a fixed 800ms / 700ms duration.
+  const clipDuration = Duration(seconds: 5);
+  const overlapDuration = Duration(milliseconds: 800);
+  const dipDuration = Duration(milliseconds: 700);
+
+  // Generous tolerance — encoder/frame rounding and the pre-render duration
+  // estimate can shift the result by a few frames.
+  const durationTolerance = 0.6; // seconds
+
+  /// Renders [model] and asserts a non-trivial, correctly-formatted result.
+  Future<VideoMetadata> render(
+    String description,
+    VideoRenderData model,
+  ) async {
+    final result = await ProVideoEditor.instance.renderVideo(model);
+    expect(result, isNotNull, reason: '$description — result is null');
+    expect(
+      result.lengthInBytes,
+      greaterThan(100000),
+      reason: '$description — video is too small',
+    );
+
+    final meta = await ProVideoEditor.instance.getMetadata(
+      EditorVideo.memory(result),
+    );
+    expect(
+      meta.extension,
+      equals(model.outputFormat.name),
+      reason: '$description — wrong format',
+    );
+    return meta;
+  }
+
+  /// Two 5s clips with [transition] applied between them.
+  VideoRenderData twoClips(ClipTransition transition) => VideoRenderData(
+    outputFormat: VideoOutputFormat.mp4,
+    videoSegments: [
+      VideoSegment(
+        video: inputVideo,
+        startTime: Duration.zero,
+        endTime: clipDuration,
+        transition: transition,
+      ),
+      VideoSegment(
+        video: inputVideo,
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 15),
+      ),
+    ],
+  );
+
+  void expectDuration(VideoMetadata meta, Duration expected, String reason) {
+    expect(
+      meta.duration.inMilliseconds / 1000,
+      closeTo(expected.inMilliseconds / 1000, durationTolerance),
+      reason: reason,
+    );
+  }
+
+  // ───────────────────────────────────────────────────────────
+  // Overlap transitions — blend the clips and shorten the output
+  // ───────────────────────────────────────────────────────────
+  group('Clip transitions — overlap (shorten timeline)', () {
+    const overlapTypes = [
+      ClipTransitionType.dissolve,
+      ClipTransitionType.slide,
+      ClipTransitionType.push,
+      ClipTransitionType.wipe,
+    ];
+
+    for (final type in overlapTypes) {
+      testWidgets(type.name, (_) async {
+        final meta = await render(
+          type.name,
+          twoClips(ClipTransition(type: type, duration: overlapDuration)),
+        );
+        // Two 5s clips overlapping by 800ms → ~9.2s.
+        expectDuration(
+          meta,
+          clipDuration * 2 - overlapDuration,
+          '${type.name} should overlap and shorten the output',
+        );
+      });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // Dip transitions — dip through a color, duration unchanged
+  // ───────────────────────────────────────────────────────────
+  group('Clip transitions — dip (keep duration)', () {
+    const dipTypes = [
+      ClipTransitionType.fadeToBlack,
+      ClipTransitionType.fadeToWhite,
+    ];
+
+    for (final type in dipTypes) {
+      testWidgets(type.name, (_) async {
+        final meta = await render(
+          type.name,
+          twoClips(ClipTransition(type: type, duration: dipDuration)),
+        );
+        // Dip happens within the clips' own time → ~10s.
+        expectDuration(
+          meta,
+          clipDuration * 2,
+          '${type.name} should keep the total duration',
+        );
+      });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // Directional transitions × all directions
+  // ───────────────────────────────────────────────────────────
+  group('Clip transitions — directions', () {
+    const directionalTypes = [
+      ClipTransitionType.slide,
+      ClipTransitionType.push,
+      ClipTransitionType.wipe,
+    ];
+
+    for (final type in directionalTypes) {
+      for (final dir in ClipTransitionDirection.values) {
+        testWidgets('${type.name} / ${dir.name}', (_) async {
+          await render(
+            '${type.name} ${dir.name}',
+            twoClips(
+              ClipTransition(
+                type: type,
+                duration: overlapDuration,
+                direction: dir,
+              ),
+            ),
+          );
+        });
+      }
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // All easing curves (driven on a dissolve)
+  // ───────────────────────────────────────────────────────────
+  group('Clip transitions — easing curves', () {
+    for (final curve in AnimationCurve.values) {
+      testWidgets('dissolve curve: ${curve.name}', (_) async {
+        await render(
+          'dissolve ${curve.name}',
+          twoClips(
+            ClipTransition(
+              type: ClipTransitionType.dissolve,
+              duration: overlapDuration,
+              curve: curve,
+            ),
+          ),
+        );
+      });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // Combined: dissolve → fade-to-black across three clips
+  // ───────────────────────────────────────────────────────────
+  group('Clip transitions — combined', () {
+    testWidgets('dissolve then fade-to-black across 3 clips', (_) async {
+      final meta = await render(
+        'combined',
+        VideoRenderData(
+          outputFormat: VideoOutputFormat.mp4,
+          videoSegments: [
+            VideoSegment(
+              video: inputVideo,
+              startTime: Duration.zero,
+              endTime: clipDuration,
+              transition: const ClipTransition(
+                type: ClipTransitionType.dissolve,
+                duration: overlapDuration,
+                curve: AnimationCurve.easeInOut,
+              ),
+            ),
+            VideoSegment(
+              video: inputVideo,
+              startTime: const Duration(seconds: 8),
+              endTime: const Duration(seconds: 13),
+              transition: const ClipTransition(
+                type: ClipTransitionType.fadeToBlack,
+                duration: Duration(milliseconds: 600),
+              ),
+            ),
+            VideoSegment(
+              video: inputVideo,
+              startTime: const Duration(seconds: 15),
+              endTime: const Duration(seconds: 20),
+            ),
+          ],
+        ),
+      );
+      // 3×5s, one overlap dissolve (-800ms); the fade-to-black keeps duration.
+      expectDuration(
+        meta,
+        clipDuration * 3 - overlapDuration,
+        'combined transitions duration mismatch',
+      );
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // A transition on the last/only segment is a no-op
+  // ───────────────────────────────────────────────────────────
+  group('Clip transitions — edge cases', () {
+    testWidgets('transition on the only segment is ignored', (_) async {
+      final meta = await render(
+        'last-segment-ignored',
+        VideoRenderData(
+          outputFormat: VideoOutputFormat.mp4,
+          videoSegments: [
+            VideoSegment(
+              video: inputVideo,
+              startTime: Duration.zero,
+              endTime: clipDuration,
+              transition: const ClipTransition(
+                type: ClipTransitionType.dissolve,
+                duration: overlapDuration,
+              ),
+            ),
+          ],
+        ),
+      );
+      // No following clip → transition ignored → full clip duration.
+      expectDuration(
+        meta,
+        clipDuration,
+        'transition on the last segment must not change the duration',
+      );
+    });
+  });
+}

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -225,6 +225,198 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     await _renderVideo(data);
   }
 
+  /// Cross-dissolve transition between two split clips.
+  ///
+  /// The two clips overlap by 800ms and blend (outgoing fades out while the
+  /// incoming fades in). The total output is shortened by the overlap.
+  Future<void> _clipDissolve() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.dissolve,
+            duration: Duration(milliseconds: 800),
+            curve: AnimationCurve.easeInOut,
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 15),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Fade-to-black (dip-to-black) transition between two split clips.
+  ///
+  /// The outgoing clip dips to black and the incoming rises from black at the
+  /// boundary. The total duration is unchanged.
+  Future<void> _clipFadeToBlack() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.fadeToBlack,
+            duration: Duration(milliseconds: 1700),
+            curve: AnimationCurve.easeInOut,
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 15),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Fade-to-white (dip-to-white) transition between two split clips.
+  Future<void> _clipFadeToWhite() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.fadeToWhite,
+            duration: Duration(milliseconds: 700),
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 15),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Slide transition: the incoming clip slides in from the right over the
+  /// outgoing clip.
+  Future<void> _clipSlide() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.slide,
+            duration: Duration(milliseconds: 700),
+            direction: ClipTransitionDirection.left,
+            curve: AnimationCurve.easeOutCubic,
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 15),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Push transition: the incoming clip pushes the outgoing clip out of frame.
+  Future<void> _clipPush() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.push,
+            duration: Duration(milliseconds: 700),
+            direction: ClipTransitionDirection.left,
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 15),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Wipe transition: the incoming clip is revealed with a moving edge.
+  Future<void> _clipWipe() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.wipe,
+            duration: Duration(milliseconds: 700),
+            direction: ClipTransitionDirection.right,
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 15),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
+  /// Combined transitions across three clips: a dissolve into the second clip,
+  /// then a fade-to-black into the third.
+  Future<void> _clipTransitionsCombined() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.dissolve,
+            duration: Duration(milliseconds: 800),
+            curve: AnimationCurve.easeInOut,
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 8),
+          endTime: const Duration(seconds: 13),
+          transition: const ClipTransition(
+            type: ClipTransitionType.fadeToBlack,
+            duration: Duration(milliseconds: 600),
+          ),
+        ),
+        VideoSegment(
+          video: _video,
+          startTime: const Duration(seconds: 15),
+          endTime: const Duration(seconds: 20),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
   Future<void> _removeAudio() async {
     var data = VideoRenderData(
       videoSegments: [VideoSegment(video: _video)],
@@ -1488,6 +1680,49 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           leading: const Icon(Icons.auto_awesome_outlined),
           title: const Text('Combined Animations'),
           subtitle: const Text('Fade + slide + scale with curves'),
+        ),
+        ..._buildSectionTitle('Clip Transitions'),
+        ListTile(
+          onTap: _clipDissolve,
+          leading: const Icon(Icons.gradient_outlined),
+          title: const Text('Dissolve'),
+          subtitle: const Text('800ms cross-dissolve between two clips'),
+        ),
+        ListTile(
+          onTap: _clipFadeToBlack,
+          leading: const Icon(Icons.nightlight_outlined),
+          title: const Text('Fade to Black'),
+          subtitle: const Text('Dip to black at the clip boundary'),
+        ),
+        ListTile(
+          onTap: _clipFadeToWhite,
+          leading: const Icon(Icons.wb_sunny_outlined),
+          title: const Text('Fade to White'),
+          subtitle: const Text('Dip to white at the clip boundary'),
+        ),
+        ListTile(
+          onTap: _clipSlide,
+          leading: const Icon(Icons.slideshow_outlined),
+          title: const Text('Slide'),
+          subtitle: const Text('Incoming slides in over the outgoing clip'),
+        ),
+        ListTile(
+          onTap: _clipPush,
+          leading: const Icon(Icons.swap_horizontal_circle_outlined),
+          title: const Text('Push'),
+          subtitle: const Text('Incoming pushes the outgoing clip out'),
+        ),
+        ListTile(
+          onTap: _clipWipe,
+          leading: const Icon(Icons.compare_outlined),
+          title: const Text('Wipe'),
+          subtitle: const Text('Incoming revealed with a moving edge'),
+        ),
+        ListTile(
+          onTap: _clipTransitionsCombined,
+          leading: const Icon(Icons.auto_awesome_motion_outlined),
+          title: const Text('Combined Transitions'),
+          subtitle: const Text('Dissolve → fade-to-black across 3 clips'),
         ),
         ..._buildSectionTitle('Video Concatenation'),
         ListTile(

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,83 +1,15 @@
 PODS:
-  - audioplayers_darwin (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - file_picker (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - fvp (0.36.1):
-    - Flutter
-    - FlutterMacOS
-    - mdk (~> 0.36.0)
-  - mdk (0.36.0)
-  - package_info_plus (0.0.1):
-    - FlutterMacOS
-  - pro_image_editor (12.0.8):
-    - Flutter
-    - FlutterMacOS
-  - pro_video_editor (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - video_player_avfoundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - wakelock_plus (0.0.1):
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
-  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - fvp (from `Flutter/ephemeral/.symlinks/plugins/fvp/darwin`)
-  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - pro_image_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin`)
-  - pro_video_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
-  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
-
-SPEC REPOS:
-  trunk:
-    - mdk
 
 EXTERNAL SOURCES:
-  audioplayers_darwin:
-    :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin
-  file_picker:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
-  fvp:
-    :path: Flutter/ephemeral/.symlinks/plugins/fvp/darwin
-  package_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  pro_image_editor:
-    :path: Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin
-  pro_video_editor:
-    :path: Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin
-  shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  video_player_avfoundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
-  wakelock_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
-  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
-  file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  fvp: f8b3b61cf8c696ecaa5608ae0d282ba710e65ae9
-  mdk: 3bfb53e0bcc9643180eaa864360051f281e4c17b
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  pro_image_editor: e57a76b305fd8c2e06d57f92aec82b9c6a6e8d9f
-  pro_video_editor: 71c273c0a82a72996526e2bfc5c2fbd2bb35aaaa
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
-  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
 
 PODFILE CHECKSUM: d53808ad3e260398c64f5e8ffae8c72d2669e2a5
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -247,7 +247,6 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				EEC91DBA2BF300121F464B73 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -416,23 +415,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EEC91DBA2BF300121F464B73 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/lib/core/models/video/clip_transition_model.dart
+++ b/lib/core/models/video/clip_transition_model.dart
@@ -1,0 +1,188 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:pro_video_editor/core/models/image/layer_animation_model.dart';
+import 'package:pro_video_editor/shared/utils/parser/int_parser.dart';
+
+/// The type of transition to play between two adjacent video clips.
+///
+/// Transitions fall into two families with different timeline behavior:
+///
+/// **Overlap transitions** — the two clips overlap and blend during the
+/// transition, so the total output is **shortened** by
+/// [ClipTransition.duration] per transition (e.g. two 5s clips + 1s transition
+/// = 9s). These are [dissolve], [slide], [push] and [wipe].
+///
+/// **Dip transitions** — the dip happens within the clips' own time at the
+/// boundary, so the total duration is **unchanged**. These are [fadeToBlack]
+/// and [fadeToWhite].
+enum ClipTransitionType {
+  /// A true cross-dissolve: the two clips overlap and the outgoing clip fades
+  /// out while the incoming clip fades in (blend). Overlap transition.
+  dissolve,
+
+  /// A dip-to-black: the outgoing clip fades to black over the first half of
+  /// the transition and the incoming clip fades up from black over the second
+  /// half. Dip transition (duration unchanged).
+  fadeToBlack,
+
+  /// A dip-to-white: like [fadeToBlack] but dips through white instead of
+  /// black. Dip transition (duration unchanged).
+  fadeToWhite,
+
+  /// The incoming clip slides in over the (stationary) outgoing clip in the
+  /// configured [ClipTransition.direction]. Overlap transition.
+  slide,
+
+  /// The incoming clip pushes the outgoing clip out of frame — both move
+  /// together in the configured [ClipTransition.direction]. Overlap
+  /// transition.
+  push,
+
+  /// A linear wipe: the incoming clip is progressively revealed over the
+  /// outgoing clip along the configured [ClipTransition.direction]. Overlap
+  /// transition.
+  wipe,
+}
+
+/// Direction for directional transitions ([ClipTransitionType.slide],
+/// [ClipTransitionType.push], [ClipTransitionType.wipe]).
+///
+/// The direction describes where the incoming content travels **toward** as
+/// the transition progresses. For example [left] means the incoming clip
+/// enters from the right edge and moves left; for a [ClipTransitionType.wipe]
+/// it means the reveal edge sweeps toward the left.
+enum ClipTransitionDirection {
+  /// Motion toward the left edge (incoming enters from the right).
+  left,
+
+  /// Motion toward the right edge (incoming enters from the left).
+  right,
+
+  /// Motion toward the top edge (incoming enters from the bottom).
+  up,
+
+  /// Motion toward the bottom edge (incoming enters from the top).
+  down,
+}
+
+/// A transition played at the boundary between one [VideoSegment] and the next.
+///
+/// Assign this to [VideoSegment.transition] to describe how that clip
+/// transitions **into the following clip** (dissolve, fade-to-black, wipe,
+/// etc.). The transition is ignored on the last segment (there is no following
+/// clip).
+///
+/// Clip transitions are currently supported on **Android** and
+/// **iOS/macOS** only. Other platforms ignore the field.
+///
+/// **Note for overlap transitions** ([ClipTransitionType.dissolve],
+/// [ClipTransitionType.slide], [ClipTransitionType.push],
+/// [ClipTransitionType.wipe]): the two clips must share the same dimensions
+/// (which split clips from the same source always do). When neighbouring clips
+/// differ in size, the native side falls back to a hard cut.
+///
+/// Example:
+/// ```dart
+/// VideoSegment(
+///   video: myVideo,
+///   endTime: const Duration(seconds: 5),
+///   transition: const ClipTransition(
+///     type: ClipTransitionType.dissolve,
+///     duration: Duration(milliseconds: 800),
+///     curve: AnimationCurve.easeInOut,
+///   ),
+/// ),
+/// VideoSegment(video: myVideo, startTime: const Duration(seconds: 5)),
+/// ```
+class ClipTransition {
+  /// Creates a [ClipTransition].
+  ///
+  /// [duration] should be greater than zero; the native side clamps it to what
+  /// the neighbouring clips can provide.
+  const ClipTransition({
+    required this.type,
+    this.duration = const Duration(milliseconds: 500),
+    this.curve = AnimationCurve.linear,
+    this.direction = ClipTransitionDirection.left,
+  });
+
+  /// The kind of transition (dissolve, fade-to-black, slide, …).
+  final ClipTransitionType type;
+
+  /// How long the transition lasts.
+  ///
+  /// For overlap transitions this is how long the two clips overlap and blend.
+  /// For dip transitions ([ClipTransitionType.fadeToBlack],
+  /// [ClipTransitionType.fadeToWhite]) this is the full dip duration
+  /// (fade-out + fade-in).
+  ///
+  /// Defaults to 500ms. The native side clamps the duration to what the
+  /// neighbouring clips can provide.
+  final Duration duration;
+
+  /// The easing curve applied to the transition's progress.
+  ///
+  /// Defaults to [AnimationCurve.linear].
+  final AnimationCurve curve;
+
+  /// The direction for directional transitions ([ClipTransitionType.slide],
+  /// [ClipTransitionType.push], [ClipTransitionType.wipe]).
+  ///
+  /// Ignored for non-directional transitions. Defaults to
+  /// [ClipTransitionDirection.left].
+  final ClipTransitionDirection direction;
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'type': type.name,
+      'durationUs': duration.inMicroseconds,
+      'curve': curve.name,
+      'direction': direction.name,
+    };
+  }
+
+  factory ClipTransition.fromMap(Map<String, dynamic> map) {
+    return ClipTransition(
+      type: ClipTransitionType.values.byName(map['type'] as String),
+      duration: Duration(microseconds: safeParseInt(map['durationUs'])),
+      curve: AnimationCurve.values.byName(
+        (map['curve'] as String?) ?? 'linear',
+      ),
+      direction: ClipTransitionDirection.values.byName(
+        (map['direction'] as String?) ?? 'left',
+      ),
+    );
+  }
+
+  ClipTransition copyWith({
+    ClipTransitionType? type,
+    Duration? duration,
+    AnimationCurve? curve,
+    ClipTransitionDirection? direction,
+  }) {
+    return ClipTransition(
+      type: type ?? this.type,
+      duration: duration ?? this.duration,
+      curve: curve ?? this.curve,
+      direction: direction ?? this.direction,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'ClipTransition(type: $type, duration: $duration, '
+        'curve: $curve, direction: $direction)';
+  }
+
+  @override
+  bool operator ==(covariant ClipTransition other) {
+    if (identical(this, other)) return true;
+    return other.type == type &&
+        other.duration == duration &&
+        other.curve == curve &&
+        other.direction == direction;
+  }
+
+  @override
+  int get hashCode =>
+      type.hashCode ^ duration.hashCode ^ curve.hashCode ^ direction.hashCode;
+}

--- a/lib/core/models/video/video_segment_model.dart
+++ b/lib/core/models/video/video_segment_model.dart
@@ -18,6 +18,7 @@ class VideoSegment {
     this.volume,
     this.playbackSpeed,
     this.reverseVideo = false,
+    this.transition,
   })  : assert(
           startTime == null || endTime == null || startTime < endTime,
           'startTime must be before endTime',
@@ -71,6 +72,16 @@ class VideoSegment {
   /// **Default**: `false`
   final bool reverseVideo;
 
+  /// The transition played between this clip and the **next** clip.
+  ///
+  /// Describes how this segment transitions into the following segment (e.g. a
+  /// dissolve or fade-to-black). The transition is ignored on the last segment
+  /// because there is no following clip.
+  ///
+  /// Currently supported on Android and iOS/macOS only; other platforms
+  /// ignore this field.
+  final ClipTransition? transition;
+
   /// Converts this clip to a map for platform channel communication.
   Future<Map<String, dynamic>> toAsyncMap() async {
     final inputPath = await video.safeFilePath();
@@ -82,6 +93,7 @@ class VideoSegment {
       'volume': volume,
       'playbackSpeed': playbackSpeed,
       'reverseVideo': reverseVideo,
+      'transition': transition?.toMap(),
     };
   }
 
@@ -93,6 +105,7 @@ class VideoSegment {
     double? volume,
     double? playbackSpeed,
     bool? reverseVideo,
+    ClipTransition? transition,
   }) {
     return VideoSegment(
       video: video ?? this.video,
@@ -101,6 +114,7 @@ class VideoSegment {
       volume: volume ?? this.volume,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
       reverseVideo: reverseVideo ?? this.reverseVideo,
+      transition: transition ?? this.transition,
     );
   }
 
@@ -113,7 +127,8 @@ class VideoSegment {
         other.endTime == endTime &&
         other.volume == volume &&
         other.playbackSpeed == playbackSpeed &&
-        other.reverseVideo == reverseVideo;
+        other.reverseVideo == reverseVideo &&
+        other.transition == transition;
   }
 
   @override
@@ -123,7 +138,8 @@ class VideoSegment {
         endTime.hashCode ^
         volume.hashCode ^
         playbackSpeed.hashCode ^
-        reverseVideo.hashCode;
+        reverseVideo.hashCode ^
+        transition.hashCode;
   }
 
   @override
@@ -133,7 +149,8 @@ class VideoSegment {
         'endTime: $endTime, '
         'volume: $volume, '
         'playbackSpeed: $playbackSpeed, '
-        'reverseVideo: $reverseVideo)';
+        'reverseVideo: $reverseVideo, '
+        'transition: $transition)';
   }
 
   Map<String, dynamic> toMap() {
@@ -144,6 +161,7 @@ class VideoSegment {
       'volume': volume,
       'playbackSpeed': playbackSpeed,
       'reverseVideo': reverseVideo,
+      'transition': transition?.toMap(),
     };
   }
 
@@ -159,6 +177,9 @@ class VideoSegment {
       volume: tryParseDouble(map['volume']),
       playbackSpeed: tryParseDouble(map['playbackSpeed']),
       reverseVideo: map['reverseVideo'] as bool? ?? false,
+      transition: map['transition'] != null
+          ? ClipTransition.fromMap(map['transition'] as Map<String, dynamic>)
+          : null,
     );
   }
 

--- a/lib/pro_video_editor.dart
+++ b/lib/pro_video_editor.dart
@@ -19,6 +19,7 @@ export 'core/models/video/editor_video_model.dart';
 export 'core/models/video/export_transform_model.dart';
 export 'core/models/video/video_render_data_model.dart';
 export 'core/models/video/video_segment_model.dart';
+export 'core/models/video/clip_transition_model.dart';
 export 'core/models/video/stop_motion_render_data_model.dart';
 export 'core/models/video/video_metadata_model.dart';
 export 'core/models/video/video_quality_preset.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.20.0
+version: 1.21.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/video/clip_transition_model_test.dart
+++ b/test/core/models/video/clip_transition_model_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  group('ClipTransition', () {
+    const transition = ClipTransition(
+      type: ClipTransitionType.dissolve,
+      duration: Duration(milliseconds: 800),
+      curve: AnimationCurve.easeInOut,
+      direction: ClipTransitionDirection.right,
+    );
+
+    group('toMap', () {
+      test('serializes all fields with enum names and microseconds', () {
+        final map = transition.toMap();
+
+        expect(map['type'], 'dissolve');
+        expect(map['durationUs'], 800000);
+        expect(map['curve'], 'easeInOut');
+        expect(map['direction'], 'right');
+      });
+    });
+
+    group('fromMap', () {
+      test('deserializes all fields correctly', () {
+        final restored = ClipTransition.fromMap(transition.toMap());
+        expect(restored, transition);
+      });
+
+      test('defaults curve and direction when missing', () {
+        final restored = ClipTransition.fromMap({
+          'type': 'fadeToBlack',
+          'durationUs': 500000,
+        });
+
+        expect(restored.type, ClipTransitionType.fadeToBlack);
+        expect(restored.duration, const Duration(milliseconds: 500));
+        expect(restored.curve, AnimationCurve.linear);
+        expect(restored.direction, ClipTransitionDirection.left);
+      });
+
+      test('parses numeric strings safely', () {
+        final restored = ClipTransition.fromMap({
+          'type': 'wipe',
+          'durationUs': '700000',
+          'direction': 'up',
+        });
+
+        expect(restored.duration, const Duration(milliseconds: 700));
+        expect(restored.direction, ClipTransitionDirection.up);
+      });
+    });
+
+    test('copyWith creates copy with updated fields', () {
+      final copy = transition.copyWith(type: ClipTransitionType.push);
+      expect(copy.type, ClipTransitionType.push);
+      expect(copy.duration, transition.duration);
+      expect(copy.direction, transition.direction);
+    });
+
+    group('equality', () {
+      test('equal instances are equal', () {
+        expect(ClipTransition.fromMap(transition.toMap()), transition);
+      });
+
+      test('different instances are not equal', () {
+        expect(transition.copyWith(duration: Duration.zero), isNot(transition));
+      });
+    });
+
+    test('toString contains class name', () {
+      expect(transition.toString(), contains('ClipTransition'));
+    });
+
+    group('VideoSegment integration', () {
+      final video = EditorVideo.asset('assets/test.mp4');
+
+      test('toMap includes the transition map', () {
+        final segment = VideoSegment(video: video, transition: transition);
+        final map = segment.toMap();
+
+        expect(map['transition'], isA<Map<String, dynamic>>());
+        expect((map['transition'] as Map)['type'], 'dissolve');
+      });
+
+      test('toMap/fromMap round-trips the transition', () {
+        final segment = VideoSegment(video: video, transition: transition);
+        final restored = VideoSegment.fromMap(segment.toMap());
+
+        expect(restored.transition, transition);
+        expect(restored, segment);
+      });
+
+      test('transition is null by default', () {
+        final segment = VideoSegment(video: video);
+        expect(segment.transition, isNull);
+        expect(segment.toMap()['transition'], isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Introduce clip transitions between video segments, allowing for various effects such as dissolve, slide, and fade-to-color. Enhance the VideoCompositor to support these transitions during rendering and include integration tests to verify functionality. Update the example app to showcase the new features. Version bumped to 1.21.0 to reflect these additions.

## Description

Introduce clip transitions between adjacent `VideoSegment`s via a new `transition` field. This feature supports various transition types, including `dissolve`, `slide`, `push`, and `wipe`, as well as `fadeToBlack` and `fadeToWhite`. The VideoCompositor has been enhanced to apply these transitions during rendering, and integration tests have been added to ensure correct behavior.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

