### PR TITLE
fix(animation): implement edge-aware slide animations for layers, ensuring full off-screen movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.21.4
+- **FIX**(android, iOS, macOS): Fix layer `slide` animations only moving the layer by its own size, leaving it partly visible at the animation's start/end. Slides are now edge-aware and carry the layer fully off-screen in the slide direction. Requires the matching `pro_image_editor` release so the in-editor preview matches the export.
+
 ## 1.21.3
 - **FIX**(android): Fix `OutOfMemoryError` when pre-rendering longer overlap clip transitions (dissolve/slide/push/wipe). Both sides previously decoded every I420 frame into memory at once (~370 MB for a 2 s 1080p30 transition); frames are now spilled to a temp file and streamed back one at a time during encoding, so heap use stays constant regardless of duration/fps/resolution — at full quality.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyAnimation.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyAnimation.kt
@@ -60,6 +60,70 @@ internal fun applyEasing(t: Double, curve: String): Double {
 }
 
 /**
+ * Normalized slide offset (OpenGL coordinates, [-1, 1], +x right / +y up).
+ */
+internal data class SlideOffset(val x: Float, val y: Float)
+
+/**
+ * Computes the slide translation that moves a layer fully out of the canvas
+ * in [direction], edge-aware rather than layer-size-relative.
+ *
+ * At [invP] == 1 the layer's trailing edge sits exactly on the canvas edge in
+ * the slide direction (so the layer is just completely outside); at [invP] == 0
+ * the offset is zero (layer at rest). The canvas spans [-1, 1] on both axes.
+ *
+ * @param baseNormX Layer center X in [-1, 1] (+x right).
+ * @param baseNormY Layer center Y in [-1, 1] (+y up).
+ * @param halfNormW Layer half-width in [-1, 1] units (imageWidth / videoWidth).
+ * @param halfNormH Layer half-height in [-1, 1] units (imageHeight / videoHeight).
+ */
+internal fun slideOffset(
+    direction: String?,
+    invP: Float,
+    baseNormX: Float,
+    baseNormY: Float,
+    halfNormW: Float,
+    halfNormH: Float,
+): SlideOffset = when (direction) {
+    "left" -> SlideOffset(invP * (-1f - baseNormX - halfNormW), 0f) // right edge → -1
+    "right" -> SlideOffset(invP * (1f - baseNormX + halfNormW), 0f) // left edge → +1
+    "top" -> SlideOffset(0f, invP * (1f - baseNormY + halfNormH)) // bottom edge → +1 (Y up)
+    "bottom" -> SlideOffset(0f, invP * (-1f - baseNormY - halfNormH)) // top edge → -1 (Y up)
+    else -> SlideOffset(0f, 0f)
+}
+
+/**
+ * A background-frame anchor paired with an overlay-frame anchor, both in the
+ * Media3 [-1, 1] range.
+ */
+internal data class OverlayAnchors(
+    val backgroundAnchor: Float,
+    val overlayAnchor: Float,
+)
+
+/**
+ * Splits a desired layer-center position (in [-1, 1] NDC, possibly beyond the
+ * canvas to place the layer off-screen) into the two anchors Media3 accepts.
+ *
+ * Media3 clamps both [StaticOverlaySettings.Builder.setBackgroundFrameAnchor]
+ * and [StaticOverlaySettings.Builder.setOverlayFrameAnchor] to [-1, 1], so a
+ * single background anchor cannot move a layer fully off-screen. The background
+ * anchor covers the on-canvas part; the overlay anchor supplies the remaining
+ * off-canvas shift — its ±1 range maps to ±[halfNorm] of background travel,
+ * which is exactly one layer half-size, enough for an edge-flush slide-out.
+ *
+ * @param targetCenter Desired layer center on this axis (may exceed [-1, 1]).
+ * @param halfNorm Layer half-size on this axis in [-1, 1] units.
+ */
+internal fun resolveAnchor(targetCenter: Float, halfNorm: Float): OverlayAnchors {
+    val background = targetCenter.coerceIn(-1f, 1f)
+    val overflow = targetCenter - background
+    // overlayCenter = background − overlayAnchor * halfNorm  ⇒  solve for anchor.
+    val overlay = if (halfNorm > 0f) (-overflow / halfNorm).coerceIn(-1f, 1f) else 0f
+    return OverlayAnchors(background, overlay)
+}
+
+/**
  * Custom BitmapOverlay that computes per-frame overlay settings for animations.
  *
  * Uses [getOverlaySettings] to dynamically compute alpha, position offsets,
@@ -86,6 +150,10 @@ internal class AnimatedBitmapOverlay(
         var offsetX = 0f
         var offsetY = 0f
         var scaleVal = 1.0f
+
+        // Layer half-size in [-1, 1] units (canvas spans [-1, 1]).
+        val halfNormW = imageWidth.toFloat() / videoWidth
+        val halfNormH = imageHeight.toFloat() / videoHeight
 
         val effectiveStartUs = if (layerStartUs == -1L) 0L else layerStartUs
         val effectiveEndUs = if (layerEndUs == -1L) Long.MAX_VALUE else layerEndUs
@@ -130,15 +198,12 @@ internal class AnimatedBitmapOverlay(
                 "fade" -> alpha *= progress.toFloat()
                 "slide" -> {
                     val invP = (1.0 - progress).toFloat()
-                    // Normalized offset in OpenGL coordinates [-1, 1]
-                    val normWidth = (imageWidth.toFloat() / videoWidth) * 2f
-                    val normHeight = (imageHeight.toFloat() / videoHeight) * 2f
-                    when (anim.slideDirection) {
-                        "left" -> offsetX -= normWidth * invP
-                        "right" -> offsetX += normWidth * invP
-                        "top" -> offsetY += normHeight * invP  // OpenGL Y is up
-                        "bottom" -> offsetY -= normHeight * invP
-                    }
+                    val off = slideOffset(
+                        anim.slideDirection, invP,
+                        baseNormX, baseNormY, halfNormW, halfNormH
+                    )
+                    offsetX += off.x
+                    offsetY += off.y
                 }
                 "scale" -> {
                     val scaleFrom = anim.scaleFrom?.toFloat() ?: 0f
@@ -151,10 +216,15 @@ internal class AnimatedBitmapOverlay(
         val clampedAlpha = alpha.coerceIn(0f, 1f)
         val clampedScale = scaleVal.coerceAtLeast(0f)
 
+        // Media3 clamps each anchor to [-1, 1], so a fully off-screen slide is
+        // split across the background and overlay anchors (see resolveAnchor).
+        val anchorX = resolveAnchor(baseNormX + offsetX, halfNormW)
+        val anchorY = resolveAnchor(baseNormY + offsetY, halfNormH)
+
         return StaticOverlaySettings.Builder()
             .setAlphaScale(clampedAlpha)
-            .setBackgroundFrameAnchor(baseNormX + offsetX, baseNormY + offsetY)
-            .setOverlayFrameAnchor(0f, 0f)
+            .setBackgroundFrameAnchor(anchorX.backgroundAnchor, anchorY.backgroundAnchor)
+            .setOverlayFrameAnchor(anchorX.overlayAnchor, anchorY.overlayAnchor)
             .setScale(clampedScale, clampedScale)
             .build()
     }

--- a/android/src/test/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/SlideOffsetTest.kt
+++ b/android/src/test/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/SlideOffsetTest.kt
@@ -1,0 +1,130 @@
+package ch.waio.pro_video_editor.src.features.render.helpers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SlideOffsetTest {
+
+    private val tol = 1e-6f
+
+    // A layer that is small relative to the canvas: half-width 0.2, half-height 0.2
+    // in [-1, 1] units (e.g. 200/1000 px wide, 100/500 px tall).
+    private val halfNormW = 0.2f
+    private val halfNormH = 0.2f
+
+    @Test
+    fun centeredLayer_slidesFullyOutAtInvPOne() {
+        val left = slideOffset("left", 1f, 0f, 0f, halfNormW, halfNormH)
+        val right = slideOffset("right", 1f, 0f, 0f, halfNormW, halfNormH)
+        val top = slideOffset("top", 1f, 0f, 0f, halfNormW, halfNormH)
+        val bottom = slideOffset("bottom", 1f, 0f, 0f, halfNormW, halfNormH)
+
+        // Old (buggy) behavior moved exactly one layer size (full width = 0.4),
+        // leaving the layer partly visible. Edge-aware moves a full half past −1/+1.
+        assertEquals(-1.2f, left.x, tol)
+        assertEquals(0f, left.y, tol)
+        assertEquals(1.2f, right.x, tol)
+        assertEquals(0f, right.y, tol)
+        assertEquals(1.2f, top.y, tol)
+        assertEquals(0f, top.x, tol)
+        assertEquals(-1.2f, bottom.y, tol)
+        assertEquals(0f, bottom.x, tol)
+    }
+
+    @Test
+    fun trailingEdgeLandsExactlyOnCanvasEdge() {
+        val baseNormX = 0.5f // off-center layer
+        val baseNormY = -0.3f
+
+        // left: right edge (base + half) must end on the left canvas edge (−1).
+        val left = slideOffset("left", 1f, baseNormX, baseNormY, halfNormW, halfNormH)
+        assertEquals(-1f, baseNormX + halfNormW + left.x, tol)
+
+        // right: left edge (base − half) must end on the right canvas edge (+1).
+        val right = slideOffset("right", 1f, baseNormX, baseNormY, halfNormW, halfNormH)
+        assertEquals(1f, baseNormX - halfNormW + right.x, tol)
+
+        // top: bottom edge (base − half, Y up) must end on the top canvas edge (+1).
+        val top = slideOffset("top", 1f, baseNormX, baseNormY, halfNormW, halfNormH)
+        assertEquals(1f, baseNormY - halfNormH + top.y, tol)
+
+        // bottom: top edge (base + half, Y up) must end on the bottom canvas edge (−1).
+        val bottom = slideOffset("bottom", 1f, baseNormX, baseNormY, halfNormW, halfNormH)
+        assertEquals(-1f, baseNormY + halfNormH + bottom.y, tol)
+    }
+
+    @Test
+    fun atRestProgressProducesNoOffset() {
+        for (dir in listOf("left", "right", "top", "bottom")) {
+            val off = slideOffset(dir, 0f, 0.5f, -0.5f, halfNormW, halfNormH)
+            assertEquals(0f, off.x, tol)
+            assertEquals(0f, off.y, tol)
+        }
+    }
+
+    @Test
+    fun offsetScalesLinearlyWithInvP() {
+        val full = slideOffset("left", 1f, 0f, 0f, halfNormW, halfNormH)
+        val half = slideOffset("left", 0.5f, 0f, 0f, halfNormW, halfNormH)
+        assertEquals(full.x / 2f, half.x, tol)
+    }
+
+    @Test
+    fun unknownDirectionProducesNoOffset() {
+        val off = slideOffset("diagonal", 1f, 0f, 0f, halfNormW, halfNormH)
+        assertEquals(0f, off.x, tol)
+        assertEquals(0f, off.y, tol)
+    }
+
+    // ── resolveAnchor: split a center into background + overlay anchors ──
+
+    @Test
+    fun inRangeCenterUsesOnlyBackgroundAnchor() {
+        val a = resolveAnchor(0.5f, halfNormW)
+        assertEquals(0.5f, a.backgroundAnchor, tol)
+        assertEquals(0f, a.overlayAnchor, tol)
+    }
+
+    @Test
+    fun fullyOutCenterIsReproducedByBothAnchors() {
+        // Centered layer slid fully left: center at −1 − halfNormW.
+        val center = -1f - halfNormW
+        val a = resolveAnchor(center, halfNormW)
+        // Background pinned to the edge, overlay supplies the off-canvas half.
+        assertEquals(-1f, a.backgroundAnchor, tol)
+        assertEquals(1f, a.overlayAnchor, tol)
+        // overlayCenter = background − overlayAnchor * halfNorm reproduces center.
+        assertEquals(center, a.backgroundAnchor - a.overlayAnchor * halfNormW, tol)
+    }
+
+    @Test
+    fun anchorsAlwaysStayWithinMedia3Range() {
+        // Media3 rejects anchors outside [-1, 1]; resolveAnchor must never emit
+        // such a value, even for centers far beyond the canvas.
+        for (center in listOf(-5f, -1.5f, -1f, 0f, 1f, 1.5f, 5f)) {
+            val a = resolveAnchor(center, halfNormW)
+            assertTrue(a.backgroundAnchor in -1f..1f, "bg ${a.backgroundAnchor}")
+            assertTrue(a.overlayAnchor in -1f..1f, "overlay ${a.overlayAnchor}")
+        }
+    }
+
+    @Test
+    fun zeroHalfSizeFallsBackToBackgroundOnly() {
+        val a = resolveAnchor(1.5f, 0f)
+        assertEquals(1f, a.backgroundAnchor, tol)
+        assertEquals(0f, a.overlayAnchor, tol)
+    }
+
+    @Test
+    fun slideOutThenResolveStaysInRangeForCenteredLayer() {
+        // End-to-end: the centered-layer slide-out that used to crash Media3.
+        for (dir in listOf("left", "right", "top", "bottom")) {
+            val off = slideOffset(dir, 1f, 0f, 0f, halfNormW, halfNormH)
+            val ax = resolveAnchor(0f + off.x, halfNormW)
+            val ay = resolveAnchor(0f + off.y, halfNormH)
+            assertTrue(ax.backgroundAnchor in -1f..1f && ax.overlayAnchor in -1f..1f, dir)
+            assertTrue(ay.backgroundAnchor in -1f..1f && ay.overlayAnchor in -1f..1f, dir)
+        }
+    }
+}

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ApplyAnimation.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ApplyAnimation.swift
@@ -54,6 +54,34 @@ func applyEasing(_ t: Double, curve: String) -> Double {
   }
 }
 
+/// Computes the slide translation (frame pixel space, Core Graphics Y bottom-up)
+/// that moves an overlay fully out of the frame in `direction`, edge-aware
+/// rather than overlay-size-relative.
+///
+/// At `invP == 1` the overlay's trailing edge sits exactly on the frame edge in
+/// the slide direction (so the overlay is just completely outside); at
+/// `invP == 0` the offset is `.zero` (overlay at rest). Visually identical to
+/// the Android `slideOffset` in normalized coordinates.
+func slideOffset(
+  direction: String,
+  invP: CGFloat,
+  overlayExtent: CGRect,
+  frameExtent: CGRect
+) -> CGPoint {
+  switch direction {
+  case "left":  // right edge → frame left
+    return CGPoint(x: (frameExtent.minX - overlayExtent.maxX) * invP, y: 0)
+  case "right":  // left edge → frame right
+    return CGPoint(x: (frameExtent.maxX - overlayExtent.minX) * invP, y: 0)
+  case "top":  // bottom edge → frame top (Core Graphics top edge is maxY)
+    return CGPoint(x: 0, y: (frameExtent.maxY - overlayExtent.minY) * invP)
+  case "bottom":  // top edge → frame bottom (Core Graphics bottom edge is minY)
+    return CGPoint(x: 0, y: (frameExtent.minY - overlayExtent.maxY) * invP)
+  default:
+    return .zero
+  }
+}
+
 /// Computes animation transforms and opacity for overlaying an image layer.
 /// Returns (opacity, additionalTransform) to apply to the overlay.
 func computeAnimation(
@@ -112,24 +140,14 @@ func computeAnimation(
 
     case "slide":
       let direction = anim.slideDirection ?? "left"
-      var dx: CGFloat = 0
-      var dy: CGFloat = 0
       let invP = CGFloat(1.0 - p)
-
-      switch direction {
-      case "left":
-        dx = -overlayExtent.width * invP
-      case "right":
-        dx = overlayExtent.width * invP
-      case "top":
-        // Core Graphics Y is bottom-up, so "top" means positive Y
-        dy = overlayExtent.height * invP
-      case "bottom":
-        dy = -overlayExtent.height * invP
-      default:
-        break
-      }
-      animTransform = animTransform.translatedBy(x: dx, y: dy)
+      let off = slideOffset(
+        direction: direction,
+        invP: invP,
+        overlayExtent: overlayExtent,
+        frameExtent: frameExtent
+      )
+      animTransform = animTransform.translatedBy(x: off.x, y: off.y)
 
     case "scale":
       let scaleFrom = CGFloat(anim.scaleFrom ?? 0.0)

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -24,4 +24,64 @@ class RunnerTests: XCTestCase {
     waitForExpectations(timeout: 1)
   }
 
+  // MARK: - Slide animation geometry
+
+  // Frame 1000×500, a small layer (200×100) centered at (400, 200) in
+  // Core Graphics (Y bottom-up) coordinates.
+  private let slideFrame = CGRect(x: 0, y: 0, width: 1000, height: 500)
+  private let slideOverlay = CGRect(x: 400, y: 200, width: 200, height: 100)
+
+  func testSlideMovesLayerFullyOutAtInvPOne() {
+    let left = slideOffset(
+      direction: "left", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let right = slideOffset(
+      direction: "right", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let top = slideOffset(
+      direction: "top", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let bottom = slideOffset(
+      direction: "bottom", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+
+    // Edge-aware distance, not the old overlay-size-relative one.
+    XCTAssertEqual(left.x, -600, accuracy: 1e-6)
+    XCTAssertEqual(right.x, 600, accuracy: 1e-6)
+    XCTAssertEqual(top.y, 300, accuracy: 1e-6)
+    XCTAssertEqual(bottom.y, -300, accuracy: 1e-6)
+  }
+
+  func testSlideTrailingEdgeLandsOnFrameEdge() {
+    let left = slideOffset(
+      direction: "left", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let right = slideOffset(
+      direction: "right", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let top = slideOffset(
+      direction: "top", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let bottom = slideOffset(
+      direction: "bottom", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+
+    XCTAssertEqual(slideOverlay.maxX + left.x, slideFrame.minX, accuracy: 1e-6)
+    XCTAssertEqual(slideOverlay.minX + right.x, slideFrame.maxX, accuracy: 1e-6)
+    XCTAssertEqual(slideOverlay.minY + top.y, slideFrame.maxY, accuracy: 1e-6)
+    XCTAssertEqual(slideOverlay.maxY + bottom.y, slideFrame.minY, accuracy: 1e-6)
+  }
+
+  func testSlideIsZeroAtRestAndLinearInInvP() {
+    let rest = slideOffset(
+      direction: "left", invP: 0, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    XCTAssertEqual(rest.x, 0, accuracy: 1e-6)
+    XCTAssertEqual(rest.y, 0, accuracy: 1e-6)
+
+    let full = slideOffset(
+      direction: "left", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let half = slideOffset(
+      direction: "left", invP: 0.5, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    XCTAssertEqual(half.x, full.x / 2, accuracy: 1e-6)
+  }
+
+  func testSlideUnknownDirectionProducesNoOffset() {
+    let off = slideOffset(
+      direction: "diagonal", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    XCTAssertEqual(off.x, 0, accuracy: 1e-6)
+    XCTAssertEqual(off.y, 0, accuracy: 1e-6)
+  }
+
 }

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -1123,6 +1123,56 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     await _renderVideo(data);
   }
 
+  /// Edge-aware slide showcase — verifies the slide fix.
+  ///
+  /// A centered sticker slides fully in from off-screen and fully back out
+  /// for each direction in sequence (left → right → top → bottom). With the
+  /// fix the sticker must be completely off-screen at the start/end of every
+  /// window; the old behavior only moved it by its own size, so it stayed
+  /// partly visible. A `linear` curve makes the travel easy to judge.
+  Future<void> _layerSlideEdgeAware() async {
+    final stickerImage = EditorLayerImage.asset('assets/sticker.png');
+
+    const stickerSize = 200.0;
+    const videoWidth = 1280.0;
+    const videoHeight = 720.0;
+    const center = Offset(
+      (videoWidth - stickerSize) / 2,
+      (videoHeight - stickerSize) / 2,
+    );
+
+    ImageLayer slideWindow(SlideDirection direction, int fromSec, int toSec) {
+      return ImageLayer(
+        image: stickerImage,
+        offset: center,
+        size: const Size(stickerSize, stickerSize),
+        startTime: Duration(seconds: fromSec),
+        endTime: Duration(seconds: toSec),
+        animations: [
+          LayerAnimation(
+            type: LayerAnimationType.slide,
+            phase: AnimationPhase.animateInOut,
+            duration: const Duration(milliseconds: 700),
+            slideDirection: direction,
+            curve: AnimationCurve.linear,
+          ),
+        ],
+      );
+    }
+
+    var data = VideoRenderData(
+      videoSegments: [VideoSegment(video: _video)],
+      imageLayers: [
+        slideWindow(SlideDirection.left, 0, 3),
+        slideWindow(SlideDirection.right, 3, 6),
+        slideWindow(SlideDirection.top, 6, 9),
+        slideWindow(SlideDirection.bottom, 9, 12),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
   /// Combined animations on image layer.
   ///
   /// This example combines fade, slide, and scale animations on a single
@@ -1737,6 +1787,14 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           leading: const Icon(Icons.swap_horiz_outlined),
           title: const Text('Slide Animation'),
           subtitle: const Text('Slide in from left, out to bottom'),
+        ),
+        ListTile(
+          onTap: _layerSlideEdgeAware,
+          leading: const Icon(Icons.open_in_full_outlined),
+          title: const Text('Slide Edge-Aware (all directions)'),
+          subtitle: const Text(
+            'Centered sticker slides fully off-screen: L → R → T → B',
+          ),
         ),
         ListTile(
           onTap: _layerCombinedAnimations,

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,15 +1,83 @@
 PODS:
+  - audioplayers_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - file_picker (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - fvp (0.36.1):
+    - Flutter
+    - FlutterMacOS
+    - mdk (~> 0.36.0)
+  - mdk (0.36.0)
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
+  - pro_image_editor (12.0.8):
+    - Flutter
+    - FlutterMacOS
+  - pro_video_editor (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - wakelock_plus (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
+  - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - fvp (from `Flutter/ephemeral/.symlinks/plugins/fvp/darwin`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - pro_image_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin`)
+  - pro_video_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
+  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
+
+SPEC REPOS:
+  trunk:
+    - mdk
 
 EXTERNAL SOURCES:
+  audioplayers_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
+  fvp:
+    :path: Flutter/ephemeral/.symlinks/plugins/fvp/darwin
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  pro_image_editor:
+    :path: Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin
+  pro_video_editor:
+    :path: Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  video_player_avfoundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
+  wakelock_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
+  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
+  file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  fvp: f8b3b61cf8c696ecaa5608ae0d282ba710e65ae9
+  mdk: 3bfb53e0bcc9643180eaa864360051f281e4c17b
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  pro_image_editor: e57a76b305fd8c2e06d57f92aec82b9c6a6e8d9f
+  pro_video_editor: 71c273c0a82a72996526e2bfc5c2fbd2bb35aaaa
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
+  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
 
 PODFILE CHECKSUM: d53808ad3e260398c64f5e8ffae8c72d2669e2a5
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				A6CE73A679E1E3A4B65E3E9D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -393,6 +394,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A6CE73A679E1E3A4B65E3E9D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CFCEFF0CF31A69A06884CF83 /* [CP] Check Pods Manifest.lock */ = {

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -25,4 +25,64 @@ class RunnerTests: XCTestCase {
     waitForExpectations(timeout: 1)
   }
 
+  // MARK: - Slide animation geometry
+
+  // Frame 1000×500, a small layer (200×100) centered at (400, 200) in
+  // Core Graphics (Y bottom-up) coordinates.
+  private let slideFrame = CGRect(x: 0, y: 0, width: 1000, height: 500)
+  private let slideOverlay = CGRect(x: 400, y: 200, width: 200, height: 100)
+
+  func testSlideMovesLayerFullyOutAtInvPOne() {
+    let left = slideOffset(
+      direction: "left", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let right = slideOffset(
+      direction: "right", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let top = slideOffset(
+      direction: "top", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let bottom = slideOffset(
+      direction: "bottom", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+
+    // Edge-aware distance, not the old overlay-size-relative one.
+    XCTAssertEqual(left.x, -600, accuracy: 1e-6)
+    XCTAssertEqual(right.x, 600, accuracy: 1e-6)
+    XCTAssertEqual(top.y, 300, accuracy: 1e-6)
+    XCTAssertEqual(bottom.y, -300, accuracy: 1e-6)
+  }
+
+  func testSlideTrailingEdgeLandsOnFrameEdge() {
+    let left = slideOffset(
+      direction: "left", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let right = slideOffset(
+      direction: "right", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let top = slideOffset(
+      direction: "top", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let bottom = slideOffset(
+      direction: "bottom", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+
+    XCTAssertEqual(slideOverlay.maxX + left.x, slideFrame.minX, accuracy: 1e-6)
+    XCTAssertEqual(slideOverlay.minX + right.x, slideFrame.maxX, accuracy: 1e-6)
+    XCTAssertEqual(slideOverlay.minY + top.y, slideFrame.maxY, accuracy: 1e-6)
+    XCTAssertEqual(slideOverlay.maxY + bottom.y, slideFrame.minY, accuracy: 1e-6)
+  }
+
+  func testSlideIsZeroAtRestAndLinearInInvP() {
+    let rest = slideOffset(
+      direction: "left", invP: 0, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    XCTAssertEqual(rest.x, 0, accuracy: 1e-6)
+    XCTAssertEqual(rest.y, 0, accuracy: 1e-6)
+
+    let full = slideOffset(
+      direction: "left", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    let half = slideOffset(
+      direction: "left", invP: 0.5, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    XCTAssertEqual(half.x, full.x / 2, accuracy: 1e-6)
+  }
+
+  func testSlideUnknownDirectionProducesNoOffset() {
+    let off = slideOffset(
+      direction: "diagonal", invP: 1, overlayExtent: slideOverlay, frameExtent: slideFrame)
+    XCTAssertEqual(off.x, 0, accuracy: 1e-6)
+    XCTAssertEqual(off.y, 0, accuracy: 1e-6)
+  }
+
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.21.3
+version: 1.21.4
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Description

Implement edge-aware slide animations for layers, ensuring they move fully off-screen in the specified direction. This update addresses the previous issue where layers only moved by their own size, resulting in partial visibility at the start and end of animations.

**Related Issue:** Closes # 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

