### PR TITLE
feat!: remove deprecated APIs (2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0
+- **BREAKING**: Remove the previously deprecated APIs. Migrate as follows:
+  - `VideoRenderData.video` → `videoSegments: [VideoSegment(video: …)]`
+  - `VideoRenderData.imageBytes` → `imageLayers`
+  - `VideoRenderData.playbackSpeed` → `VideoSegment.playbackSpeed`
+  - `VideoRenderData.colorMatrixList` → `colorFilters` (`ColorFilter`)
+  - `VideoRenderData.customAudioPath` / `customAudioStartTime` / `customAudioVolume` / `loopCustomAudio` → `audioTracks` (`VideoAudioTrack`)
+  - `VideoRenderData.originalAudioVolume` → `VideoSegment.volume`
+  - `VideoMetadata.originalResolution` → `rawResolution`
+
 ## 1.22.0
 - **FEAT**(android, iOS, macOS): Add multi-layer video compositions via a new `composition` field on `VideoRenderData` (`VideoComposition`). A composition stacks several `VideoLayer`s on a fixed-size canvas, each layer being a time-ordered track of `VideoSegment`s composited bottom-to-top with its own `opacity` and placement (`SegmentTransform`: `offset`, `size`, `fit` = `fill`/`contain`/`cover`). Clips gain `timelineStart` (delayed entry on a layer) and `transform` (per-clip placement), enabling picture-in-picture, side-by-side and grid layouts over a configurable `backgroundColor`. Android composites layered Media3 sequences with a per-clip GL transform (cover overflow is scissored to its rect); Darwin uses a custom `AVVideoCompositing` compositor. Per-clip `transition`, `playbackSpeed` and `reverseVideo` are not applied inside a composition. Web/Windows/Linux ignore the field.
 

--- a/README.md
+++ b/README.md
@@ -578,18 +578,18 @@ var task = VideoRenderData(
         VideoSegment(
             video: EditorVideo.asset('assets/my-video.mp4'),
             volume: 0.7, // Original audio at 70%
+            playbackSpeed: 2, // Double speed
         ),
     ],
     imageLayers: [
       ImageLayer(
-        imageBytes: layerBytes,
+        image: EditorLayerImage.memory(layerBytes),
         offset: const Offset(100, 50),
         startTime: const Duration(seconds: 2),
         endTime: const Duration(seconds: 8),
       ),
     ],
     outputFormat: VideoOutputFormat.mp4,
-    playbackSpeed: 2,
     startTime: const Duration(seconds: 5),
     endTime: const Duration(seconds: 20),
     blur: 10,

--- a/example/integration_test/video_render_test.dart
+++ b/example/integration_test/video_render_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: deprecated_member_use
-
 import 'dart:io';
 import 'dart:ui' as ui;
 

--- a/example/integration_test/video_render_test.dart
+++ b/example/integration_test/video_render_test.dart
@@ -231,9 +231,8 @@ void main() {
 
     Future<void> testSpeed(double speed) async {
       final renderModel = VideoRenderData(
-        videoSegments: [VideoSegment(video: inputVideo)],
+        videoSegments: [VideoSegment(video: inputVideo, playbackSpeed: speed)],
         outputFormat: VideoOutputFormat.mp4,
-        playbackSpeed: speed,
       );
       final meta = await testRender(
         description: 'Speed x$speed',
@@ -329,9 +328,9 @@ void main() {
                 video: inputVideo,
                 startTime: Duration.zero,
                 endTime: const Duration(seconds: 4),
+                playbackSpeed: 2.0,
               ),
             ],
-            playbackSpeed: 2.0,
             audioTracks: [
               VideoAudioTrack(path: audioPath, volume: 1, loop: true),
             ],
@@ -836,9 +835,8 @@ void main() {
       final originalMeta = await ProVideoEditor.instance.getMetadata(hevcVideo);
       final result = await ProVideoEditor.instance.renderVideo(
         VideoRenderData(
-          videoSegments: [VideoSegment(video: hevcVideo)],
+          videoSegments: [VideoSegment(video: hevcVideo, playbackSpeed: 2.0)],
           outputFormat: VideoOutputFormat.mp4,
-          playbackSpeed: 2.0,
         ),
       );
       expect(result, isNotNull, reason: 'HEVC with speed change failed');
@@ -862,10 +860,10 @@ void main() {
               video: hevcVideo,
               startTime: Duration.zero,
               endTime: const Duration(seconds: 2),
+              playbackSpeed: 0.5,
             ),
           ],
           outputFormat: VideoOutputFormat.mp4,
-          playbackSpeed: 0.5,
         ),
       );
       expect(result, isNotNull, reason: 'HEVC with slow motion failed');
@@ -1147,9 +1145,8 @@ void main() {
       final originalMeta = await ProVideoEditor.instance.getMetadata(h264Video);
       final result = await ProVideoEditor.instance.renderVideo(
         VideoRenderData(
-          videoSegments: [VideoSegment(video: h264Video)],
+          videoSegments: [VideoSegment(video: h264Video, playbackSpeed: 2.0)],
           outputFormat: VideoOutputFormat.mp4,
-          playbackSpeed: 2.0,
         ),
       );
       expect(result, isNotNull, reason: 'H.264 with speed change failed');
@@ -1173,10 +1170,10 @@ void main() {
               video: h264Video,
               startTime: Duration.zero,
               endTime: const Duration(seconds: 2),
+              playbackSpeed: 0.5,
             ),
           ],
           outputFormat: VideoOutputFormat.mp4,
-          playbackSpeed: 0.5,
         ),
       );
       expect(result, isNotNull, reason: 'H.264 with slow motion failed');
@@ -1546,10 +1543,10 @@ void main() {
                 video: video,
                 startTime: Duration.zero,
                 endTime: end,
+                playbackSpeed: 2.0,
               ),
             ],
             outputFormat: VideoOutputFormat.mp4,
-            playbackSpeed: 2.0,
           ),
         );
       }

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -882,7 +882,7 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
       audioTracks: [
         VideoAudioTrack(
           path: customAudioFile.path,
-          startTime: const Duration(seconds: 5),
+          audioStartTime: const Duration(seconds: 5),
           volume: 1.0,
           loop: false,
         ),

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -409,9 +409,7 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
       kVideoEditorExampleAudio1Path,
     );
     var data = VideoRenderData(
-      videoSegments: [VideoSegment(video: _video)],
-      // ignore: deprecated_member_use
-      playbackSpeed: 2,
+      videoSegments: [VideoSegment(video: _video, playbackSpeed: 2)],
       audioTracks: [
         VideoAudioTrack(
           path: customAudioFile.path,
@@ -851,7 +849,7 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
   /// Play custom audio once without looping.
   ///
   /// By default, custom audio loops to match the video duration.
-  /// Setting `loopCustomAudio: false` plays the audio only once,
+  /// Setting `VideoAudioTrack.loop: false` plays the audio only once,
   /// with silence for the remaining video duration.
   Future<void> _customAudioNoLoop() async {
     final customAudioFile = await _writeAssetAudioToFile(
@@ -870,9 +868,9 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
 
   /// Start custom audio from a specific offset.
   ///
-  /// This example demonstrates how to use `customAudioStartTime` to start
-  /// playing the custom audio from a specific position instead of from the
-  /// beginning. This is useful for using a specific section of a longer
+  /// This example demonstrates how to use `VideoAudioTrack.audioStartTime` to
+  /// start playing the custom audio from a specific position instead of from
+  /// the beginning. This is useful for using a specific section of a longer
   /// audio file.
   Future<void> _customAudioStartOffset() async {
     final customAudioFile = await _writeAssetAudioToFile(

--- a/example/lib/features/thumbnail/thumbnail_example_page.dart
+++ b/example/lib/features/thumbnail/thumbnail_example_page.dart
@@ -210,11 +210,7 @@ class _ThumbnailExamplePageState extends State<ThumbnailExamplePage> {
             builder: (context, animatedValue, _) {
               return Column(
                 children: [
-                  CircularProgressIndicator(
-                    value: animatedValue,
-                    // ignore: deprecated_member_use
-                    year2023: false,
-                  ),
+                  CircularProgressIndicator(value: animatedValue),
                   Text('${(animatedValue * 100).toStringAsFixed(1)} / 100'),
                 ],
               );

--- a/example/lib/shared/widgets/video_renderer_progress.dart
+++ b/example/lib/shared/widgets/video_renderer_progress.dart
@@ -35,11 +35,7 @@ class VideoRendererProgressPanel extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               spacing: 12,
               children: [
-                CircularProgressIndicator(
-                  value: animatedValue,
-                  // ignore: deprecated_member_use
-                  year2023: false,
-                ),
+                CircularProgressIndicator(value: animatedValue),
                 Text('${(animatedValue * 100).toStringAsFixed(1)} / 100'),
                 if (supportsCancel && onCancel != null)
                   FilledButton.icon(

--- a/lib/core/models/video/video_metadata_model.dart
+++ b/lib/core/models/video/video_metadata_model.dart
@@ -169,13 +169,6 @@ class VideoMetadata {
     return isRotated90Or270 ? resolution.flipped : resolution;
   }
 
-  /// The original resolution of the video before rotation is applied.
-  ///
-  /// @Deprecated: Use [rawResolution] instead. This getter will be removed
-  /// in a future version.
-  @Deprecated('Use rawResolution instead')
-  Size get originalResolution => rawResolution;
-
   /// The rotation of the video.
   final int rotation;
 
@@ -276,7 +269,6 @@ class VideoMetadata {
     DateTime? date,
     int? fileSize,
     Size? resolution,
-    @Deprecated('No longer supported, has no effect') Size? originalResolution,
     int? rotation,
     Duration? duration,
     Duration? audioDuration,

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -9,16 +9,15 @@ import 'package:pro_video_editor/shared/utils/parser/int_parser.dart';
 
 /// A model describing settings for rendering or exporting a video.
 ///
-/// Includes input video data (single video or multiple clips), optional
-/// overlays, transformations, color filters, audio options, playback settings,
-/// and output format.
+/// Includes input video data (a single track of clips or a layered
+/// composition), optional overlays, transformations, color filters, audio
+/// options, and output format.
 class VideoRenderData {
   /// Creates a [VideoRenderData] with the given parameters.
   ///
-  /// **Important:** You must provide exactly one of [video], [videoSegments],
-  /// or [composition].
-  /// - Use [video] for a single video with optional [startTime] and [endTime]
-  /// - Use [videoSegments] for concatenating multiple videos into one track,
+  /// **Important:** You must provide exactly one of [videoSegments] or
+  /// [composition].
+  /// - Use [videoSegments] for concatenating one or more videos into one track,
   ///   each with their own trim settings
   /// - Use [composition] for multiple layered tracks that overlap in time or
   ///   space (picture-in-picture, side-by-side, grid)
@@ -26,58 +25,27 @@ class VideoRenderData {
     String? id,
     this.qualityConfig,
     this.outputFormat = VideoOutputFormat.mp4,
-    @Deprecated('Use videoSegments instead.') this.video,
     this.videoSegments,
     this.composition,
-    @Deprecated('Use imageLayers instead.') this.imageBytes,
     this.imageLayers,
     this.transform,
     this.enableAudio = true,
-    @Deprecated('Use VideoSegment.playbackSpeed instead.') this.playbackSpeed,
     this.startTime,
     this.endTime,
-    @Deprecated('Use colorFilters instead.') this.colorMatrixList = const [],
     this.colorFilters = const [],
     this.audioTracks = const [],
     this.blur,
     this.bitrate,
-    @Deprecated('Use audioTracks instead.') this.customAudioPath,
-    @Deprecated('Use audioTracks instead.') this.customAudioStartTime,
-    @Deprecated('Use VideoSegment.volume instead.') this.originalAudioVolume,
-    @Deprecated('Use audioTracks instead.') this.customAudioVolume,
     this.shouldOptimizeForNetworkUse = false,
     this.imageBytesWithCropping = false,
-    @Deprecated('Use audioTracks instead.') this.loopCustomAudio = true,
   })  : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
         assert(
-          (video != null ? 1 : 0) +
-                  (videoSegments != null ? 1 : 0) +
-                  (composition != null ? 1 : 0) ==
-              1,
-          'You must provide exactly one of video, videoSegments, '
-          'or composition',
+          (videoSegments != null ? 1 : 0) + (composition != null ? 1 : 0) == 1,
+          'You must provide exactly one of videoSegments or composition',
         ),
         assert(
           videoSegments == null || videoSegments.isNotEmpty,
           'videoSegments must not be empty if provided',
-        ),
-        assert(
-          imageBytes == null || imageLayers == null || imageLayers.isEmpty,
-          'Cannot use both imageBytes and imageLayers. '
-          'Use imageLayers instead.',
-        ),
-        assert(
-          colorMatrixList.isEmpty || colorFilters.isEmpty,
-          'Cannot use both colorMatrixList and colorFilters. '
-          'Use colorFilters instead.',
-        ),
-        assert(
-          audioTracks.isEmpty ||
-              (customAudioPath == null &&
-                  customAudioStartTime == null &&
-                  customAudioVolume == null),
-          'Cannot use both audioTracks and customAudio* fields. '
-          'Use audioTracks instead.',
         ),
         assert(
           startTime == null || endTime == null || startTime < endTime,
@@ -88,20 +56,8 @@ class VideoRenderData {
           '[blur] must be greater than or equal to 0',
         ),
         assert(
-          playbackSpeed == null || playbackSpeed > 0,
-          '[playbackSpeed] must be greater than 0',
-        ),
-        assert(
           bitrate == null || bitrate > 0,
           '[bitrate] must be greater than 0',
-        ),
-        assert(
-          originalAudioVolume == null || originalAudioVolume >= 0,
-          '[originalAudioVolume] must be greater than or equal to 0',
-        ),
-        assert(
-          customAudioVolume == null || customAudioVolume >= 0,
-          '[customAudioVolume] must be greater than or equal to 0',
         );
 
   /// Creates a [VideoRenderData] with a predefined quality preset.
@@ -113,7 +69,7 @@ class VideoRenderData {
   /// Example:
   /// ```dart
   /// var model = VideoRenderData.withQualityPreset(
-  ///   video: EditorVideo.asset('assets/my-video.mp4'),
+  ///   videoSegments: [VideoSegment(video: EditorVideo.asset('assets/v.mp4'))],
   ///   qualityPreset: VideoQualityPreset.p1080,
   ///   outputFormat: VideoOutputFormat.mp4,
   /// );
@@ -123,32 +79,21 @@ class VideoRenderData {
   /// [transform] with scale or crop settings. The bitrate from the preset
   /// will still be used unless explicitly overridden with [bitrateOverride].
   factory VideoRenderData.withQualityPreset({
-    @Deprecated('Use videoSegments instead.') EditorVideo? video,
     List<VideoSegment>? videoSegments,
     VideoComposition? composition,
     required VideoQualityPreset qualityPreset,
     VideoOutputFormat outputFormat = VideoOutputFormat.mp4,
-    @Deprecated('Use imageLayers instead.') Uint8List? imageBytes,
     List<ImageLayer> imageLayers = const [],
     ExportTransform? transform,
     bool enableAudio = true,
-    @Deprecated('Use VideoSegment.playbackSpeed instead.')
-    double? playbackSpeed,
     Duration? startTime,
     Duration? endTime,
     double? blur,
     int? bitrateOverride,
-    @Deprecated('Use colorFilters instead.')
-    List<List<double>> colorMatrixList = const [],
     List<ColorFilter> colorFilters = const [],
     List<VideoAudioTrack> audioTracks = const [],
-    @Deprecated('Use audioTracks instead.') String? customAudioPath,
-    @Deprecated('Use audioTracks instead.') Duration? customAudioStartTime,
-    @Deprecated('Use VideoSegment.volume instead.') double? originalAudioVolume,
-    @Deprecated('Use audioTracks instead.') double? customAudioVolume,
     bool shouldOptimizeForNetworkUse = false,
     bool imageBytesWithCropping = false,
-    @Deprecated('Use audioTracks instead.') bool loopCustomAudio = true,
     String? id,
   }) {
     final qualityConfig = VideoQualityConfig.fromPreset(qualityPreset);
@@ -156,36 +101,20 @@ class VideoRenderData {
     return VideoRenderData(
       id: id,
       outputFormat: outputFormat,
-      video: video,
       videoSegments: videoSegments,
       composition: composition,
-      imageBytes: imageBytes,
       imageLayers: imageLayers,
       transform: transform,
       enableAudio: enableAudio,
-      // ignore: deprecated_member_use_from_same_package
-      playbackSpeed: playbackSpeed,
       startTime: startTime,
       endTime: endTime,
       blur: blur,
       bitrate: bitrateOverride ?? qualityConfig.bitrate,
-      // ignore: deprecated_member_use_from_same_package
-      colorMatrixList: colorMatrixList,
       colorFilters: colorFilters,
       audioTracks: audioTracks,
       qualityConfig: qualityConfig,
-      // ignore: deprecated_member_use_from_same_package
-      customAudioPath: customAudioPath,
-      // ignore: deprecated_member_use_from_same_package
-      customAudioStartTime: customAudioStartTime,
-      // ignore: deprecated_member_use_from_same_package
-      originalAudioVolume: originalAudioVolume,
-      // ignore: deprecated_member_use_from_same_package
-      customAudioVolume: customAudioVolume,
       shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
       imageBytesWithCropping: imageBytesWithCropping,
-      // ignore: deprecated_member_use_from_same_package
-      loopCustomAudio: loopCustomAudio,
     );
   }
 
@@ -198,42 +127,24 @@ class VideoRenderData {
   /// The target format for the exported video.
   final VideoOutputFormat outputFormat;
 
-  /// A model that encapsulates various ways to load and represent a video.
-  ///
-  /// This class supports videos from in-memory bytes, file system, network,
-  /// or asset bundle. It provides convenience methods for identifying the
-  /// source type and safely retrieving video bytes.
-  ///
-  /// **Note:** Either [video] or [videoSegments] must be provided, but not
-  /// both.
-  /// Use this field for a single video. For concatenating multiple videos,
-  /// use [videoSegments] instead.
-  @Deprecated('Use videoSegments instead.')
-  final EditorVideo? video;
-
   /// A list of video clips to be concatenated into a single output video.
   ///
   /// Each clip can have its own start and end time for trimming. The clips
   /// will be joined in the order they appear in the list.
   ///
-  /// **Note:** Either [video] or [videoSegments] must be provided, but not
-  /// both.
-  /// Use this field for concatenating multiple videos. For a single video,
-  /// use [video] instead.
+  /// **Note:** Exactly one of [videoSegments] or [composition] must be
+  /// provided. Use this field for a single track of concatenated clips, and
+  /// [composition] when layers overlap in time or space.
   ///
   /// **Example:**
   /// ```dart
   /// videoSegments: [
-  ///   VideoClipModel(
+  ///   VideoSegment(
   ///     video: EditorVideo.file('video1.mp4'),
   ///     startTime: Duration(seconds: 0),
   ///     endTime: Duration(seconds: 5),
   ///   ),
-  ///   VideoClipModel(
-  ///     video: EditorVideo.file('video2.mp4'),
-  ///     startTime: Duration(seconds: 2),
-  ///     endTime: Duration(seconds: 8),
-  ///   ),
+  ///   VideoSegment(video: EditorVideo.file('video2.mp4')),
   /// ]
   /// ```
   final List<VideoSegment>? videoSegments;
@@ -244,14 +155,10 @@ class VideoRenderData {
   /// picture-in-picture overlays. Each [VideoLayer] is a track with its own
   /// time-ordered clips; layers are composited bottom-to-top.
   ///
-  /// **Note:** Exactly one of [video], [videoSegments], or [composition] must
-  /// be provided. Use [videoSegments] for a single track of concatenated
-  /// clips, and [composition] when layers overlap in time or space.
+  /// **Note:** Exactly one of [videoSegments] or [composition] must be
+  /// provided. Use [videoSegments] for a single track of concatenated clips,
+  /// and [composition] when layers overlap in time or space.
   final VideoComposition? composition;
-
-  /// A transparent image which will overlay the video.
-  @Deprecated('Use imageLayers instead.')
-  final Uint8List? imageBytes;
 
   /// A list of image layers with timing information for overlaying on the video
   final List<ImageLayer>? imageLayers;
@@ -267,12 +174,6 @@ class VideoRenderData {
   /// **Default**: `true`
   final bool enableAudio;
 
-  /// Playback speed of the exported video.
-  ///
-  /// For example, `0.5` for half speed, `2.0` for double speed.
-  @Deprecated('Use VideoSegment.playbackSpeed instead.')
-  final double? playbackSpeed;
-
   /// Optional start time for trimming the entire composition across all
   /// segments.
   final Duration? startTime;
@@ -280,10 +181,6 @@ class VideoRenderData {
   /// Optional end time for trimming the entire composition across all
   /// segments.
   final Duration? endTime;
-
-  /// A 4x5 matrix used to apply color filters (e.g., saturation, brightness).
-  @Deprecated('Use colorFilters instead.')
-  final List<List<double>> colorMatrixList;
 
   /// A list of color filters with optional time ranges.
   ///
@@ -316,56 +213,6 @@ class VideoRenderData {
   /// applied bitrate.
   final int? bitrate;
 
-  /// Path to a custom audio file to be mixed with the video.
-  ///
-  /// When provided, this audio will be mixed with the original video audio.
-  /// Use [originalAudioVolume] and [customAudioVolume] to control the mix
-  /// levels of each audio track.
-  @Deprecated('Use audioTracks instead.')
-  final String? customAudioPath;
-
-  /// The start time offset for the custom audio track.
-  ///
-  /// When provided, the custom audio will start playing from this position
-  /// instead of from the beginning. This is useful for using a specific
-  /// section of a longer audio file.
-  ///
-  /// This parameter is only effective when [customAudioPath] is provided.
-  @Deprecated('Use audioTracks instead.')
-  final Duration? customAudioStartTime;
-
-  /// Volume multiplier for the original video audio track.
-  ///
-  /// - Range: `0.0` (mute) to `1.0+` (amplify)
-  /// - Default: `1.0` (unchanged)
-  ///
-  /// **Examples:**
-  /// - `0.0`: Mute original audio completely
-  /// - `0.5`: Reduce original audio to 50%
-  /// - `1.0`: Keep original volume (default)
-  /// - `1.5`: Amplify original audio by 50%
-  /// - `2.0`: Double the original volume
-  ///
-  /// This parameter is only effective when [enableAudio] is `true`.
-  @Deprecated('Use VideoSegment.volume instead.')
-  final double? originalAudioVolume;
-
-  /// Volume multiplier for the custom audio track.
-  ///
-  /// - Range: `0.0` (mute) to `1.0+` (amplify)
-  /// - Default: `1.0` (unchanged)
-  ///
-  /// **Examples:**
-  /// - `0.0`: Mute custom audio
-  /// - `0.3`: Subtle background music (30%)
-  /// - `0.5`: Equal mix with original audio
-  /// - `1.0`: Full volume (default)
-  /// - `1.2`: Slightly amplified
-  ///
-  /// This parameter is only effective when [customAudioPath] is provided.
-  @Deprecated('Use audioTracks instead.')
-  final double? customAudioVolume;
-
   /// Whether to optimize the video for network streaming (fast start).
   ///
   /// When `true`, the video metadata (moov atom) is moved to the beginning
@@ -385,15 +232,15 @@ class VideoRenderData {
 
   /// Whether to apply cropping to the image overlay along with the video.
   ///
-  /// When `false` (default), the [imageBytes] amd [imageLayers] overlays
-  /// are scaled to match the **final** video dimensions (after cropping).
-  /// The overlay covers the entire output frame.
+  /// When `false` (default), the [imageLayers] overlays are scaled to match
+  /// the **final** video dimensions (after cropping). The overlay covers the
+  /// entire output frame.
   ///
-  /// When `true`, the [imageBytes] and [imageLayers] overlays are scaled
-  /// to match the **original** video dimensions (before cropping), and then
-  /// the same crop is applied to both the video and the overlay together.
-  /// This is useful when the overlay contains elements that should be
-  /// cropped in sync with the video content.
+  /// When `true`, the [imageLayers] overlays are scaled to match the
+  /// **original** video dimensions (before cropping), and then the same crop
+  /// is applied to both the video and the overlay together. This is useful
+  /// when the overlay contains elements that should be cropped in sync with
+  /// the video content.
   ///
   /// **Default**: `false`
   ///
@@ -401,18 +248,6 @@ class VideoRenderData {
   /// - `false`: Overlay stretches to fill the cropped output
   /// - `true`: Overlay is cropped together with the video
   final bool imageBytesWithCropping;
-
-  /// Whether to loop the custom audio track if it is shorter than the video.
-  ///
-  /// When `true` (default), the custom audio will be repeated until it
-  /// matches the video duration. When `false`, the audio plays once and
-  /// silence fills the remaining duration.
-  ///
-  /// This parameter is only effective when [customAudioPath] is provided.
-  ///
-  /// **Default**: `true`
-  @Deprecated('Use audioTracks instead.')
-  final bool loopCustomAudio;
 
   /// Returns a [Stream] of [ProgressModel] objects that provides updates on
   /// the progress of the video rendering process associated with this model's
@@ -433,8 +268,7 @@ class VideoRenderData {
 
     // Handle quality config
     if (qualityConfig != null && scaleX == null && scaleY == null) {
-      final targetVideo = video ??
-          (videoSegments != null && videoSegments!.isNotEmpty
+      final targetVideo = (videoSegments != null && videoSegments!.isNotEmpty
               ? videoSegments!.first.video
               : null) ??
           composition?.layers.first.clips.first.video;
@@ -451,106 +285,54 @@ class VideoRenderData {
       }
     }
 
-    // Convert video clips to map format
-    // ignore: deprecated_member_use_from_same_package
-    final fallbackVolume = originalAudioVolume;
+    // Convert video clips to map format.
     List<Map<String, dynamic>>? videoSegmentsMaps;
     if (videoSegments != null) {
       videoSegmentsMaps = await Future.wait(
-        videoSegments!.map(
-          (clip) async => {
-            ...await clip.toAsyncMap(),
-            'volume': clip.volume ?? fallbackVolume,
-          },
-        ),
+        videoSegments!.map((clip) => clip.toAsyncMap()),
       );
-    } else if (video != null) {
-      // Single video: convert to single clip format
-      videoSegmentsMaps = [
-        {
-          // ignore: deprecated_member_use_from_same_package
-          'inputPath': await video!.safeFilePath(),
-          'startUs': startTime?.inMicroseconds,
-          'endUs': endTime?.inMicroseconds,
-          'volume': fallbackVolume,
-        },
-      ];
     }
 
-    // Merge deprecated colorMatrixList into colorFilters
-    // ignore: deprecated_member_use_from_same_package
-    final mergedColorFilters = [
-      ...colorFilters.map(
-        (f) => {
-          'matrix': f.matrix,
-          'startUs': f.startTime?.inMicroseconds,
-          'endUs': f.endTime?.inMicroseconds,
-        },
-      ),
-      // ignore: deprecated_member_use_from_same_package
-      ...colorMatrixList.map(
-        (matrix) => {'matrix': matrix, 'startUs': null, 'endUs': null},
-      ),
-    ];
+    final colorFilterMaps = colorFilters
+        .map(
+          (f) => {
+            'matrix': f.matrix,
+            'startUs': f.startTime?.inMicroseconds,
+            'endUs': f.endTime?.inMicroseconds,
+          },
+        )
+        .toList();
 
-    // Merge deprecated customAudio* fields into audioTracks
-    final mergedAudioTracks = [
-      ...audioTracks.map(
-        (t) => {
-          'path': t.path,
-          'volume': t.volume,
-          'loop': t.loop,
-          'audioStartUs': t.audioStartTime?.inMicroseconds,
-          'audioEndUs': t.audioEndTime?.inMicroseconds,
-          'startUs': t.startTime?.inMicroseconds,
-          'endUs': t.endTime?.inMicroseconds,
-        },
-      ),
-      // ignore: deprecated_member_use_from_same_package
-      if (customAudioPath != null)
-        {
-          // ignore: deprecated_member_use_from_same_package
-          'path': customAudioPath,
-          // ignore: deprecated_member_use_from_same_package
-          'volume': customAudioVolume ?? 1.0,
-          // ignore: deprecated_member_use_from_same_package
-          'loop': loopCustomAudio,
-          // ignore: deprecated_member_use_from_same_package
-          'audioStartUs': customAudioStartTime?.inMicroseconds,
-          'audioEndUs': null,
-          'startUs': null,
-          'endUs': null,
-        },
-    ];
+    final audioTrackMaps = audioTracks
+        .map(
+          (t) => {
+            'path': t.path,
+            'volume': t.volume,
+            'loop': t.loop,
+            'audioStartUs': t.audioStartTime?.inMicroseconds,
+            'audioEndUs': t.audioEndTime?.inMicroseconds,
+            'startUs': t.startTime?.inMicroseconds,
+            'endUs': t.endTime?.inMicroseconds,
+          },
+        )
+        .toList();
 
-    // Merge deprecated imageBytes into imageLayers
-    final mergedImageLayers = [
-      if (imageLayers != null)
-        ...await Future.wait(
-          imageLayers!.map(
-            (layer) async => {
-              'imageData': await layer.image.safeByteArray(),
-              'startUs': layer.startTime?.inMicroseconds,
-              'endUs': layer.endTime?.inMicroseconds,
-              'x': layer.offset?.dx.toInt(),
-              'y': layer.offset?.dy.toInt(),
-              'width': layer.size?.width,
-              'height': layer.size?.height,
-              'animations': layer.animations.map((a) => a.toMap()).toList(),
-            },
-          ),
-        ),
-      // ignore: deprecated_member_use_from_same_package
-      if (imageBytes != null)
-        {
-          // ignore: deprecated_member_use_from_same_package
-          'imageData': imageBytes,
-          'startUs': null,
-          'endUs': null,
-          'x': null,
-          'y': null,
-        },
-    ];
+    final imageLayerMaps = imageLayers == null
+        ? <Map<String, dynamic>>[]
+        : await Future.wait(
+            imageLayers!.map(
+              (layer) async => {
+                'imageData': await layer.image.safeByteArray(),
+                'startUs': layer.startTime?.inMicroseconds,
+                'endUs': layer.endTime?.inMicroseconds,
+                'x': layer.offset?.dx.toInt(),
+                'y': layer.offset?.dy.toInt(),
+                'width': layer.size?.width,
+                'height': layer.size?.height,
+                'animations': layer.animations.map((a) => a.toMap()).toList(),
+              },
+            ),
+          );
 
     return {
       ...transform.toMap(),
@@ -558,25 +340,19 @@ class VideoRenderData {
       'videoClips': videoSegmentsMaps,
       'composition':
           composition != null ? await composition!.toAsyncMap() : null,
-      'imageLayers': mergedImageLayers,
-      'colorFilters': mergedColorFilters,
-      'audioTracks': mergedAudioTracks,
+      'imageLayers': imageLayerMaps,
+      'colorFilters': colorFilterMaps,
+      'audioTracks': audioTrackMaps,
       'enableAudio': enableAudio,
-      'playbackSpeed': playbackSpeed,
       'outputFormat': outputFormat.name,
       'blur': blur,
       'bitrate': bitrate,
       'scaleX': scaleX,
       'scaleY': scaleY,
       // Global trim across the whole timeline (for videoSegments and
-      // compositions). For a single video, startTime/endTime are already
-      // applied to the clip itself.
-      'startUs': (videoSegments != null || composition != null)
-          ? startTime?.inMicroseconds
-          : null,
-      'endUs': (videoSegments != null || composition != null)
-          ? endTime?.inMicroseconds
-          : null,
+      // compositions).
+      'startUs': startTime?.inMicroseconds,
+      'endUs': endTime?.inMicroseconds,
       'shouldOptimizeForNetworkUse': shouldOptimizeForNetworkUse,
       'imageBytesWithCropping': imageBytesWithCropping,
     };
@@ -587,57 +363,39 @@ class VideoRenderData {
     String? id,
     VideoQualityConfig? qualityConfig,
     VideoOutputFormat? outputFormat,
-    EditorVideo? video,
     List<VideoSegment>? videoSegments,
     VideoComposition? composition,
-    Uint8List? imageBytes,
     List<ImageLayer>? imageLayers,
     ExportTransform? transform,
     bool? enableAudio,
-    double? playbackSpeed,
     Duration? startTime,
     Duration? endTime,
-    List<List<double>>? colorMatrixList,
     List<ColorFilter>? colorFilters,
     List<VideoAudioTrack>? audioTracks,
     double? blur,
     int? bitrate,
-    String? customAudioPath,
-    Duration? customAudioStartTime,
-    double? originalAudioVolume,
-    double? customAudioVolume,
     bool? shouldOptimizeForNetworkUse,
     bool? imageBytesWithCropping,
-    bool? loopCustomAudio,
   }) {
     return VideoRenderData(
       id: id ?? this.id,
       qualityConfig: qualityConfig ?? this.qualityConfig,
       outputFormat: outputFormat ?? this.outputFormat,
-      video: video ?? this.video,
       videoSegments: videoSegments ?? this.videoSegments,
       composition: composition ?? this.composition,
-      imageBytes: imageBytes ?? this.imageBytes,
       imageLayers: imageLayers ?? this.imageLayers,
       transform: transform ?? this.transform,
       enableAudio: enableAudio ?? this.enableAudio,
-      playbackSpeed: playbackSpeed ?? this.playbackSpeed,
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
-      colorMatrixList: colorMatrixList ?? this.colorMatrixList,
       colorFilters: colorFilters ?? this.colorFilters,
       audioTracks: audioTracks ?? this.audioTracks,
       blur: blur ?? this.blur,
       bitrate: bitrate ?? this.bitrate,
-      customAudioPath: customAudioPath ?? this.customAudioPath,
-      customAudioStartTime: customAudioStartTime ?? this.customAudioStartTime,
-      originalAudioVolume: originalAudioVolume ?? this.originalAudioVolume,
-      customAudioVolume: customAudioVolume ?? this.customAudioVolume,
       shouldOptimizeForNetworkUse:
           shouldOptimizeForNetworkUse ?? this.shouldOptimizeForNetworkUse,
       imageBytesWithCropping:
           imageBytesWithCropping ?? this.imageBytesWithCropping,
-      loopCustomAudio: loopCustomAudio ?? this.loopCustomAudio,
     );
   }
 
@@ -646,28 +404,19 @@ class VideoRenderData {
       'id': id,
       'qualityConfig': qualityConfig?.toMap(),
       'outputFormat': outputFormat.name,
-      'video': video?.toMap(),
       'videoSegments': videoSegments?.map((x) => x.toMap()).toList(),
       'composition': composition?.toMap(),
-      'imageBytes': imageBytes?.toList(),
       'imageLayers': imageLayers?.map((x) => x.toMap()).toList(),
       'transform': transform?.toMap(),
       'enableAudio': enableAudio,
-      'playbackSpeed': playbackSpeed,
       'startTime': startTime?.inMicroseconds,
       'endTime': endTime?.inMicroseconds,
-      'colorMatrixList': colorMatrixList,
       'colorFilters': colorFilters.map((x) => x.toMap()).toList(),
       'audioTracks': audioTracks.map((x) => x.toMap()).toList(),
       'blur': blur,
       'bitrate': bitrate,
-      'customAudioPath': customAudioPath,
-      'customAudioStartTime': customAudioStartTime?.inMicroseconds,
-      'originalAudioVolume': originalAudioVolume,
-      'customAudioVolume': customAudioVolume,
       'shouldOptimizeForNetworkUse': shouldOptimizeForNetworkUse,
       'imageBytesWithCropping': imageBytesWithCropping,
-      'loopCustomAudio': loopCustomAudio,
     };
   }
 
@@ -682,9 +431,6 @@ class VideoRenderData {
       outputFormat: VideoOutputFormat.values.byName(
         map['outputFormat'] as String,
       ),
-      video: map['video'] != null
-          ? EditorVideo.fromMap(map['video'] as Map<String, dynamic>)
-          : null,
       videoSegments: map['videoSegments'] != null
           ? List<VideoSegment>.from(
               (map['videoSegments'] as List).map<VideoSegment>(
@@ -694,9 +440,6 @@ class VideoRenderData {
           : null,
       composition: map['composition'] != null
           ? VideoComposition.fromMap(map['composition'] as Map<String, dynamic>)
-          : null,
-      imageBytes: map['imageBytes'] != null
-          ? Uint8List.fromList(List<int>.from(map['imageBytes'] as List))
           : null,
       imageLayers: map['imageLayers'] != null
           ? List<ImageLayer>.from(
@@ -709,18 +452,12 @@ class VideoRenderData {
           ? ExportTransform.fromMap(map['transform'] as Map<String, dynamic>)
           : null,
       enableAudio: map['enableAudio'] as bool,
-      playbackSpeed: tryParseDouble(map['playbackSpeed']),
       startTime: map['startTime'] != null
           ? Duration(microseconds: safeParseInt(map['startTime']))
           : null,
       endTime: map['endTime'] != null
           ? Duration(microseconds: safeParseInt(map['endTime']))
           : null,
-      colorMatrixList: List<List<double>>.from(
-        (map['colorMatrixList'] as List).map<List<double>>(
-          (x) => List<double>.from(x as List),
-        ),
-      ),
       colorFilters: List<ColorFilter>.from(
         (map['colorFilters'] as List).map<ColorFilter>(
           (x) => ColorFilter.fromMap(x as Map<String, dynamic>),
@@ -733,17 +470,8 @@ class VideoRenderData {
       ),
       blur: tryParseDouble(map['blur']),
       bitrate: map['bitrate'] != null ? safeParseInt(map['bitrate']) : null,
-      customAudioPath: map['customAudioPath'] != null
-          ? map['customAudioPath'] as String
-          : null,
-      customAudioStartTime: map['customAudioStartTime'] != null
-          ? Duration(microseconds: safeParseInt(map['customAudioStartTime']))
-          : null,
-      originalAudioVolume: tryParseDouble(map['originalAudioVolume']),
-      customAudioVolume: tryParseDouble(map['customAudioVolume']),
       shouldOptimizeForNetworkUse: map['shouldOptimizeForNetworkUse'] as bool,
       imageBytesWithCropping: map['imageBytesWithCropping'] as bool,
-      loopCustomAudio: map['loopCustomAudio'] as bool,
     );
   }
 
@@ -756,28 +484,20 @@ class VideoRenderData {
   String toString() {
     return 'VideoRenderData(id: $id, '
         'qualityConfig: $qualityConfig, '
-        'outputFormat: $outputFormat, video: $video, '
+        'outputFormat: $outputFormat, '
         'videoSegments: $videoSegments, '
         'composition: $composition, '
-        'imageBytes: $imageBytes, '
         'imageLayers: $imageLayers, '
         'transform: $transform, '
         'enableAudio: $enableAudio, '
-        'playbackSpeed: $playbackSpeed, '
         'startTime: $startTime, '
         'endTime: $endTime, '
-        'colorMatrixList: $colorMatrixList, '
         'colorFilters: $colorFilters, '
         'audioTracks: $audioTracks, '
         'blur: $blur, '
         'bitrate: $bitrate, '
-        'customAudioPath: $customAudioPath, '
-        'customAudioStartTime: $customAudioStartTime, '
-        'originalAudioVolume: $originalAudioVolume, '
-        'customAudioVolume: $customAudioVolume, '
         'shouldOptimizeForNetworkUse: $shouldOptimizeForNetworkUse, '
-        'imageBytesWithCropping: $imageBytesWithCropping, '
-        'loopCustomAudio: $loopCustomAudio)';
+        'imageBytesWithCropping: $imageBytesWithCropping)';
   }
 
   @override
@@ -787,28 +507,19 @@ class VideoRenderData {
     return other.id == id &&
         other.qualityConfig == qualityConfig &&
         other.outputFormat == outputFormat &&
-        other.video == video &&
         listEquals(other.videoSegments, videoSegments) &&
         other.composition == composition &&
-        other.imageBytes == imageBytes &&
         listEquals(other.imageLayers, imageLayers) &&
         other.transform == transform &&
         other.enableAudio == enableAudio &&
-        other.playbackSpeed == playbackSpeed &&
         other.startTime == startTime &&
         other.endTime == endTime &&
-        listEquals(other.colorMatrixList, colorMatrixList) &&
         listEquals(other.colorFilters, colorFilters) &&
         listEquals(other.audioTracks, audioTracks) &&
         other.blur == blur &&
         other.bitrate == bitrate &&
-        other.customAudioPath == customAudioPath &&
-        other.customAudioStartTime == customAudioStartTime &&
-        other.originalAudioVolume == originalAudioVolume &&
-        other.customAudioVolume == customAudioVolume &&
         other.shouldOptimizeForNetworkUse == shouldOptimizeForNetworkUse &&
-        other.imageBytesWithCropping == imageBytesWithCropping &&
-        other.loopCustomAudio == loopCustomAudio;
+        other.imageBytesWithCropping == imageBytesWithCropping;
   }
 
   @override
@@ -816,28 +527,19 @@ class VideoRenderData {
     return id.hashCode ^
         qualityConfig.hashCode ^
         outputFormat.hashCode ^
-        video.hashCode ^
         videoSegments.hashCode ^
         composition.hashCode ^
-        imageBytes.hashCode ^
         imageLayers.hashCode ^
         transform.hashCode ^
         enableAudio.hashCode ^
-        playbackSpeed.hashCode ^
         startTime.hashCode ^
         endTime.hashCode ^
-        colorMatrixList.hashCode ^
         colorFilters.hashCode ^
         audioTracks.hashCode ^
         blur.hashCode ^
         bitrate.hashCode ^
-        customAudioPath.hashCode ^
-        customAudioStartTime.hashCode ^
-        originalAudioVolume.hashCode ^
-        customAudioVolume.hashCode ^
         shouldOptimizeForNetworkUse.hashCode ^
-        imageBytesWithCropping.hashCode ^
-        loopCustomAudio.hashCode;
+        imageBytesWithCropping.hashCode;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 1.22.0
+version: 2.0.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/video/render_video_model_quality_preset_test.dart
+++ b/test/core/models/video/render_video_model_quality_preset_test.dart
@@ -7,11 +7,11 @@ void main() {
 
     test('creates model with 1080p quality preset', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.p1080,
       );
 
-      expect(model.video, equals(testVideo));
+      expect(model.videoSegments!.first.video, equals(testVideo));
       expect(model.bitrate, equals(8000000)); // 8 Mbps
       expect(model.outputFormat, equals(VideoOutputFormat.mp4));
       expect(model.enableAudio, isTrue);
@@ -19,7 +19,7 @@ void main() {
 
     test('creates model with 720p quality preset', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.p720,
       );
 
@@ -31,7 +31,7 @@ void main() {
 
     test('creates model with 4K quality preset', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.k4,
       );
 
@@ -43,7 +43,7 @@ void main() {
 
     test('allows bitrate override', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.p1080,
         bitrateOverride: 12000000,
       );
@@ -55,7 +55,7 @@ void main() {
       const customTransform = ExportTransform(flipX: true, rotateTurns: 1);
 
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.p1080,
         transform: customTransform,
       );
@@ -67,31 +67,36 @@ void main() {
 
     test('creates model with all optional parameters', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.p720,
         outputFormat: VideoOutputFormat.mov,
         enableAudio: false,
-        playbackSpeed: 2.0,
         startTime: const Duration(seconds: 5),
         endTime: const Duration(seconds: 10),
         blur: 5.0,
-        colorMatrixList: const [
-          [1.0, 0.0, 0.0, 0.0, 0.0],
+        colorFilters: const [
+          ColorFilter(
+            matrix: [
+              1.0, 0.0, 0.0, 0.0, 0.0, //
+              0.0, 1.0, 0.0, 0.0, 0.0, //
+              0.0, 0.0, 1.0, 0.0, 0.0, //
+              0.0, 0.0, 0.0, 1.0, 0.0, //
+            ],
+          ),
         ],
       );
 
       expect(model.outputFormat, equals(VideoOutputFormat.mov));
       expect(model.enableAudio, isFalse);
-      expect(model.playbackSpeed, equals(2.0));
       expect(model.startTime, equals(const Duration(seconds: 5)));
       expect(model.endTime, equals(const Duration(seconds: 10)));
       expect(model.blur, equals(5.0));
-      expect(model.colorMatrixList.length, equals(1));
+      expect(model.colorFilters.length, equals(1));
     });
 
     test('creates model with custom ID', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.p1080,
         id: 'custom-task-id',
       );
@@ -101,7 +106,7 @@ void main() {
 
     test('creates model with low quality preset', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.low,
       );
 
@@ -113,7 +118,7 @@ void main() {
 
     test('creates model with ultra 4K preset', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.ultra4K,
       );
 
@@ -125,7 +130,7 @@ void main() {
 
     test('custom preset does not set transform', () {
       final model = VideoRenderData.withQualityPreset(
-        video: testVideo,
+        videoSegments: [VideoSegment(video: testVideo)],
         qualityPreset: VideoQualityPreset.custom,
       );
 

--- a/test/pro_video_editor_method_channel_test.dart
+++ b/test/pro_video_editor_method_channel_test.dart
@@ -105,7 +105,6 @@ void main() {
     final mockModel = MockVideoRenderData();
 
     when(mockModel.id).thenReturn('test-render-id');
-    when(mockModel.video).thenReturn(mockVideo);
     when(
       mockModel.toAsyncMap(),
     ).thenAnswer((_) async => {'inputPath': 'test.mp4'});
@@ -122,10 +121,8 @@ void main() {
     });
 
     final mockModel = MockVideoRenderData();
-    final mockVideo = MockEditorVideo();
 
     when(mockModel.id).thenReturn('test-render-id');
-    when(mockModel.video).thenReturn(mockVideo);
     when(
       mockModel.toAsyncMap(),
     ).thenAnswer((_) async => {'inputPath': 'test.mp4'});

--- a/test/pro_video_editor_method_channel_test.mocks.dart
+++ b/test/pro_video_editor_method_channel_test.mocks.dart
@@ -374,12 +374,6 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
       ) as bool);
 
   @override
-  List<List<double>> get colorMatrixList => (super.noSuchMethod(
-        Invocation.getter(#colorMatrixList),
-        returnValue: <List<double>>[],
-      ) as List<List<double>>);
-
-  @override
   List<_i4.ColorFilter> get colorFilters => (super.noSuchMethod(
         Invocation.getter(#colorFilters),
         returnValue: <_i4.ColorFilter>[],
@@ -404,12 +398,6 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
       ) as bool);
 
   @override
-  bool get loopCustomAudio => (super.noSuchMethod(
-        Invocation.getter(#loopCustomAudio),
-        returnValue: false,
-      ) as bool);
-
-  @override
   _i7.Stream<_i11.ProgressModel> get progressStream => (super.noSuchMethod(
         Invocation.getter(#progressStream),
         returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
@@ -430,28 +418,19 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
     String? id,
     _i4.VideoQualityConfig? qualityConfig,
     _i4.VideoOutputFormat? outputFormat,
-    _i2.EditorVideo? video,
     List<_i4.VideoSegment>? videoSegments,
     _i4.VideoComposition? composition,
-    _i5.Uint8List? imageBytes,
     List<_i4.ImageLayer>? imageLayers,
     _i4.ExportTransform? transform,
     bool? enableAudio,
-    double? playbackSpeed,
     Duration? startTime,
     Duration? endTime,
-    List<List<double>>? colorMatrixList,
     List<_i4.ColorFilter>? colorFilters,
     List<_i4.VideoAudioTrack>? audioTracks,
     double? blur,
     int? bitrate,
-    String? customAudioPath,
-    Duration? customAudioStartTime,
-    double? originalAudioVolume,
-    double? customAudioVolume,
     bool? shouldOptimizeForNetworkUse,
     bool? imageBytesWithCropping,
-    bool? loopCustomAudio,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -461,28 +440,19 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
             #id: id,
             #qualityConfig: qualityConfig,
             #outputFormat: outputFormat,
-            #video: video,
             #videoSegments: videoSegments,
             #composition: composition,
-            #imageBytes: imageBytes,
             #imageLayers: imageLayers,
             #transform: transform,
             #enableAudio: enableAudio,
-            #playbackSpeed: playbackSpeed,
             #startTime: startTime,
             #endTime: endTime,
-            #colorMatrixList: colorMatrixList,
             #colorFilters: colorFilters,
             #audioTracks: audioTracks,
             #blur: blur,
             #bitrate: bitrate,
-            #customAudioPath: customAudioPath,
-            #customAudioStartTime: customAudioStartTime,
-            #originalAudioVolume: originalAudioVolume,
-            #customAudioVolume: customAudioVolume,
             #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
             #imageBytesWithCropping: imageBytesWithCropping,
-            #loopCustomAudio: loopCustomAudio,
           },
         ),
         returnValue: _FakeVideoRenderData_2(
@@ -494,28 +464,19 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
               #id: id,
               #qualityConfig: qualityConfig,
               #outputFormat: outputFormat,
-              #video: video,
               #videoSegments: videoSegments,
               #composition: composition,
-              #imageBytes: imageBytes,
               #imageLayers: imageLayers,
               #transform: transform,
               #enableAudio: enableAudio,
-              #playbackSpeed: playbackSpeed,
               #startTime: startTime,
               #endTime: endTime,
-              #colorMatrixList: colorMatrixList,
               #colorFilters: colorFilters,
               #audioTracks: audioTracks,
               #blur: blur,
               #bitrate: bitrate,
-              #customAudioPath: customAudioPath,
-              #customAudioStartTime: customAudioStartTime,
-              #originalAudioVolume: originalAudioVolume,
-              #customAudioVolume: customAudioVolume,
               #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
               #imageBytesWithCropping: imageBytesWithCropping,
-              #loopCustomAudio: loopCustomAudio,
             },
           ),
         ),


### PR DESCRIPTION
## Summary

Removes the long-deprecated APIs and bumps the package to **2.0.0** (the first breaking release). Builds on top of the composition feature (#156, shipped as `1.22.0`).

## Removed → replacement

| Removed | Use instead |
|---|---|
| `VideoRenderData.video` | `videoSegments: [VideoSegment(video: …)]` |
| `VideoRenderData.imageBytes` | `imageLayers` |
| `VideoRenderData.playbackSpeed` | `VideoSegment.playbackSpeed` |
| `VideoRenderData.colorMatrixList` | `colorFilters` (`ColorFilter`) |
| `VideoRenderData.customAudioPath` / `customAudioStartTime` / `customAudioVolume` / `loopCustomAudio` | `audioTracks` (`VideoAudioTrack`) |
| `VideoRenderData.originalAudioVolume` | `VideoSegment.volume` |
| `VideoMetadata.originalResolution` | `rawResolution` |

The corresponding constructor params, `withQualityPreset` params, `toMap`/`fromMap`/`toAsyncMap`/`copyWith`/`toString`/`==`/`hashCode` entries and the merge-fallback logic (single video → clip, `customAudio*` → `audioTracks`, `colorMatrixList` → `colorFilters`, `imageBytes` → `imageLayers`) are all gone.

## Migrations done in-repo
- Regenerated the mockito mocks.
- Migrated the example app and integration tests (global `playbackSpeed` → per-segment).
- Updated unit tests (`colorMatrixList` → `colorFilters`).
- README "Advanced Example" updated (`ImageLayer(image:)`, per-segment speed).

## Native
No native changes needed — the removed fields simply stop being sent over the channel; the native parsers already default missing keys.

## Testing
- `flutter analyze` clean (lib, test, example).
- 228 Dart unit tests pass.
- Migrated per-segment speed integration tests pass on macOS (14/14).