### PR TITLE
feat: add per-layer rotation to image overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- **FEAT**(android, iOS, macOS): Add per-layer rotation to image overlays via a new `rotation` field on `ImageLayer` (radians, clockwise around the layer center — matches Flutter's `Transform.rotate`, so a `pro_image_editor` layer rotation can be forwarded directly). `offset`/`size` keep describing the layout box before rotation. Web/Windows/Linux ignore the field.
+
 ## 2.0.0
 - **BREAKING**: Remove the previously deprecated APIs. Migrate as follows:
   - `VideoRenderData.video` → `videoSegments: [VideoSegment(video: …)]`

--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ var task = VideoRenderData(
       ImageLayer(
         image: EditorLayerImage.memory(layerBytes),
         offset: const Offset(100, 50),
+        rotation: 45 * pi / 180, // clockwise, in radians (like Transform.rotate)
         startTime: const Duration(seconds: 2),
         endTime: const Duration(seconds: 8),
       ),

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyComposition.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyComposition.kt
@@ -56,6 +56,7 @@ fun applyComposition(
                 y = imageLayer.y,
                 width = imageLayer.width,
                 height = imageLayer.height,
+                rotation = imageLayer.rotation,
                 animations = imageLayer.animations
             )
         }

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
@@ -3,6 +3,7 @@ package ch.waio.pro_video_editor.src.features.render.helpers
 import RENDER_TAG
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
 import androidx.media3.common.Effect
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.effect.BitmapOverlay
@@ -151,6 +152,14 @@ fun applyTimedImageLayers(
                 )
             }
 
+            // Rotate the overlay around its center. baseNormX/baseNormY describe
+            // the (unrotated) layout center; rotating about the bitmap center
+            // keeps that point fixed, so the anchor stays correct while the
+            // bounding box grows symmetrically.
+            val rotatedOverlay = rotateBitmap(
+                finalOverlay, Math.toDegrees(layer.rotation).toFloat()
+            )
+
             // Convert times from microseconds
             val startTimeUs = layer.startUs
             val endTimeUs = layer.endUs
@@ -165,10 +174,10 @@ fun applyTimedImageLayers(
             val bitmapOverlay: BitmapOverlay
 
             if (hasAnimations) {
-                val imageWidth = finalOverlay.width
-                val imageHeight = finalOverlay.height
+                val imageWidth = rotatedOverlay.width
+                val imageHeight = rotatedOverlay.height
                 bitmapOverlay = AnimatedBitmapOverlay(
-                    bitmap = finalOverlay,
+                    bitmap = rotatedOverlay,
                     baseNormX = baseNormX,
                     baseNormY = baseNormY,
                     imageWidth = imageWidth,
@@ -182,7 +191,7 @@ fun applyTimedImageLayers(
                 Log.d(RENDER_TAG, "Layer: using AnimatedBitmapOverlay with ${layer.animations.size} animation(s)")
             } else {
                 bitmapOverlay = BitmapOverlay.createStaticBitmapOverlay(
-                    finalOverlay, overlaySettings
+                    rotatedOverlay, overlaySettings
                 )
             }
             val overlayEffect = OverlayEffect(listOf(bitmapOverlay))
@@ -202,6 +211,27 @@ fun applyTimedImageLayers(
             Log.e(RENDER_TAG, "Failed to decode image layer: ${e.message}")
         }
     }
+}
+
+/**
+ * Rotates [bitmap] clockwise by [degrees] around its center.
+ *
+ * Returns a new bitmap sized to the rotated bounding box; the source center
+ * maps to the new center, so a center-anchored overlay keeps its position.
+ * The source bitmap is recycled when a new one is produced. A rotation that is
+ * a multiple of 360° (including `0`) returns the input unchanged.
+ *
+ * The input is expected to carry straight (un-premultiplied) alpha so the
+ * bilinear edge pixels introduced by the rotation interpolate correctly.
+ */
+private fun rotateBitmap(bitmap: Bitmap, degrees: Float): Bitmap {
+    if (degrees % 360f == 0f) return bitmap
+    val matrix = Matrix().apply { postRotate(degrees) }
+    val rotated = Bitmap.createBitmap(
+        bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
+    )
+    if (rotated !== bitmap) bitmap.recycle()
+    return rotated
 }
 
 /**

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/CompositionBuilder.kt
@@ -90,6 +90,7 @@ class CompositionBuilder(
                     y = imageLayer.y,
                     width = imageLayer.width,
                     height = imageLayer.height,
+                    rotation = imageLayer.rotation,
                     animations = imageLayer.animations
                 )
             })

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -76,6 +76,8 @@ class VideoSequenceBuilder(
         val y: Int? = null,
         val width: Double? = null,
         val height: Double? = null,
+        /** Clockwise rotation around the layer center, in radians. */
+        val rotation: Double = 0.0,
         val animations: List<LayerAnimationConfig> = emptyList()
     )
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -280,6 +280,7 @@ data class LayerAnimationConfig(
  * @property y Vertical offset in pixels (null = stretch to fill)
  * @property width Target width in pixels (null = original width)
  * @property height Target height in pixels (null = original height)
+ * @property rotation Clockwise rotation around the layer center, in radians
  * @property animations List of animations to apply to this layer
  */
 data class ImageLayer(
@@ -290,6 +291,7 @@ data class ImageLayer(
     val y: Int? = null,
     val width: Double? = null,
     val height: Double? = null,
+    val rotation: Double = 0.0,
     val animations: List<LayerAnimationConfig> = emptyList()
 ) {
     override fun equals(other: Any?): Boolean {
@@ -303,6 +305,7 @@ data class ImageLayer(
                 y == other.y &&
                 width == other.width &&
                 height == other.height &&
+                rotation == other.rotation &&
                 animations == other.animations
     }
 
@@ -314,6 +317,7 @@ data class ImageLayer(
         result = 31 * result + (y?.hashCode() ?: 0)
         result = 31 * result + (width?.hashCode() ?: 0)
         result = 31 * result + (height?.hashCode() ?: 0)
+        result = 31 * result + rotation.hashCode()
         result = 31 * result + animations.hashCode()
         return result
     }
@@ -405,6 +409,7 @@ data class RenderConfig(
                 val y = (layerMap["y"] as? Number)?.toInt()
                 val width = (layerMap["width"] as? Number)?.toDouble()
                 val height = (layerMap["height"] as? Number)?.toDouble()
+                val rotation = (layerMap["rotation"] as? Number)?.toDouble() ?: 0.0
 
                 // Parse animations
                 @Suppress("UNCHECKED_CAST")
@@ -414,7 +419,7 @@ data class RenderConfig(
                 if (imageData == null || imageData.isEmpty()) {
                     null
                 } else {
-                    ImageLayer(imageData, startUs, endUs, x, y, width, height, animations)
+                    ImageLayer(imageData, startUs, endUs, x, y, width, height, rotation, animations)
                 }
             } ?: emptyList()
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
@@ -83,6 +83,8 @@ public struct ImageLayerConfig: Sendable {
   let width: Double?
   /// Target height in pixels. When nil, the image is used at its original height.
   let height: Double?
+  /// Clockwise rotation around the layer center, in radians.
+  let rotation: Double
   /// Animations to apply to this layer.
   let animations: [LayerAnimationConfig]
 
@@ -111,6 +113,7 @@ public struct ImageLayerConfig: Sendable {
     // Parse optional size
     let width = (args["width"] as? NSNumber)?.doubleValue
     let height = (args["height"] as? NSNumber)?.doubleValue
+    let rotation = (args["rotation"] as? NSNumber)?.doubleValue ?? 0.0
 
     // Use -1 as sentinel value for "from start" when startUs is null
     // Use -1 for endUs to signify "until the end of the video"
@@ -122,6 +125,7 @@ public struct ImageLayerConfig: Sendable {
       y: (args["y"] as? NSNumber)?.int64Value,
       width: width,
       height: height,
+      rotation: rotation,
       animations: animations
     )
   }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/utils/VideoCompositor.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/utils/VideoCompositor.swift
@@ -20,8 +20,27 @@ struct ImageLayer {
   let width: Double?
   /// Target height in pixels. When nil, the image is used at its original height.
   let height: Double?
+  /// Clockwise rotation around the layer center, in radians.
+  let rotation: Double
   /// Animations applied to this layer.
   let animations: [LayerAnimationConfig]
+}
+
+/// Rotates [overlay] clockwise by [radians] around its own center.
+///
+/// CoreImage uses a y-up coordinate space where a positive `rotationAngle`
+/// turns counter-clockwise, so the sign is flipped to match the clockwise
+/// (Flutter `Transform.rotate`) convention used by `ImageLayer.rotation`.
+/// Rotating around the center keeps the layer's placement fixed while the
+/// bounding box grows symmetrically.
+private func rotateOverlayAroundCenter(_ overlay: CIImage, radians: Double) -> CIImage {
+  if radians == 0 { return overlay }
+  let cx = overlay.extent.midX
+  let cy = overlay.extent.midY
+  let transform = CGAffineTransform(translationX: cx, y: cy)
+    .rotated(by: CGFloat(-radians))
+    .translatedBy(x: -cx, y: -cy)
+  return overlay.transformed(by: transform)
 }
 
 class VideoCompositor: NSObject, AVVideoCompositing {
@@ -151,6 +170,7 @@ class VideoCompositor: NSObject, AVVideoCompositing {
           y: layer.y,
           width: layer.width,
           height: layer.height,
+          rotation: layer.rotation,
           animations: layer.animations
         ))
     }
@@ -537,14 +557,15 @@ class VideoCompositor: NSObject, AVVideoCompositing {
               by: CGAffineTransform(translationX: posX, y: cgY))
           }
 
+          let rotated = rotateOverlayAroundCenter(overlay, radians: layer.rotation)
           let (opacity, animTransform) = computeAnimation(
             layer: layer,
             currentTimeUs: currentTimeUs,
-            overlayExtent: overlay.extent,
+            overlayExtent: rotated.extent,
             frameExtent: imageRect
           )
           outputImage = compositeOverlay(
-            overlay, over: outputImage, opacity: opacity, transform: animTransform)
+            rotated, over: outputImage, opacity: opacity, transform: animTransform)
         }
       }
     }
@@ -651,14 +672,15 @@ class VideoCompositor: NSObject, AVVideoCompositing {
               by: CGAffineTransform(translationX: posX, y: cgY))
           }
 
+          let rotated = rotateOverlayAroundCenter(overlay, radians: layer.rotation)
           let (opacity, animTransform) = computeAnimation(
             layer: layer,
             currentTimeUs: currentTimeUs,
-            overlayExtent: overlay.extent,
+            overlayExtent: rotated.extent,
             frameExtent: imageRect
           )
           outputImage = compositeOverlay(
-            overlay, over: outputImage, opacity: opacity, transform: animTransform)
+            rotated, over: outputImage, opacity: opacity, transform: animTransform)
         }
       }
     }

--- a/example/integration_test/image_layer_test.dart
+++ b/example/integration_test/image_layer_test.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -167,6 +168,26 @@ void main() {
           imageLayers: [
             ImageLayer(
               image: overlayImage,
+              startTime: const Duration(seconds: 1),
+              endTime: const Duration(seconds: 4),
+            ),
+          ],
+        ),
+      );
+    });
+
+    testWidgets('image layer with its own rotation', (_) async {
+      await testRender(
+        description: 'Image layer (rotated 45°)',
+        renderModel: VideoRenderData(
+          videoSegments: [VideoSegment(video: inputVideo)],
+          outputFormat: VideoOutputFormat.mp4,
+          imageLayers: [
+            ImageLayer(
+              image: overlayImage,
+              offset: const ui.Offset(120, 80),
+              size: const ui.Size(200, 120),
+              rotation: math.pi / 4,
               startTime: const Duration(seconds: 1),
               endTime: const Duration(seconds: 4),
             ),

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -1137,6 +1137,39 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     await _renderVideo(data);
   }
 
+  /// Rotate image layers around their own center.
+  ///
+  /// [ImageLayer.rotation] is in radians (clockwise, like Flutter's
+  /// `Transform.rotate`), so a `pro_image_editor` layer rotation can be
+  /// forwarded directly. [offset] and [size] keep describing the layout box
+  /// before rotation.
+  Future<void> _layersWithRotation() async {
+    final stickerImage = EditorLayerImage.asset('assets/sticker.png');
+
+    var data = VideoRenderData(
+      videoSegments: [VideoSegment(video: _video)],
+      imageLayers: [
+        /// Tilted 30° clockwise at top-left
+        ImageLayer(
+          image: stickerImage,
+          offset: const Offset(40, 40),
+          size: const Size(200, 200),
+          rotation: 30 * pi / 180,
+        ),
+
+        /// Tilted 45° counter-clockwise in the center
+        ImageLayer(
+          image: stickerImage,
+          offset: const Offset(500, 300),
+          size: const Size(200, 200),
+          rotation: -45 * pi / 180,
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
   Future<void> _colorMatrix() async {
     var data = VideoRenderData(
       videoSegments: [VideoSegment(video: _video)],
@@ -2008,6 +2041,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           leading: const Icon(Icons.photo_size_select_large_outlined),
           title: const Text('Layers with custom size'),
           subtitle: const Text('Scale layers to specific dimensions'),
+        ),
+        ListTile(
+          onTap: _layersWithRotation,
+          leading: const Icon(Icons.rotate_right_outlined),
+          title: const Text('Layers with rotation'),
+          subtitle: const Text('Rotate layers around their own center'),
         ),
         ListTile(
           onTap: _colorMatrix,

--- a/lib/core/models/image/image_layer_model.dart
+++ b/lib/core/models/image/image_layer_model.dart
@@ -20,6 +20,7 @@ class ImageLayer with TimeRangeMixin {
     this.endTime,
     this.offset,
     this.size,
+    this.rotation = 0.0,
     this.animations = const [],
   }) : assert(
           startTime == null || endTime == null || startTime < endTime,
@@ -54,6 +55,16 @@ class ImageLayer with TimeRangeMixin {
   /// fill the frame when [offset] is also `null`).
   final Size? size;
 
+  /// Clockwise rotation applied to the image layer, in **radians**.
+  ///
+  /// The image is rotated around its own center, so [offset] and [size] still
+  /// describe the unrotated layout box. This matches Flutter's
+  /// [Transform.rotate] convention, which makes it possible to forward a
+  /// `pro_image_editor` layer rotation directly.
+  ///
+  /// **Default**: `0.0` (no rotation).
+  final double rotation;
+
   /// Animations to apply to this layer (e.g. fade, slide, scale).
   ///
   /// Multiple animations can be combined. Each animation specifies its
@@ -67,6 +78,7 @@ class ImageLayer with TimeRangeMixin {
     Duration? endTime,
     Offset? offset,
     Size? size,
+    double? rotation,
     List<LayerAnimation>? animations,
   }) {
     return ImageLayer(
@@ -75,6 +87,7 @@ class ImageLayer with TimeRangeMixin {
       endTime: endTime ?? this.endTime,
       offset: offset ?? this.offset,
       size: size ?? this.size,
+      rotation: rotation ?? this.rotation,
       animations: animations ?? this.animations,
     );
   }
@@ -87,6 +100,7 @@ class ImageLayer with TimeRangeMixin {
       'offset': offset != null ? {'dx': offset!.dx, 'dy': offset!.dy} : null,
       'size':
           size != null ? {'width': size!.width, 'height': size!.height} : null,
+      'rotation': rotation,
       'animations': animations.map((a) => a.toMap()).toList(),
     };
   }
@@ -112,6 +126,8 @@ class ImageLayer with TimeRangeMixin {
               safeParseDouble((map['size'] as Map<String, dynamic>)['height']),
             )
           : null,
+      rotation:
+          map['rotation'] != null ? safeParseDouble(map['rotation']) : 0.0,
       animations: (map['animations'] as List<dynamic>?)
               ?.map((a) => LayerAnimation.fromMap(a as Map<String, dynamic>))
               .toList() ??
@@ -132,6 +148,7 @@ class ImageLayer with TimeRangeMixin {
         'endTime: $endTime, '
         'offset: $offset, '
         'size: $size, '
+        'rotation: $rotation, '
         'animations: $animations'
         ')';
   }
@@ -145,6 +162,7 @@ class ImageLayer with TimeRangeMixin {
         other.endTime == endTime &&
         other.offset == offset &&
         other.size == size &&
+        other.rotation == rotation &&
         listEquals(other.animations, animations);
   }
 
@@ -155,6 +173,7 @@ class ImageLayer with TimeRangeMixin {
         endTime.hashCode ^
         offset.hashCode ^
         size.hashCode ^
+        rotation.hashCode ^
         animations.hashCode;
   }
 }

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -329,6 +329,7 @@ class VideoRenderData {
                 'y': layer.offset?.dy.toInt(),
                 'width': layer.size?.width,
                 'height': layer.size?.height,
+                'rotation': layer.rotation,
                 'animations': layer.animations.map((a) => a.toMap()).toList(),
               },
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/image/image_layer_model_test.dart
+++ b/test/core/models/image/image_layer_model_test.dart
@@ -17,6 +17,7 @@ void main() {
           endTime: const Duration(seconds: 10),
           offset: const Offset(100, 200),
           size: const Size(300, 150),
+          rotation: 1.5,
         );
         final map = layer.toMap();
 
@@ -25,6 +26,7 @@ void main() {
         expect(map['endTime'], 10000000);
         expect(map['offset'], {'dx': 100.0, 'dy': 200.0});
         expect(map['size'], {'width': 300.0, 'height': 150.0});
+        expect(map['rotation'], 1.5);
       });
 
       test('serializes null fields as null', () {
@@ -35,6 +37,7 @@ void main() {
         expect(map['endTime'], isNull);
         expect(map['offset'], isNull);
         expect(map['size'], isNull);
+        expect(map['rotation'], 0.0);
       });
     });
 
@@ -46,6 +49,7 @@ void main() {
           endTime: const Duration(seconds: 10),
           offset: const Offset(100, 200),
           size: const Size(300, 150),
+          rotation: 1.5,
         );
         final map = layer.toMap();
         final restored = ImageLayer.fromMap(map);
@@ -54,6 +58,7 @@ void main() {
         expect(restored.endTime, const Duration(seconds: 10));
         expect(restored.offset, const Offset(100, 200));
         expect(restored.size, const Size(300, 150));
+        expect(restored.rotation, 1.5);
       });
 
       test('handles null optional fields', () {
@@ -65,6 +70,26 @@ void main() {
         expect(restored.endTime, isNull);
         expect(restored.offset, isNull);
         expect(restored.size, isNull);
+        expect(restored.rotation, 0.0);
+      });
+
+      test('defaults rotation to 0 when absent from map', () {
+        final map = {
+          'image': image.toMap(),
+        };
+        final restored = ImageLayer.fromMap(map);
+
+        expect(restored.rotation, 0.0);
+      });
+
+      test('parses numeric string for rotation safely', () {
+        final map = {
+          'image': image.toMap(),
+          'rotation': '0.75',
+        };
+        final restored = ImageLayer.fromMap(map);
+
+        expect(restored.rotation, 0.75);
       });
 
       test('parses numeric strings safely for offset', () {
@@ -108,12 +133,21 @@ void main() {
           startTime: const Duration(seconds: 2),
           offset: const Offset(10, 20),
           size: const Size(640, 480),
+          rotation: 0.5,
         );
 
         expect(copy.startTime, const Duration(seconds: 2));
         expect(copy.offset, const Offset(10, 20));
         expect(copy.size, const Size(640, 480));
+        expect(copy.rotation, 0.5);
         expect(copy.endTime, isNull);
+      });
+
+      test('keeps original rotation when not overridden', () {
+        final layer = ImageLayer(image: image, rotation: 1.2);
+        final copy = layer.copyWith(offset: const Offset(5, 5));
+
+        expect(copy.rotation, 1.2);
       });
     });
 


### PR DESCRIPTION
Closes #122

## What

Image (and text) overlays can now be rotated via a new `rotation` field on `ImageLayer`.

- **Unit**: `double` **radians**, clockwise around the layer center — matches Flutter's `Transform.rotate` and the `pro_image_editor` layer convention, so a layer rotation from the image editor can be forwarded directly.
- `offset`/`size` keep describing the layout box *before* rotation; rotating around the center keeps the layer's placement fixed while its bounding box grows symmetrically.
- Defaults to `0.0` (no rotation).

```dart
imageLayers: [
  ImageLayer(
    image: EditorLayerImage.memory(bytes),
    offset: const Offset(100, 50),
    size: const Size(200, 120),
    rotation: 45 * pi / 180, // clockwise radians
  ),
],
```

## How

- **Dart** (`ImageLayer`, `VideoRenderData`): new field + serialization, `copyWith`, equality, `toString`.
- **Android**: rotate the overlay bitmap around its center before placement (`rotateBitmap`), leaving the anchor and animation math untouched. Wired through both the single-track and composition render paths.
- **iOS/macOS**: rotate the overlay `CIImage` around its center (sign flipped for the y-up coordinate space).
- **Web/Windows/Linux**: ignore the field, consistent with other render features.

## Tests

- New unit tests for the `rotation` field (serialization, defaults, safe parsing, `copyWith`).
- New integration test rendering a rotated positioned layer.
- New "Layers with rotation" entry on the render example page.

Verified: `flutter analyze` clean, full `flutter test` green (241), Android Kotlin `BUILD SUCCESSFUL`.

## Note

On iOS/macOS, image overlays are not composited in the `composition` (multi-track) path — a pre-existing gap unrelated to this change. Rotation works wherever overlays are applied (single-track on darwin; both paths on Android).