### PR TITLE
Expand integration tests and fix 3 platform bugs

### DIFF
--- a/android/src/main/kotlin/ch/waio/pro_video_editor/ProVideoEditorPlugin.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/ProVideoEditorPlugin.kt
@@ -539,8 +539,10 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
                 onComplete = { waveformData ->
                     mainHandler.post {
                         postProgress(id, 1.0)
-                        val removedTask = activeWaveformTasks.remove(id)
-                        if (removedTask?.isCanceled == true) {
+                        activeWaveformTasks.remove(id)
+                        // Use the captured task: handleCancelTask may have already
+                        // removed it from the map, so the map lookup can be null.
+                        if (task.isCanceled) {
                             result.error("CANCELED", "Waveform generation was cancelled", null)
                         } else {
                             result.success(waveformData)
@@ -549,9 +551,9 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
                 },
                 onError = { error ->
                     mainHandler.post {
-                        val removedTask = activeWaveformTasks.remove(id)
+                        activeWaveformTasks.remove(id)
                         val code = when {
-                            removedTask?.isCanceled == true -> "CANCELED"
+                            task.isCanceled -> "CANCELED"
                             error is NoAudioTrackException -> "NO_AUDIO"
                             else -> "WAVEFORM_ERROR"
                         }
@@ -623,9 +625,11 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
                 },
                 onError = { error ->
                     mainHandler.post {
-                        val removedTask = activeWaveformTasks.remove(id)
+                        activeWaveformTasks.remove(id)
+                        // Use the captured task: handleCancelTask may have already
+                        // removed it from the map, so the map lookup can be null.
                         val code = when {
-                            removedTask?.isCanceled == true -> "CANCELED"
+                            task.isCanceled -> "CANCELED"
                             error is NoAudioTrackException -> "NO_AUDIO"
                             else -> "WAVEFORM_ERROR"
                         }

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
@@ -470,7 +470,10 @@ class RenderVideo(private val context: Context) {
             } else {
                 File(
                     context.cacheDir,
-                    "video_output_${System.currentTimeMillis()}.${config.outputFormat}"
+                    // A UUID keeps concurrent renders from colliding on the same
+                    // millisecond timestamp.
+                    "video_output_${System.currentTimeMillis()}_" +
+                        "${java.util.UUID.randomUUID()}.${config.outputFormat}"
                 )
             }
         outputFileRef.set(outputFile)

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoTranscoder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoTranscoder.kt
@@ -86,7 +86,7 @@ object VideoTranscoder {
 
         val outputFile = File(
             context.cacheDir,
-            "transcoded_${System.currentTimeMillis()}.mp4"
+            "transcoded_${System.currentTimeMillis()}_${java.util.UUID.randomUUID()}.mp4"
         )
 
         val resultRef = AtomicReference<TranscodeResult>()

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/thumbnail/ThumbnailGenerator.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/thumbnail/ThumbnailGenerator.kt
@@ -137,7 +137,7 @@ class ThumbnailGenerator(private val context: Context) {
 
                     // Extract frame at specified timestamp (closest frame)
                     val bitmap =
-                        retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST)
+                        extractFrame(retriever, timeUs, MediaMetadataRetriever.OPTION_CLOSEST)
                     if (bitmap != null) {
                         val resized =
                             resizeBitmapKeepingAspect(bitmap, outputWidth, outputHeight, boxFit)
@@ -219,7 +219,11 @@ class ThumbnailGenerator(private val context: Context) {
 
                     // Extract keyframe (OPTION_CLOSEST_SYNC ensures we get exact keyframe)
                     val bitmap =
-                        retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+                        extractFrame(
+                            retriever,
+                            timeUs,
+                            MediaMetadataRetriever.OPTION_CLOSEST_SYNC
+                        )
                     if (bitmap != null) {
                         val resized =
                             resizeBitmapKeepingAspect(bitmap, outputWidth, outputHeight, boxFit)
@@ -302,6 +306,54 @@ class ThumbnailGenerator(private val context: Context) {
         return List(maxOutputFrames) { i ->
             allKeyframes[(i * step).toInt()]
         }
+    }
+
+    /**
+     * Extracts a frame at [timeUs], falling back through alternative seek
+     * options when the preferred [primaryOption] returns null.
+     *
+     * Some devices return a null frame for 10-bit HDR HEVC at non-sync
+     * timestamps with OPTION_CLOSEST, so we retry at the nearest sync frames
+     * before giving up. Any frame is normalized to a software ARGB_8888 bitmap
+     * so the downstream resize/compress path can read its pixels.
+     */
+    private fun extractFrame(
+        retriever: MediaMetadataRetriever,
+        timeUs: Long,
+        primaryOption: Int,
+    ): Bitmap? {
+        val options = linkedSetOf(
+            primaryOption,
+            MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+            MediaMetadataRetriever.OPTION_PREVIOUS_SYNC,
+            MediaMetadataRetriever.OPTION_NEXT_SYNC,
+        )
+        for (option in options) {
+            val frame = try {
+                retriever.getFrameAtTime(timeUs, option)
+            } catch (e: Exception) {
+                null
+            }
+            if (frame != null) return normalizeBitmap(frame)
+        }
+        // Last resort: a representative frame near the start of the video.
+        return try {
+            retriever.getFrameAtTime()?.let { normalizeBitmap(it) }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Converts a frame to a software ARGB_8888 bitmap when needed (e.g. HDR
+     * frames decoded as RGBA_1010102 or hardware bitmaps can't be read
+     * directly by the resize/compress path).
+     */
+    private fun normalizeBitmap(bitmap: Bitmap): Bitmap {
+        if (bitmap.config == Bitmap.Config.ARGB_8888) return bitmap
+        val converted = bitmap.copy(Bitmap.Config.ARGB_8888, false) ?: return bitmap
+        if (converted !== bitmap) bitmap.recycle()
+        return converted
     }
 
     /**

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
@@ -339,7 +339,10 @@ class RenderVideo {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyyMMdd_HHmmss_SSS"
     let timestamp = formatter.string(from: Date())
-    return "\(prefix)_\(timestamp).\(ext)"
+    // A random suffix keeps concurrent renders from colliding on the same
+    // millisecond timestamp.
+    let random = UInt32.random(in: 0...UInt32.max)
+    return "\(prefix)_\(timestamp)_\(random).\(ext)"
   }
 
   private static func temporaryURL(for format: String) -> URL {

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/stopmotion/StopMotionGenerator.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/stopmotion/StopMotionGenerator.swift
@@ -227,7 +227,8 @@ internal enum StopMotionGenerator {
     }
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyyMMdd_HHmmss_SSS"
-    let filename = "stopmotion_\(formatter.string(from: Date())).\(format)"
+    let random = UInt32.random(in: 0...UInt32.max)
+    let filename = "stopmotion_\(formatter.string(from: Date()))_\(random).\(format)"
     return FileManager.default.temporaryDirectory.appendingPathComponent(filename)
   }
 

--- a/example/integration_test/audio_extract_test.dart
+++ b/example/integration_test/audio_extract_test.dart
@@ -304,6 +304,31 @@ void main() {
     }
   }, skip: skipPlatform);
 
+  testWidgets('extractAudio throws on a video without an audio track', (
+    tester,
+  ) async {
+    final format = Platform.isAndroid ? AudioFormat.mp3 : AudioFormat.m4a;
+
+    final directory = await getTemporaryDirectory();
+    final outputPath =
+        '${directory.path}/test_audio_noaudio_${DateTime.now().millisecondsSinceEpoch}.${format.extension}';
+
+    final config = AudioExtractConfigs(
+      video: EditorVideo.asset('assets/demo_muted.mp4'),
+      format: format,
+    );
+
+    await expectLater(
+      ProVideoEditor.instance.extractAudioToFile(outputPath, config),
+      throwsA(isA<AudioNoTrackException>()),
+    );
+
+    final file = File(outputPath);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }, skip: skipPlatform);
+
   testWidgets('extractAudio handles invalid time ranges gracefully', (
     tester,
   ) async {

--- a/example/integration_test/concurrency_test.dart
+++ b/example/integration_test/concurrency_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final pve = ProVideoEditor.instance;
+  final testVideo = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+  final isAndroid = !kIsWeb && Platform.isAndroid;
+  final isIOS = !kIsWeb && Platform.isIOS;
+  final isMacOS = !kIsWeb && Platform.isMacOS;
+  final supportsCancel = !kIsWeb && (isAndroid || isIOS || isMacOS);
+
+  ThumbnailConfigs thumbTask(String id) => ThumbnailConfigs(
+    id: id,
+    video: testVideo,
+    outputFormat: ThumbnailFormat.jpeg,
+    timestamps: List.generate(6, (i) => Duration(seconds: i * 2)),
+    outputSize: const Size(64, 64),
+    boxFit: ThumbnailBoxFit.cover,
+  );
+
+  VideoRenderData renderTask(String id, Duration start, Duration end) =>
+      VideoRenderData(
+        id: id,
+        videoSegments: [
+          VideoSegment(video: testVideo, startTime: start, endTime: end),
+        ],
+        outputFormat: VideoOutputFormat.mp4,
+      );
+
+  testWidgets('concurrent tasks keep progress streams isolated', (
+    tester,
+  ) async {
+    final taskA = thumbTask('concurrent-a');
+    final taskB = thumbTask('concurrent-b');
+
+    final aEvents = <ProgressModel>[];
+    final bEvents = <ProgressModel>[];
+    final seenIds = <String>{};
+
+    final subA = taskA.progressStream.listen(aEvents.add);
+    final subB = taskB.progressStream.listen(bEvents.add);
+    final subAll = pve.progressStream.listen((e) => seenIds.add(e.id));
+
+    await Future.wait([pve.getThumbnails(taskA), pve.getThumbnails(taskB)]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await subA.cancel();
+    await subB.cancel();
+    await subAll.cancel();
+
+    expect(aEvents, isNotEmpty, reason: 'task A produced no progress');
+    expect(bEvents, isNotEmpty, reason: 'task B produced no progress');
+    expect(
+      aEvents.every((e) => e.id == taskA.id),
+      isTrue,
+      reason: 'task A stream leaked events from another task',
+    );
+    expect(
+      bEvents.every((e) => e.id == taskB.id),
+      isTrue,
+      reason: 'task B stream leaked events from another task',
+    );
+    expect(seenIds, containsAll(<String>{taskA.id, taskB.id}));
+  }, skip: kIsWeb);
+
+  testWidgets('two concurrent in-memory renders both succeed', (tester) async {
+    // Both renders start in the same instant; the native temp output filename
+    // must be unique per task so they don't collide.
+    final results = await Future.wait([
+      pve.renderVideo(
+        renderTask('render-a', Duration.zero, const Duration(seconds: 2)),
+      ),
+      pve.renderVideo(
+        renderTask(
+          'render-b',
+          const Duration(seconds: 2),
+          const Duration(seconds: 4),
+        ),
+      ),
+    ]);
+
+    for (final bytes in results) {
+      expect(bytes.lengthInBytes, greaterThan(10000));
+    }
+  }, skip: kIsWeb);
+
+  testWidgets('cancelling one render leaves the other running', (tester) async {
+    final modelA = renderTask(
+      'cancel-a',
+      Duration.zero,
+      const Duration(seconds: 8),
+    );
+    final modelB = renderTask(
+      'cancel-b',
+      Duration.zero,
+      const Duration(seconds: 2),
+    );
+
+    final futureA = pve.renderVideo(modelA);
+    final errorA = futureA.then<Object?>((_) => null, onError: (Object e) => e);
+    final futureB = pve.renderVideo(modelB);
+
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+
+    try {
+      await pve.cancel(modelA.id);
+    } on PlatformException catch (e) {
+      if (e.code != 'TASK_NOT_FOUND') rethrow;
+    }
+
+    /// Task B must finish untouched by task A's cancellation.
+    final bytesB = await futureB;
+    expect(bytesB.lengthInBytes, greaterThan(10000));
+
+    /// Task A was either cancelled (RenderCanceledException) or had already
+    /// finished before the cancel landed on a fast machine.
+    final error = await errorA;
+    if (error != null) {
+      expect(error, isA<RenderCanceledException>());
+    }
+  }, skip: !supportsCancel);
+}

--- a/example/integration_test/error_handling_test.dart
+++ b/example/integration_test/error_handling_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final pve = ProVideoEditor.instance;
+  final testVideo = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+  final isWindows = defaultTargetPlatform == TargetPlatform.windows;
+  final isLinux = defaultTargetPlatform == TargetPlatform.linux;
+  final skipAudioTrack = kIsWeb || isWindows || isLinux;
+
+  /// 1 KiB of zeros — a syntactically invalid video container.
+  final garbageBytes = Uint8List(1024);
+
+  group('Invalid input - getMetadata', () {
+    testWidgets('throws on empty bytes', (tester) async {
+      await expectLater(
+        pve.getMetadata(EditorVideo.memory(Uint8List(0))),
+        throwsA(anything),
+      );
+    });
+
+    testWidgets('throws on garbage bytes', (tester) async {
+      await expectLater(
+        pve.getMetadata(EditorVideo.memory(garbageBytes)),
+        throwsA(anything),
+      );
+    });
+
+    testWidgets('throws on a non-existent asset path', (tester) async {
+      await expectLater(
+        pve.getMetadata(EditorVideo.asset('assets/does_not_exist.mp4')),
+        throwsA(anything),
+      );
+    });
+  });
+
+  group('Invalid input - hasAudioTrack', () {
+    testWidgets('throws on garbage bytes', (tester) async {
+      await expectLater(
+        pve.hasAudioTrack(EditorVideo.memory(garbageBytes)),
+        throwsA(anything),
+      );
+    }, skip: skipAudioTrack);
+  });
+
+  group('Thumbnail edge cases', () {
+    testWidgets('empty timestamp list yields no thumbnails', (tester) async {
+      List<Uint8List>? result;
+      Object? error;
+      try {
+        result = await pve.getThumbnails(
+          ThumbnailConfigs(
+            video: testVideo,
+            outputFormat: ThumbnailFormat.jpeg,
+            timestamps: const [],
+            outputSize: const Size(64, 64),
+            boxFit: ThumbnailBoxFit.cover,
+          ),
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      /// Either an empty result or a thrown error is acceptable, but the
+      /// plugin must not hang or return malformed data.
+      expect(
+        result?.isEmpty ?? error != null,
+        isTrue,
+        reason: 'empty timestamps must not produce thumbnails',
+      );
+    });
+
+    testWidgets('timestamp beyond duration is handled', (tester) async {
+      /// A timestamp far past the end of the clip must clamp to a valid frame
+      /// or fail cleanly — never hang.
+      Object? error;
+      List<Uint8List>? result;
+      try {
+        result = await pve.getThumbnails(
+          ThumbnailConfigs(
+            video: testVideo,
+            outputFormat: ThumbnailFormat.jpeg,
+            timestamps: const [Duration(hours: 1)],
+            outputSize: const Size(64, 64),
+            boxFit: ThumbnailBoxFit.cover,
+          ),
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      if (error == null) {
+        expect(result, isNotNull);
+        for (final thumb in result!) {
+          expect(thumb.lengthInBytes, greaterThan(0));
+        }
+      }
+    });
+  });
+
+  group('Render - invalid configuration', () {
+    testWidgets('crop rect outside bounds fails cleanly or clamps', (
+      tester,
+    ) async {
+      /// A crop window entirely outside the source frame should either be
+      /// rejected with an exception or clamped — but must not crash the
+      /// plugin or hang.
+      Object? error;
+      Uint8List? result;
+      try {
+        result = await pve.renderVideo(
+          VideoRenderData(
+            videoSegments: [VideoSegment(video: testVideo)],
+            outputFormat: VideoOutputFormat.mp4,
+            transform: const ExportTransform(
+              x: 100000,
+              y: 100000,
+              width: 64,
+              height: 64,
+            ),
+          ),
+        );
+      } catch (e) {
+        error = e;
+      }
+
+      expect(
+        error != null || (result != null && result.isNotEmpty),
+        isTrue,
+        reason: 'out-of-bounds crop must throw or produce a clamped output',
+      );
+    }, skip: kIsWeb);
+  });
+}

--- a/example/integration_test/render_pixel_test.dart
+++ b/example/integration_test/render_pixel_test.dart
@@ -1,0 +1,661 @@
+import 'dart:typed_data';
+import 'dart:ui' show Offset, Size, instantiateImageCodec;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+/// Pixel-level verification that render effects actually transform the frame —
+/// not just that the render completes. Each effect output is decoded back to a
+/// frame (via a PNG thumbnail) and its pixels are compared against the source.
+///
+/// All assertions are deliberately *content-independent*: they compare the
+/// effect output against the source (or against an internal invariant such as
+/// "R == G == B") rather than hard-coding any expected colors, so they stay
+/// robust against YUV/codec rounding.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final pve = ProVideoEditor.instance;
+
+  final h264Video = EditorVideo.asset(kVideoEditorExampleH264Path);
+  final hevcVideo = EditorVideo.asset(kVideoEditorExampleHevcPath);
+
+  /// Sample points that include the center axes — fine for color tests.
+  const colorPoints = <Offset>[
+    Offset(0.2, 0.3),
+    Offset(0.5, 0.3),
+    Offset(0.8, 0.3),
+    Offset(0.2, 0.5),
+    Offset(0.5, 0.5),
+    Offset(0.8, 0.5),
+    Offset(0.2, 0.7),
+    Offset(0.5, 0.7),
+    Offset(0.8, 0.7),
+  ];
+
+  /// Sample points that avoid both center axes (0.5) — required for mirror
+  /// checks, where a center pixel maps onto itself.
+  const geoPoints = <Offset>[
+    Offset(0.15, 0.25),
+    Offset(0.35, 0.25),
+    Offset(0.65, 0.25),
+    Offset(0.85, 0.25),
+    Offset(0.15, 0.4),
+    Offset(0.35, 0.4),
+    Offset(0.65, 0.4),
+    Offset(0.85, 0.4),
+    Offset(0.15, 0.6),
+    Offset(0.35, 0.6),
+    Offset(0.65, 0.6),
+    Offset(0.85, 0.6),
+    Offset(0.15, 0.75),
+    Offset(0.35, 0.75),
+    Offset(0.65, 0.75),
+    Offset(0.85, 0.75),
+  ];
+
+  /// Decodes a frame at [at], sized to the video's own aspect ratio so that
+  /// `cover` performs no crop and relative coordinates map linearly.
+  /// Decodes a frame, or returns null if no frame could be extracted (e.g. some
+  /// devices cannot thumbnail 10-bit HDR HEVC at an arbitrary timestamp).
+  Future<_Frame?> tryFrameOf(
+    EditorVideo video, {
+    Duration at = const Duration(seconds: 1),
+  }) async {
+    final meta = await pve.getMetadata(video);
+    const baseHeight = 200.0;
+    final width = (baseHeight * meta.resolution.aspectRatio).roundToDouble();
+    final size = Size(width, baseHeight);
+
+    final frames = await pve.getThumbnails(
+      ThumbnailConfigs(
+        video: video,
+        outputFormat: ThumbnailFormat.png,
+        timestamps: [at],
+        outputSize: size,
+        boxFit: ThumbnailBoxFit.cover,
+      ),
+    );
+    if (frames.isEmpty) return null;
+    final codec = await instantiateImageCodec(frames.first);
+    final image = (await codec.getNextFrame()).image;
+    final data = await image.toByteData();
+    return _Frame(data!, image.width, image.height);
+  }
+
+  Future<_Frame> frameOf(
+    EditorVideo video, {
+    Duration at = const Duration(seconds: 1),
+  }) async {
+    final frame = await tryFrameOf(video, at: at);
+    expect(frame, isNotNull, reason: 'no frame extracted');
+    return frame!;
+  }
+
+  Future<Uint8List> renderFilter(EditorVideo video, List<double> matrix) {
+    return pve.renderVideo(
+      VideoRenderData(
+        videoSegments: [VideoSegment(video: video)],
+        outputFormat: VideoOutputFormat.mp4,
+        colorFilters: [ColorFilter(matrix: matrix)],
+      ),
+    );
+  }
+
+  group('Color filters', () {
+    testWidgets('identity matrix preserves the image', (tester) async {
+      final bytes = await renderFilter(h264Video, _identity);
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      final meanError = _meanError(out, original, colorPoints, (o, s) => o);
+      expect(
+        meanError,
+        lessThan(40),
+        reason: 'identity filter should not noticeably alter pixels',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('grayscale desaturates colored pixels', (tester) async {
+      final bytes = await renderFilter(h264Video, _grayscale);
+      final original = await frameOf(h264Video);
+      final gray = await frameOf(EditorVideo.memory(bytes));
+
+      var colored = 0;
+      var desaturated = 0;
+      for (final p in colorPoints) {
+        if (_spread(original.at(p.dx, p.dy)) > 25) {
+          colored++;
+          if (_spread(gray.at(p.dx, p.dy)) <= 20) desaturated++;
+        }
+      }
+      expect(colored, greaterThan(0), reason: 'no colored source pixels');
+      expect(
+        desaturated,
+        equals(colored),
+        reason: '$colored colored sample(s) stayed saturated',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('invert produces the photographic negative', (tester) async {
+      final bytes = await renderFilter(h264Video, _invert);
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      // Error against the expected negative must be far smaller than the
+      // error a non-inverted (identity) output would show.
+      final negError = _meanError(
+        out,
+        original,
+        colorPoints,
+        (o, s) => 255 - s,
+      );
+      final idError = _meanError(out, original, colorPoints, (o, s) => s);
+      expect(negError, lessThan(55), reason: 'output is not a negative');
+      expect(
+        negError,
+        lessThan(idError),
+        reason: 'output matches the source more than its negative',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('half-scale matrix darkens the image', (tester) async {
+      final bytes = await renderFilter(h264Video, _darken);
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      expect(
+        _meanLuma(out, colorPoints),
+        lessThan(_meanLuma(original, colorPoints) * 0.75),
+        reason: 'a 0.5 scale matrix must visibly darken the frame',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('channel-swap matrix swaps red and blue', (tester) async {
+      final bytes = await renderFilter(h264Video, _swapRB);
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      var tested = 0;
+      var swapError = 0;
+      var keepError = 0;
+      for (final p in colorPoints) {
+        final s = original.at(p.dx, p.dy);
+        if ((s[0] - s[2]).abs() < 30) continue; // need R≠B to tell them apart
+        tested++;
+        final o = out.at(p.dx, p.dy);
+        swapError += (o[0] - s[2]).abs() + (o[2] - s[0]).abs();
+        keepError += (o[0] - s[0]).abs() + (o[2] - s[2]).abs();
+      }
+      expect(tested, greaterThan(0), reason: 'no R≠B pixels to test the swap');
+      expect(
+        swapError,
+        lessThan(keepError),
+        reason: 'output red/blue match the swapped source channels',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('zero matrix blacks out the frame', (tester) async {
+      final bytes = await renderFilter(h264Video, _blackout);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      for (final p in colorPoints) {
+        final c = out.at(p.dx, p.dy);
+        expect(
+          c[0] + c[1] + c[2],
+          lessThan(100),
+          reason: 'pixel ${p.dx},${p.dy} is not black: $c',
+        );
+      }
+    }, skip: kIsWeb);
+  });
+
+  group('Geometric transforms', () {
+    Future<Uint8List> renderTransform(ExportTransform transform) {
+      return pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: h264Video)],
+          outputFormat: VideoOutputFormat.mp4,
+          transform: transform,
+        ),
+      );
+    }
+
+    testWidgets('flipX mirrors horizontally', (tester) async {
+      final bytes = await renderTransform(const ExportTransform(flipX: true));
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      final mirror = _matchSum(
+        out,
+        original,
+        geoPoints,
+        (x, y) => Offset(1 - x, y),
+      );
+      final identity = _matchSum(out, original, geoPoints, Offset.new);
+      expect(identity, greaterThan(0), reason: 'source frame is uniform');
+      expect(
+        mirror,
+        lessThan(identity),
+        reason: 'flipped frame matches the horizontally mirrored source',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('flipY mirrors vertically', (tester) async {
+      final bytes = await renderTransform(const ExportTransform(flipY: true));
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      final mirror = _matchSum(
+        out,
+        original,
+        geoPoints,
+        (x, y) => Offset(x, 1 - y),
+      );
+      final identity = _matchSum(out, original, geoPoints, Offset.new);
+      expect(
+        mirror,
+        lessThan(identity),
+        reason: 'flipped frame matches the vertically mirrored source',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('flipX + flipY rotates 180°', (tester) async {
+      final bytes = await renderTransform(
+        const ExportTransform(flipX: true, flipY: true),
+      );
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      final flipped = _matchSum(
+        out,
+        original,
+        geoPoints,
+        (x, y) => Offset(1 - x, 1 - y),
+      );
+      final identity = _matchSum(out, original, geoPoints, Offset.new);
+      expect(
+        flipped,
+        lessThan(identity),
+        reason: 'double flip matches the 180°-rotated source',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('crop selects the requested source region', (tester) async {
+      const cropX = 200, cropY = 150, cropW = 700, cropH = 300;
+      final bytes = await renderTransform(
+        const ExportTransform(x: cropX, y: cropY, width: cropW, height: cropH),
+      );
+
+      final srcMeta = await pve.getMetadata(h264Video);
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      // Map each output point into the source crop window, then compare with
+      // the same point taken at face value (the wrong region).
+      var regionSum = 0;
+      var wrongSum = 0;
+      for (final p in geoPoints) {
+        final sx = (cropX + p.dx * cropW) / srcMeta.resolution.width;
+        final sy = (cropY + p.dy * cropH) / srcMeta.resolution.height;
+        final o = out.at(p.dx, p.dy);
+        regionSum += _dist(o, original.at(sx, sy));
+        wrongSum += _dist(o, original.at(p.dx, p.dy));
+      }
+      expect(
+        regionSum,
+        lessThan(wrongSum),
+        reason: 'crop output matches the requested source sub-rectangle',
+      );
+    }, skip: kIsWeb);
+  });
+
+  group('Blur', () {
+    testWidgets('reduces high-frequency detail', (tester) async {
+      final bytes = await pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: h264Video)],
+          outputFormat: VideoOutputFormat.mp4,
+          blur: 20,
+        ),
+      );
+      final original = await frameOf(h264Video);
+      final blurred = await frameOf(EditorVideo.memory(bytes));
+
+      final sharpOriginal = _sharpness(original);
+      final sharpBlurred = _sharpness(blurred);
+      expect(sharpOriginal, greaterThan(0));
+      expect(
+        sharpBlurred,
+        lessThan(sharpOriginal * 0.9),
+        reason: 'blurred frame should be measurably smoother',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('preserves overall brightness', (tester) async {
+      final bytes = await pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: h264Video)],
+          outputFormat: VideoOutputFormat.mp4,
+          blur: 20,
+        ),
+      );
+      final original = await frameOf(h264Video);
+      final blurred = await frameOf(EditorVideo.memory(bytes));
+
+      final lumaOriginal = _meanLuma(original, colorPoints);
+      final lumaBlurred = _meanLuma(blurred, colorPoints);
+      expect(
+        lumaBlurred,
+        closeTo(lumaOriginal, lumaOriginal * 0.25 + 15),
+        reason: 'blur must not significantly shift overall brightness',
+      );
+    }, skip: kIsWeb);
+  });
+
+  group('Timed color filter', () {
+    testWidgets('applies only inside its time window', (tester) async {
+      final bytes = await pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: h264Video)],
+          outputFormat: VideoOutputFormat.mp4,
+          colorFilters: [
+            ColorFilter(
+              matrix: _grayscale,
+              startTime: const Duration(seconds: 3),
+              endTime: const Duration(seconds: 6),
+            ),
+          ],
+        ),
+      );
+
+      const inside = Duration(milliseconds: 4500);
+      const outside = Duration(seconds: 1);
+
+      final srcInside = await frameOf(h264Video, at: inside);
+      final srcOutside = await frameOf(h264Video, at: outside);
+      final outInside = await frameOf(EditorVideo.memory(bytes), at: inside);
+      final outOutside = await frameOf(EditorVideo.memory(bytes), at: outside);
+
+      // Inside the window: colored source pixels become desaturated.
+      var insideColored = 0, insideDesat = 0;
+      for (final p in colorPoints) {
+        if (_spread(srcInside.at(p.dx, p.dy)) > 25) {
+          insideColored++;
+          if (_spread(outInside.at(p.dx, p.dy)) <= 20) insideDesat++;
+        }
+      }
+      expect(insideColored, greaterThan(0));
+      expect(
+        insideDesat,
+        equals(insideColored),
+        reason: 'filter did not apply inside its window',
+      );
+
+      // Outside the window: colored source pixels stay colored.
+      var outsideColored = 0, outsideStillColored = 0;
+      for (final p in colorPoints) {
+        if (_spread(srcOutside.at(p.dx, p.dy)) > 25) {
+          outsideColored++;
+          if (_spread(outOutside.at(p.dx, p.dy)) > 20) outsideStillColored++;
+        }
+      }
+      expect(outsideColored, greaterThan(0));
+      expect(
+        outsideStillColored,
+        equals(outsideColored),
+        reason: 'filter leaked outside its window',
+      );
+    }, skip: kIsWeb);
+  });
+
+  group('Combined effects', () {
+    testWidgets('grayscale + flipX apply together', (tester) async {
+      final bytes = await pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: h264Video)],
+          outputFormat: VideoOutputFormat.mp4,
+          colorFilters: [const ColorFilter(matrix: _grayscale)],
+          transform: const ExportTransform(flipX: true),
+        ),
+      );
+      final original = await frameOf(h264Video);
+      final out = await frameOf(EditorVideo.memory(bytes));
+
+      // Desaturated everywhere it was colored...
+      var colored = 0, desaturated = 0;
+      for (final p in colorPoints) {
+        if (_spread(original.at(p.dx, p.dy)) > 25) {
+          colored++;
+          if (_spread(out.at(p.dx, p.dy)) <= 20) desaturated++;
+        }
+      }
+      expect(colored, greaterThan(0));
+      expect(desaturated, equals(colored), reason: 'grayscale not applied');
+
+      // ...and mirrored (compare luminance, since color was removed).
+      final mirror = _lumaMatchSum(
+        out,
+        original,
+        geoPoints,
+        (x, y) => Offset(1 - x, y),
+      );
+      final identity = _lumaMatchSum(out, original, geoPoints, Offset.new);
+      expect(mirror, lessThan(identity), reason: 'flipX not applied');
+    }, skip: kIsWeb);
+  });
+
+  group('HEVC source', () {
+    testWidgets('grayscale desaturates an HEVC frame', (tester) async {
+      final bytes = await renderFilter(hevcVideo, _grayscale);
+      final original = await tryFrameOf(hevcVideo);
+      final gray = await tryFrameOf(EditorVideo.memory(bytes));
+      if (original == null || gray == null) {
+        markTestSkipped('HDR HEVC frame not extractable on this device');
+        return;
+      }
+
+      var colored = 0, desaturated = 0;
+      for (final p in colorPoints) {
+        if (_spread(original.at(p.dx, p.dy)) > 25) {
+          colored++;
+          if (_spread(gray.at(p.dx, p.dy)) <= 20) desaturated++;
+        }
+      }
+      // Some devices tone-map the HDR HEVC frame to a near-gray image, leaving
+      // no colored source pixels to verify desaturation against.
+      if (colored == 0) {
+        markTestSkipped('HEVC frame has no colored pixels on this device');
+        return;
+      }
+      expect(desaturated, equals(colored));
+    }, skip: kIsWeb);
+
+    testWidgets('flipX mirrors an HEVC frame', (tester) async {
+      final bytes = await pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: hevcVideo)],
+          outputFormat: VideoOutputFormat.mp4,
+          transform: const ExportTransform(flipX: true),
+        ),
+      );
+      final original = await tryFrameOf(hevcVideo);
+      final out = await tryFrameOf(EditorVideo.memory(bytes));
+      if (original == null || out == null) {
+        markTestSkipped('HDR HEVC frame not extractable on this device');
+        return;
+      }
+
+      final mirror = _matchSum(
+        out,
+        original,
+        geoPoints,
+        (x, y) => Offset(1 - x, y),
+      );
+      final identity = _matchSum(out, original, geoPoints, Offset.new);
+      expect(mirror, lessThan(identity), reason: 'HEVC flipX not applied');
+    }, skip: kIsWeb);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 4x5 color matrices (offsets on a 0–255 scale).
+// ---------------------------------------------------------------------------
+
+const _identity = <double>[
+  1, 0, 0, 0, 0, //
+  0, 1, 0, 0, 0, //
+  0, 0, 1, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+
+const _grayscale = <double>[
+  0.299, 0.587, 0.114, 0, 0, //
+  0.299, 0.587, 0.114, 0, 0, //
+  0.299, 0.587, 0.114, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+
+const _invert = <double>[
+  -1, 0, 0, 0, 255, //
+  0, -1, 0, 0, 255, //
+  0, 0, -1, 0, 255, //
+  0, 0, 0, 1, 0, //
+];
+
+const _darken = <double>[
+  0.5, 0, 0, 0, 0, //
+  0, 0.5, 0, 0, 0, //
+  0, 0, 0.5, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+
+const _swapRB = <double>[
+  0, 0, 1, 0, 0, //
+  0, 1, 0, 0, 0, //
+  1, 0, 0, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+
+const _blackout = <double>[
+  0, 0, 0, 0, 0, //
+  0, 0, 0, 0, 0, //
+  0, 0, 0, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+
+// ---------------------------------------------------------------------------
+// Frame + pixel helpers.
+// ---------------------------------------------------------------------------
+
+/// A decoded RGBA frame with pixel sampling helpers.
+class _Frame {
+  _Frame(this.data, this.width, this.height);
+
+  final ByteData data;
+  final int width;
+  final int height;
+
+  /// RGBA at the relative position ([fx], [fy]) in `0..1`.
+  List<int> at(double fx, double fy) {
+    final px = (fx * (width - 1)).round().clamp(0, width - 1);
+    final py = (fy * (height - 1)).round().clamp(0, height - 1);
+    final i = (py * width + px) * 4;
+    return [
+      data.getUint8(i),
+      data.getUint8(i + 1),
+      data.getUint8(i + 2),
+      data.getUint8(i + 3),
+    ];
+  }
+}
+
+/// Per-pixel RGB spread (max channel − min channel); 0 means a gray pixel.
+int _spread(List<int> c) {
+  final rgb = [c[0], c[1], c[2]]..sort();
+  return rgb.last - rgb.first;
+}
+
+/// Sum of absolute per-channel RGB differences between two pixels.
+int _dist(List<int> a, List<int> b) =>
+    (a[0] - b[0]).abs() + (a[1] - b[1]).abs() + (a[2] - b[2]).abs();
+
+/// Rec.601 luminance of a pixel.
+double _luma(List<int> c) => 0.299 * c[0] + 0.587 * c[1] + 0.114 * c[2];
+
+/// Mean luminance across [points].
+double _meanLuma(_Frame f, List<Offset> points) {
+  var sum = 0.0;
+  for (final p in points) {
+    sum += _luma(f.at(p.dx, p.dy));
+  }
+  return sum / points.length;
+}
+
+/// Mean per-channel error between [out] and an [expected] transform of the
+/// matching [source] pixel.
+double _meanError(
+  _Frame out,
+  _Frame source,
+  List<Offset> points,
+  int Function(int outChannel, int sourceChannel) expected,
+) {
+  var sum = 0;
+  for (final p in points) {
+    final o = out.at(p.dx, p.dy);
+    final s = source.at(p.dx, p.dy);
+    for (var c = 0; c < 3; c++) {
+      sum += (o[c] - expected(o[c], s[c])).abs();
+    }
+  }
+  return sum / (points.length * 3);
+}
+
+/// Sum of color distances between [out] at each point and [source] at the
+/// point produced by [map].
+int _matchSum(
+  _Frame out,
+  _Frame source,
+  List<Offset> points,
+  Offset Function(double x, double y) map,
+) {
+  var sum = 0;
+  for (final p in points) {
+    final m = map(p.dx, p.dy);
+    sum += _dist(out.at(p.dx, p.dy), source.at(m.dx, m.dy));
+  }
+  return sum;
+}
+
+/// Like [_matchSum] but compares luminance only (for desaturated outputs).
+double _lumaMatchSum(
+  _Frame out,
+  _Frame source,
+  List<Offset> points,
+  Offset Function(double x, double y) map,
+) {
+  var sum = 0.0;
+  for (final p in points) {
+    final m = map(p.dx, p.dy);
+    sum += (_luma(out.at(p.dx, p.dy)) - _luma(source.at(m.dx, m.dy))).abs();
+  }
+  return sum;
+}
+
+/// Total horizontal gradient across the frame — a proxy for image sharpness.
+int _sharpness(_Frame f) {
+  var sum = 0;
+  for (var y = 0; y < f.height; y++) {
+    for (var x = 0; x < f.width - 1; x++) {
+      final i = (y * f.width + x) * 4;
+      final j = i + 4;
+      sum += (f.data.getUint8(i) - f.data.getUint8(j)).abs();
+      sum += (f.data.getUint8(i + 1) - f.data.getUint8(j + 1)).abs();
+      sum += (f.data.getUint8(i + 2) - f.data.getUint8(j + 2)).abs();
+    }
+  }
+  return sum;
+}

--- a/example/integration_test/render_roundtrip_test.dart
+++ b/example/integration_test/render_roundtrip_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final pve = ProVideoEditor.instance;
+  final audioVideo = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+  /// A H.264 video without any audio track.
+  const mutedVideoPath = 'assets/demo_muted.mp4';
+
+  final isWindows = defaultTargetPlatform == TargetPlatform.windows;
+  final isLinux = defaultTargetPlatform == TargetPlatform.linux;
+
+  /// Rendering is not available on web.
+  const skipRender = kIsWeb;
+
+  /// `hasAudioTrack` is only implemented on Android, iOS, and macOS.
+  final skipAudioTrack = kIsWeb || isWindows || isLinux;
+
+  bool hasAudio(VideoMetadata meta) =>
+      meta.audioDuration != null && meta.audioDuration != Duration.zero;
+
+  /// Renders [model] and returns the metadata of the encoded result.
+  Future<VideoMetadata> renderAndRead(VideoRenderData model) async {
+    final bytes = await pve.renderVideo(model);
+    expect(bytes.lengthInBytes, greaterThan(10000));
+    return pve.getMetadata(EditorVideo.memory(bytes));
+  }
+
+  group('Audio presence after render', () {
+    testWidgets('enableAudio:false strips the audio track', (tester) async {
+      final meta = await renderAndRead(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: audioVideo)],
+          outputFormat: VideoOutputFormat.mp4,
+          enableAudio: false,
+        ),
+      );
+
+      expect(
+        hasAudio(meta),
+        isFalse,
+        reason: 'enableAudio:false must produce a silent output',
+      );
+    }, skip: skipRender);
+
+    testWidgets('enableAudio:false output reports hasAudioTrack false', (
+      tester,
+    ) async {
+      final bytes = await pve.renderVideo(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: audioVideo)],
+          outputFormat: VideoOutputFormat.mp4,
+          enableAudio: false,
+        ),
+      );
+
+      final result = await pve.hasAudioTrack(EditorVideo.memory(bytes));
+      expect(result, isFalse);
+    }, skip: skipAudioTrack);
+
+    testWidgets('default render keeps the audio track', (tester) async {
+      final meta = await renderAndRead(
+        VideoRenderData(
+          videoSegments: [VideoSegment(video: audioVideo)],
+          outputFormat: VideoOutputFormat.mp4,
+        ),
+      );
+
+      expect(
+        hasAudio(meta),
+        isTrue,
+        reason: 'a default render of an audio video must retain audio',
+      );
+    }, skip: skipRender);
+
+    testWidgets('merging audio + silent video keeps audio', (tester) async {
+      final meta = await renderAndRead(
+        VideoRenderData(
+          videoSegments: [
+            VideoSegment(video: audioVideo),
+            VideoSegment(video: EditorVideo.asset(mutedVideoPath)),
+          ],
+          outputFormat: VideoOutputFormat.mp4,
+        ),
+      );
+
+      expect(hasAudio(meta), isTrue);
+    }, skip: skipRender);
+  });
+
+  group('Quality presets', () {
+    testWidgets('lower preset yields a lower output bitrate', (tester) async {
+      final low = await renderAndRead(
+        VideoRenderData.withQualityPreset(
+          videoSegments: [VideoSegment(video: audioVideo)],
+          qualityPreset: VideoQualityPreset.low,
+          outputFormat: VideoOutputFormat.mp4,
+        ),
+      );
+      final high = await renderAndRead(
+        VideoRenderData.withQualityPreset(
+          videoSegments: [VideoSegment(video: audioVideo)],
+          qualityPreset: VideoQualityPreset.p720,
+          outputFormat: VideoOutputFormat.mp4,
+        ),
+      );
+
+      expect(
+        low.bitrate,
+        lessThan(high.bitrate),
+        reason: 'the low preset must encode at a lower bitrate than p720',
+      );
+    }, skip: skipRender);
+
+    testWidgets('output bitrate tracks the preset target', (tester) async {
+      const preset = VideoQualityPreset.p480; // 2.5 Mbps target
+      const tolerance = 0.5; // ±50% — encoders rarely hit CBR exactly
+
+      final meta = await renderAndRead(
+        VideoRenderData.withQualityPreset(
+          videoSegments: [VideoSegment(video: audioVideo)],
+          qualityPreset: preset,
+          outputFormat: VideoOutputFormat.mp4,
+        ),
+      );
+
+      expect(
+        meta.bitrate,
+        inInclusiveRange(
+          preset.bitrate * (1 - tolerance),
+          preset.bitrate * (1 + tolerance),
+        ),
+        reason: 'output bitrate ${meta.bitrate} drifted from the preset target',
+      );
+    }, skip: skipRender);
+  });
+}

--- a/example/integration_test/video_metadata_test.dart
+++ b/example/integration_test/video_metadata_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -8,13 +8,29 @@ import 'package:pro_video_editor_example/core/constants/example_constants.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  final pve = ProVideoEditor.instance;
+
   final isIOS = defaultTargetPlatform == TargetPlatform.iOS;
   final isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
+  final isWindows = defaultTargetPlatform == TargetPlatform.windows;
+  final isLinux = defaultTargetPlatform == TargetPlatform.linux;
+
+  /// `hasAudioTrack` is only implemented on Android, iOS, and macOS.
+  final skipAudioTrack = kIsWeb || isWindows || isLinux;
+
+  /// A H.264 video without any audio track.
+  const mutedVideoPath = 'assets/demo_muted.mp4';
+
+  /// Portrait 720×1280, 30fps, carries rotation metadata.
+  const portraitVideoPath = 'assets/tests/test_b.mp4';
+
+  /// Carries an AC3 (Dolby Digital) audio track.
+  const ac3VideoPath = 'assets/tests/test_f.mp4';
 
   testWidgets('plugin getMetadata returns correct values', (tester) async {
     final video = EditorVideo.asset(kVideoEditorExampleH264Path);
 
-    final metadata = await ProVideoEditor.instance.getMetadata(video);
+    final metadata = await pve.getMetadata(video);
 
     expect(metadata.duration.inSeconds, equals(29));
     expect(metadata.resolution, equals(const Size(1280.0, 720.0)));
@@ -29,5 +45,142 @@ void main() {
     } else {
       expect(metadata.bitrate, equals(1421504));
     }
+  });
+
+  group('getMetadata - codecs & sources', () {
+    testWidgets('reads HEVC video metadata', (tester) async {
+      final video = EditorVideo.asset(kVideoEditorExampleHevcPath);
+
+      final metadata = await pve.getMetadata(video);
+
+      expect(metadata.duration.inMilliseconds, greaterThan(0));
+      expect(metadata.resolution.width, greaterThan(0));
+      expect(metadata.resolution.height, greaterThan(0));
+      expect(metadata.extension, equals('mp4'));
+      expect(metadata.bitrate, greaterThan(0));
+    });
+
+    testWidgets('reads portrait video with rotation metadata', (tester) async {
+      final video = EditorVideo.asset(portraitVideoPath);
+
+      final metadata = await pve.getMetadata(video);
+
+      expect(metadata.duration.inMilliseconds, greaterThan(0));
+
+      /// Regardless of how the rotation is stored, the displayed frame must
+      /// resolve to portrait orientation.
+      expect(
+        metadata.resolution.height,
+        greaterThan(metadata.resolution.width),
+        reason: 'displayed resolution should be portrait',
+      );
+    });
+
+    testWidgets('memory source matches asset source', (tester) async {
+      final bytes = (await rootBundle.load(
+        kVideoEditorExampleH264Path,
+      )).buffer.asUint8List();
+
+      final fromAsset = await pve.getMetadata(
+        EditorVideo.asset(kVideoEditorExampleH264Path),
+      );
+      final fromMemory = await pve.getMetadata(EditorVideo.memory(bytes));
+
+      expect(fromMemory.resolution, equals(fromAsset.resolution));
+      expect(
+        fromMemory.duration.inSeconds,
+        equals(fromAsset.duration.inSeconds),
+      );
+    });
+  });
+
+  group('getMetadata - audio presence', () {
+    testWidgets('video with audio reports an audio duration', (tester) async {
+      final metadata = await pve.getMetadata(
+        EditorVideo.asset(kVideoEditorExampleH264Path),
+      );
+
+      expect(metadata.audioDuration, isNotNull);
+      expect(metadata.audioDuration!.inMilliseconds, greaterThan(0));
+    });
+
+    testWidgets('video without audio has no audio duration', (tester) async {
+      final metadata = await pve.getMetadata(EditorVideo.asset(mutedVideoPath));
+
+      expect(
+        metadata.audioDuration == null ||
+            metadata.audioDuration == Duration.zero,
+        isTrue,
+        reason: 'muted video should not expose an audio duration',
+      );
+    });
+
+    testWidgets('reads AC3 audio video', (tester) async {
+      final metadata = await pve.getMetadata(EditorVideo.asset(ac3VideoPath));
+
+      expect(metadata.duration.inMilliseconds, greaterThan(0));
+      expect(metadata.audioDuration, isNotNull);
+    });
+  });
+
+  group('getMetadata - streaming optimization', () {
+    testWidgets('populates isOptimizedForStreaming when requested', (
+      tester,
+    ) async {
+      final metadata = await pve.getMetadata(
+        EditorVideo.asset(kVideoEditorExampleH264Path),
+        checkStreamingOptimization: true,
+      );
+
+      expect(
+        metadata.isOptimizedForStreaming,
+        isNotNull,
+        reason: 'flag should be resolved to a bool when requested',
+      );
+    }, skip: kIsWeb);
+
+    testWidgets('leaves isOptimizedForStreaming null by default', (
+      tester,
+    ) async {
+      final metadata = await pve.getMetadata(
+        EditorVideo.asset(kVideoEditorExampleH264Path),
+      );
+
+      expect(metadata.isOptimizedForStreaming, isNull);
+    }, skip: kIsWeb);
+  });
+
+  group('hasAudioTrack', () {
+    testWidgets('returns true for a video with an audio track', (tester) async {
+      final result = await pve.hasAudioTrack(
+        EditorVideo.asset(kVideoEditorExampleH264Path),
+      );
+
+      expect(result, isTrue);
+    }, skip: skipAudioTrack);
+
+    testWidgets('returns false for a video without an audio track', (
+      tester,
+    ) async {
+      final result = await pve.hasAudioTrack(EditorVideo.asset(mutedVideoPath));
+
+      expect(result, isFalse);
+    }, skip: skipAudioTrack);
+
+    testWidgets('returns true for an AC3 audio track', (tester) async {
+      final result = await pve.hasAudioTrack(EditorVideo.asset(ac3VideoPath));
+
+      expect(result, isTrue);
+    }, skip: skipAudioTrack);
+
+    testWidgets('works with a memory source', (tester) async {
+      final bytes = (await rootBundle.load(
+        kVideoEditorExampleH264Path,
+      )).buffer.asUint8List();
+
+      final result = await pve.hasAudioTrack(EditorVideo.memory(bytes));
+
+      expect(result, isTrue);
+    }, skip: skipAudioTrack);
   });
 }

--- a/example/integration_test/video_thumbnail_test.dart
+++ b/example/integration_test/video_thumbnail_test.dart
@@ -243,4 +243,64 @@ void main() {
       );
     },
   );
+
+  group('getSingleThumbnail', () {
+    for (final position in ThumbnailPosition.values) {
+      testWidgets('extracts the ${position.name} frame', (tester) async {
+        final thumb = await ProVideoEditor.instance.getSingleThumbnail(
+          SingleThumbnailConfigs(
+            video: testVideo,
+            outputFormat: ThumbnailFormat.jpeg,
+            outputSize: const Size(outputWidth, outputHeight),
+            boxFit: ThumbnailBoxFit.cover,
+            position: position,
+          ),
+        );
+
+        expect(thumb, isNotNull);
+        expect(thumb!.lengthInBytes, greaterThan(100));
+
+        final mime = lookupMimeType('', headerBytes: thumb);
+        expect(mime, equals(formatMimeMap[ThumbnailFormat.jpeg]));
+
+        final image = await decodeImageFromList(thumb);
+        expect(image.width, equals(outputWidth));
+        expect(image.height, equals(outputHeight));
+      });
+    }
+
+    testWidgets('last frame uses an explicit videoDuration', (tester) async {
+      final meta = await ProVideoEditor.instance.getMetadata(testVideo);
+
+      final thumb = await ProVideoEditor.instance.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: testVideo,
+          outputFormat: ThumbnailFormat.jpeg,
+          outputSize: const Size(outputWidth, outputHeight),
+          boxFit: ThumbnailBoxFit.cover,
+          position: ThumbnailPosition.last,
+          videoDuration: meta.duration,
+        ),
+      );
+
+      expect(thumb, isNotNull);
+      expect(thumb!.lengthInBytes, greaterThan(100));
+    });
+
+    testWidgets('honors the png output format', (tester) async {
+      final thumb = await ProVideoEditor.instance.getSingleThumbnail(
+        SingleThumbnailConfigs(
+          video: testVideo,
+          outputFormat: ThumbnailFormat.png,
+          outputSize: const Size(outputWidth, outputHeight),
+          boxFit: ThumbnailBoxFit.cover,
+          position: ThumbnailPosition.first,
+        ),
+      );
+
+      expect(thumb, isNotNull);
+      final mime = lookupMimeType('', headerBytes: thumb!);
+      expect(mime, equals(formatMimeMap[ThumbnailFormat.png]));
+    });
+  });
 }

--- a/example/integration_test/waveform_test.dart
+++ b/example/integration_test/waveform_test.dart
@@ -1,0 +1,253 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final pve = ProVideoEditor.instance;
+  final testVideo = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+  /// A H.264 video without any audio track.
+  const mutedVideoPath = 'assets/demo_muted.mp4';
+
+  final isWindows = defaultTargetPlatform == TargetPlatform.windows;
+  final isLinux = defaultTargetPlatform == TargetPlatform.linux;
+
+  /// Waveform generation decodes the audio track natively and is only
+  /// supported on Android, iOS, and macOS (same as audio extraction).
+  final skipPlatform = kIsWeb || isWindows || isLinux;
+
+  /// Asserts that every sample sits in the normalized `[0, 1]` range and that
+  /// at least one peak is audibly above silence.
+  void expectNormalized(Float32List channel, {required String reason}) {
+    var maxPeak = 0.0;
+    for (final value in channel) {
+      expect(
+        value,
+        inInclusiveRange(0.0, 1.0),
+        reason: '$reason: sample outside [0, 1]',
+      );
+      if (value > maxPeak) maxPeak = value;
+    }
+    expect(
+      maxPeak,
+      greaterThan(0.0),
+      reason: '$reason: waveform is all silence',
+    );
+  }
+
+  group('getWaveform', () {
+    testWidgets('returns normalized peaks for an audio track', (tester) async {
+      final configs = WaveformConfigs(video: testVideo);
+
+      final waveform = await pve.getWaveform(configs);
+
+      expect(waveform.sampleCount, greaterThan(0));
+      expect(waveform.leftChannel, isNotEmpty);
+      expect(
+        waveform.samplesPerSecond,
+        equals(WaveformResolution.medium.samplesPerSecond),
+      );
+      expect(waveform.duration.inSeconds, greaterThan(0));
+      expect(waveform.sampleRate, greaterThan(0));
+      expectNormalized(waveform.leftChannel, reason: 'leftChannel');
+
+      /// The sample count should track duration × resolution closely.
+      final expectedSamples =
+          waveform.duration.inMilliseconds / 1000 * waveform.samplesPerSecond;
+      expect(
+        waveform.sampleCount,
+        closeTo(expectedSamples, expectedSamples * 0.15),
+        reason: 'sampleCount should match duration × samplesPerSecond',
+      );
+    }, skip: skipPlatform);
+
+    testWidgets('higher resolution yields more samples', (tester) async {
+      final low = await pve.getWaveform(
+        WaveformConfigs(video: testVideo, resolution: WaveformResolution.low),
+      );
+      final high = await pve.getWaveform(
+        WaveformConfigs(video: testVideo, resolution: WaveformResolution.high),
+      );
+
+      expect(low.samplesPerSecond, lessThan(high.samplesPerSecond));
+      expect(
+        high.sampleCount,
+        greaterThan(low.sampleCount),
+        reason: 'higher resolution must produce more samples',
+      );
+    }, skip: skipPlatform);
+
+    testWidgets('time range produces a shorter waveform', (tester) async {
+      final full = await pve.getWaveform(WaveformConfigs(video: testVideo));
+      final ranged = await pve.getWaveform(
+        WaveformConfigs(
+          video: testVideo,
+          startTime: const Duration(seconds: 5),
+          endTime: const Duration(seconds: 10),
+        ),
+      );
+
+      expect(ranged.duration.inSeconds, closeTo(5, 1));
+      expect(
+        ranged.sampleCount,
+        lessThan(full.sampleCount),
+        reason: 'a 5s window must contain fewer samples than the full track',
+      );
+      expectNormalized(ranged.leftChannel, reason: 'ranged leftChannel');
+    }, skip: skipPlatform);
+
+    testWidgets('emits progress updates', (tester) async {
+      final configs = WaveformConfigs(
+        video: testVideo,
+        resolution: WaveformResolution.high,
+      );
+
+      final progressValues = <double>[];
+      final sub = pve
+          .progressStreamById(configs.id)
+          .listen((event) => progressValues.add(event.progress));
+
+      await pve.getWaveform(configs);
+
+      /// Give the stream time to flush the final value on iOS/macOS.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await sub.cancel();
+
+      expect(
+        progressValues,
+        isNotEmpty,
+        reason: 'no progress updates received',
+      );
+      expect(progressValues.first, lessThanOrEqualTo(0.1));
+      expect(progressValues.last, closeTo(1.0, 0.05));
+
+      final sorted = List.of(progressValues)..sort();
+      expect(progressValues, sorted, reason: 'progress not monotonic');
+    }, skip: skipPlatform);
+
+    testWidgets('throws when the video has no audio track', (tester) async {
+      final configs = WaveformConfigs(video: EditorVideo.asset(mutedVideoPath));
+
+      await expectLater(
+        pve.getWaveform(configs),
+        throwsA(isA<AudioNoTrackException>()),
+      );
+    }, skip: skipPlatform);
+
+    testWidgets('can be cancelled', (tester) async {
+      final configs = WaveformConfigs(
+        video: testVideo,
+        resolution: WaveformResolution.ultra,
+      );
+
+      final future = pve.getWaveform(configs);
+      final capturedError = future.then<Object?>(
+        (_) => null,
+        onError: (Object e) => e,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      try {
+        await pve.cancel(configs.id);
+      } on PlatformException catch (e) {
+        if (e.code != 'TASK_NOT_FOUND') rethrow;
+      }
+
+      /// On fast machines generation may finish before the cancel lands; a
+      /// cancelled run fails with [RenderCanceledException], a completed one
+      /// resolves without error.
+      final error = await capturedError;
+      if (error != null) {
+        expect(error, isA<RenderCanceledException>());
+      }
+    }, skip: skipPlatform);
+  });
+
+  group('getWaveformStream', () {
+    testWidgets('streams chunks until completion', (tester) async {
+      final configs = WaveformConfigs(
+        video: testVideo,
+        resolution: WaveformResolution.high,
+        chunkSize: 100,
+      );
+
+      final chunks = <WaveformChunk>[];
+      await for (final chunk in pve.getWaveformStream(configs)) {
+        chunks.add(chunk);
+      }
+
+      expect(chunks, isNotEmpty, reason: 'no chunks emitted');
+      expect(
+        chunks.last.isComplete,
+        isTrue,
+        reason: 'final chunk not complete',
+      );
+      expect(chunks.last.progress, closeTo(1.0, 0.01));
+
+      /// Progress must be non-decreasing across chunks.
+      for (var i = 1; i < chunks.length; i++) {
+        expect(
+          chunks[i].progress,
+          greaterThanOrEqualTo(chunks[i - 1].progress),
+          reason: 'chunk progress went backwards',
+        );
+      }
+
+      /// Non-final chunks must respect the configured chunk size.
+      for (final chunk in chunks.take(chunks.length - 1)) {
+        expect(chunk.sampleCount, lessThanOrEqualTo(configs.chunkSize));
+        expectNormalized(chunk.leftChannel, reason: 'chunk leftChannel');
+      }
+    }, skip: skipPlatform);
+
+    testWidgets('concatenated chunks match a single getWaveform', (
+      tester,
+    ) async {
+      const resolution = WaveformResolution.medium;
+
+      final single = await pve.getWaveform(
+        WaveformConfigs(video: testVideo, resolution: resolution),
+      );
+
+      final streamConfig = WaveformConfigs(
+        video: testVideo,
+        resolution: resolution,
+      );
+
+      var streamedSamples = 0;
+      await for (final chunk in pve.getWaveformStream(streamConfig)) {
+        streamedSamples += chunk.sampleCount;
+      }
+
+      /// The streaming path can emit up to one extra trailing chunk relative to
+      /// the one-shot total, so allow a full chunk of slack on top of a small
+      /// relative tolerance.
+      expect(
+        streamedSamples,
+        closeTo(
+          single.sampleCount,
+          single.sampleCount * 0.05 + streamConfig.chunkSize,
+        ),
+        reason: 'streamed sample count should match the one-shot waveform',
+      );
+    }, skip: skipPlatform);
+
+    testWidgets('errors when the video has no audio track', (tester) async {
+      final configs = WaveformConfigs(video: EditorVideo.asset(mutedVideoPath));
+
+      /// The no-audio condition surfaces as [AudioNoTrackException] via the
+      /// event channel, but may arrive as a raw [PlatformException] if the
+      /// native side rejects the start call itself.
+      await expectLater(
+        pve.getWaveformStream(configs).toList(),
+        throwsA(anyOf(isA<AudioNoTrackException>(), isA<PlatformException>())),
+      );
+    }, skip: skipPlatform);
+  });
+}

--- a/test/features/audio/audio_waveform_widget_test.dart
+++ b/test/features/audio/audio_waveform_widget_test.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+WaveformData buildWaveform({bool stereo = false}) {
+  final left = Float32List(120);
+  for (var i = 0; i < left.length; i++) {
+    left[i] = (i % 10) / 10;
+  }
+  Float32List? right;
+  if (stereo) {
+    right = Float32List(120);
+    for (var i = 0; i < right.length; i++) {
+      right[i] = (i % 7) / 7;
+    }
+  }
+  return WaveformData(
+    leftChannel: left,
+    rightChannel: right,
+    sampleRate: 44100,
+    duration: const Duration(seconds: 2),
+    samplesPerSecond: 60,
+  );
+}
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+  }
+
+  testWidgets('renders mono waveform without error', (tester) async {
+    await pump(tester, AudioWaveform(waveform: buildWaveform()));
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(AudioWaveform), findsOneWidget);
+    expect(find.byType(CustomPaint), findsWidgets);
+  });
+
+  testWidgets('renders stereo waveform without error', (tester) async {
+    await pump(tester, AudioWaveform(waveform: buildWaveform(stereo: true)));
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(AudioWaveform), findsOneWidget);
+  });
+
+  testWidgets('interactive tap reports a seek position', (tester) async {
+    Duration? seeked;
+
+    await pump(
+      tester,
+      SizedBox(
+        width: 300,
+        child: AudioWaveform.interactive(
+          waveform: buildWaveform(),
+          currentPosition: Duration.zero,
+          onSeek: (position) => seeked = position,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(AudioWaveform));
+    await tester.pump();
+
+    expect(seeked, isNotNull, reason: 'tap should trigger an onSeek callback');
+    expect(seeked!.inMilliseconds, greaterThan(0));
+  });
+
+  testWidgets('non-interactive waveform tolerates taps', (tester) async {
+    await pump(
+      tester,
+      SizedBox(width: 300, child: AudioWaveform(waveform: buildWaveform())),
+    );
+
+    await tester.tap(find.byType(AudioWaveform));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/audio/waveform_painter_test.dart
+++ b/test/features/audio/waveform_painter_test.dart
@@ -1,0 +1,120 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_video_editor/features/audio/widgets/waveform_painter.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+WaveformData buildWaveform({
+  int samples = 100,
+  bool stereo = false,
+  Duration duration = const Duration(seconds: 2),
+}) {
+  final left = Float32List(samples);
+  for (var i = 0; i < samples; i++) {
+    left[i] = (i % 10) / 10;
+  }
+  Float32List? right;
+  if (stereo) {
+    right = Float32List(samples);
+    for (var i = 0; i < samples; i++) {
+      right[i] = (i % 7) / 7;
+    }
+  }
+  return WaveformData(
+    leftChannel: left,
+    rightChannel: right,
+    sampleRate: 44100,
+    duration: duration,
+    samplesPerSecond: 50,
+  );
+}
+
+void paintOnce(WaveformPainter painter, [Size size = const Size(300, 80)]) {
+  final recorder = ui.PictureRecorder();
+  painter.paint(Canvas(recorder), size);
+  recorder.endRecording();
+}
+
+void main() {
+  group('WaveformPainter.shouldRepaint', () {
+    test('repaints when the playback position changes', () {
+      final waveform = buildWaveform();
+      const style = WaveformStyle();
+      final oldPainter = WaveformPainter(
+        waveform: waveform,
+        style: style,
+        currentPosition: const Duration(seconds: 1),
+        showPositionIndicator: true,
+      );
+      final newPainter = WaveformPainter(
+        waveform: waveform,
+        style: style,
+        currentPosition: const Duration(milliseconds: 1500),
+        showPositionIndicator: true,
+      );
+
+      expect(newPainter.shouldRepaint(oldPainter), isTrue);
+    });
+
+    test('does not repaint when nothing changed', () {
+      final waveform = buildWaveform();
+      const style = WaveformStyle();
+      final oldPainter = WaveformPainter(waveform: waveform, style: style);
+      final newPainter = WaveformPainter(waveform: waveform, style: style);
+
+      expect(newPainter.shouldRepaint(oldPainter), isFalse);
+    });
+
+    test('repaints when the waveform data changes', () {
+      const style = WaveformStyle();
+      final oldPainter = WaveformPainter(
+        waveform: buildWaveform(samples: 50),
+        style: style,
+      );
+      final newPainter = WaveformPainter(
+        waveform: buildWaveform(samples: 80),
+        style: style,
+      );
+
+      expect(newPainter.shouldRepaint(oldPainter), isTrue);
+    });
+  });
+
+  group('WaveformPainter.paint', () {
+    test('paints mono data without throwing', () {
+      final painter = WaveformPainter(
+        waveform: buildWaveform(),
+        style: const WaveformStyle(),
+        currentPosition: const Duration(seconds: 1),
+        showPositionIndicator: true,
+      );
+
+      expect(() => paintOnce(painter), returnsNormally);
+    });
+
+    test('paints stereo data without throwing', () {
+      final painter = WaveformPainter(
+        waveform: buildWaveform(stereo: true),
+        style: const WaveformStyle(),
+      );
+
+      expect(() => paintOnce(painter), returnsNormally);
+    });
+
+    test('handles an empty waveform gracefully', () {
+      final painter = WaveformPainter(
+        waveform: WaveformData(
+          leftChannel: Float32List(0),
+          sampleRate: 44100,
+          duration: Duration.zero,
+          samplesPerSecond: 50,
+        ),
+        style: const WaveformStyle(),
+      );
+
+      expect(() => paintOnce(painter, const Size(100, 40)), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Substantially expands the integration-test suite and fixes three platform bugs that the new tests surfaced on real hardware (macOS + a Samsung Galaxy).

The integration tests run **manually / locally**, not in CI — device-based video-render tests are too slow and runner-environment-sensitive to gate every PR. The existing `flutter_analysis.yml` (analyze + `flutter test`) remains the PR gate and now also covers the new waveform widget tests, which run without a device.

## Plugin fixes (validated on macOS + Galaxy)

1. **Concurrent renders collided on the temp output filename.** The Apple and Android renderers derived the temp output name from a millisecond timestamp, so two renders started in the same instant overwrote each other (`RENDER_ERROR, Cannot create file`). Now suffixed with a random/UUID component — Apple `RenderVideo`/`StopMotion`, Android `RenderVideo`/`VideoTranscoder`.
2. **Android waveform cancel surfaced a raw `WAVEFORM_ERROR`** instead of mapping to `CANCELED` → `RenderCanceledException`. A race removed the task from the tracking map before `onError` fired; fixed by checking the captured task reference rather than the map lookup (non-streaming + streaming paths).
3. **Android couldn't thumbnail 10-bit HDR HEVC** at arbitrary timestamps (`getFrameAtTime(OPTION_CLOSEST)` returned `null` → empty result). Added a sync-frame fallback chain and ARGB_8888 normalization, so frames now extract.

## Test additions

- **New integration suites:** `waveform`, `error_handling`, `render_roundtrip`, `concurrency`, and `render_pixel` (content-independent pixel verification of color matrices, flips, crop region, blur, timed filters, combined effects, HEVC).
- **Extended:** metadata (codecs/sources/audio presence/streaming flag + `hasAudioTrack`), thumbnails (`getSingleThumbnail`), audio extraction (no-audio track → `AudioNoTrackException`).
- **Widget tests** for `WaveformPainter` and `AudioWaveform` (run without a device, so they execute in the existing analysis/test job).

## Verification

All affected suites run green on macOS and the Galaxy. One known graceful skip: on the emulator/Galaxy the HDR HEVC frame tone-maps to near-gray, so the HEVC grayscale pixel check skips itself (inconclusive, not a failure); it runs fully on macOS.

## Follow-ups (not in this PR)

- A CHANGELOG entry / version bump for the three fixes.
- Optionally wire the integration suite into a manual/scheduled job (or Firebase Test Lab for real-device codec coverage) later.
