### PR TITLE
fix(android): correct rotation handling for overlap clip transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.21.1
+- **FIX**(android): Fix overlap clip transitions (dissolve/slide/push/wipe) appearing rotated 90°/180° when a clip carries container rotation metadata (e.g. portrait phone videos). The transition pre-render decodes coded (un-rotated) frames, so it now re-applies the source rotation via `MediaMuxer.setOrientationHint` and maps geometric directions into coded space.
+
 ## 1.21.0
 - **FEAT**(android, iOS, macOS): Add clip transitions between adjacent `VideoSegment`s via a new `transition` field (`ClipTransition` with `type`, `duration`, `curve`, `direction`). Supports `dissolve`, `slide`, `push` and `wipe` (overlap and shorten the output) plus `fadeToBlack` and `fadeToWhite` (dip through a color, duration unchanged). Web/Windows/Linux ignore the field.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionRenderer.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionRenderer.kt
@@ -107,6 +107,25 @@ object ClipTransitionRenderer {
             val tailDurationUs = (outTailEndUs - outTailStartUs).coerceAtLeast(1L)
             val frameDurationUs = tailDurationUs / frameCount
 
+            // Frames are decoded in their *coded* orientation (decoding to a
+            // ByteBuffer/Image does not apply the container rotation), so the
+            // rotation must be re-attached to the output muxer. Otherwise the
+            // pre-rendered transition clip plays back un-rotated while the
+            // surrounding clips — which the main Media3 pipeline auto-rotates —
+            // stay upright, making the whole transition appear rotated 90°/180°.
+            val rotation = outSeg.rotation
+            if (inSeg.rotation != outSeg.rotation) {
+                Log.w(
+                    RENDER_TAG,
+                    "Transition: clips have different rotations " +
+                            "(${outSeg.rotation}° vs ${inSeg.rotation}°); using ${outSeg.rotation}°"
+                )
+            }
+            // Geometric transitions (wipe/slide/push) are authored in display
+            // space; map the requested direction back into coded space so they
+            // still move the right way after the orientation hint is applied.
+            val blendDirection = rotatedDirection(direction, rotation)
+
             // 2) Pre-encode the cross-faded audio (best effort, no muxer yet).
             var audioPre: AudioPreEncoded? = null
             if (includeAudio) {
@@ -124,6 +143,8 @@ object ClipTransitionRenderer {
 
             // 3) Encode the blended video frames into the shared muxer.
             val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+            // Must be set before muxer.start() (called on INFO_OUTPUT_FORMAT_CHANGED).
+            if (rotation != 0) muxer.setOrientationHint(rotation)
             var muxerStarted = false
             var audioTrackIdx = -1
             var videoTrackIdx = -1
@@ -150,7 +171,7 @@ object ClipTransitionRenderer {
                             val blended = blendFrame(
                                 outSeg.frames[nextEncoderFrame],
                                 inSeg.frames[bIdx.coerceIn(0, inSeg.frames.size - 1)],
-                                width, height, eased, type, direction
+                                width, height, eased, type, blendDirection
                             )
                             val encImage = encoder.getInputImage(inIdx)
                             if (encImage != null) {
@@ -262,7 +283,31 @@ object ClipTransitionRenderer {
         val frames: MutableList<ByteArray>,
         val width: Int,
         val height: Int,
+        /** Container rotation in degrees (0/90/180/270); frames are coded, un-rotated. */
+        val rotation: Int,
     )
+
+    /**
+     * Maps a display-space transition [direction] into the coded
+     * (pre-rotation) frame space, given the container [rotation] that is
+     * re-applied via [MediaMuxer.setOrientationHint] on playback.
+     *
+     * The renderer blends raw coded frames, so a direction the user perceives
+     * in display space must be rotated back (counter-clockwise) by [rotation]
+     * to land on the matching coded axis. Dissolve ignores direction, so this
+     * is a no-op there.
+     */
+    private fun rotatedDirection(direction: String, rotation: Int): String {
+        val steps = (((rotation % 360) + 360) % 360) / 90
+        if (steps == 0) return direction
+        // Inverse (CCW) of the clockwise rotation the orientation hint applies.
+        val ccw = mapOf(
+            "up" to "left", "left" to "down", "down" to "right", "right" to "up",
+        )
+        var d = direction
+        repeat(steps) { d = ccw[d] ?: d }
+        return d
+    }
 
     /**
      * Decodes [path] within [[startUs]..[endUs]] into packed I420 frames.
@@ -279,6 +324,8 @@ object ClipTransitionRenderer {
         }
         val width = inputFormat.getInteger(MediaFormat.KEY_WIDTH)
         val height = inputFormat.getInteger(MediaFormat.KEY_HEIGHT)
+        val rotation = if (inputFormat.containsKey(MediaFormat.KEY_ROTATION))
+            inputFormat.getInteger(MediaFormat.KEY_ROTATION) else 0
 
         val decoderFormat = inputFormat.also {
             it.setInteger(
@@ -349,7 +396,7 @@ object ClipTransitionRenderer {
             try { extractor.release() } catch (_: Exception) {}
         }
 
-        return if (frames.isEmpty()) null else DecodedSegment(frames, width, height)
+        return if (frames.isEmpty()) null else DecodedSegment(frames, width, height, rotation)
     }
 
     // ---------------------------------------------------------------------

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.21.0
+version: 1.21.1
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Description

Fixes the issue where overlap clip transitions appeared rotated when the clips carried container rotation metadata. The solution re-applies the source rotation during playback to ensure proper orientation.

**Related Issue:** Closes # 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

