### PR TITLE
feat: add output frame-rate cap (maxFrameRate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- **FEAT**(android, iOS, macOS): Add an output frame-rate cap via a new `maxFrameRate` field on `VideoRenderData`. It is an upper limit, not a target: a faster source is reduced to it (e.g. 60→30 fps) while a slower source is left untouched, lowering encoding cost and output file size. Android drops surplus frames with Media3's `FrameDropEffect`; Darwin caps the composition `frameDuration`. Web/Windows/Linux ignore the field.
+
 ## 2.1.0
 - **FEAT**(android, iOS, macOS): Add per-layer rotation to image overlays via a new `rotation` field on `ImageLayer` (radians, clockwise around the layer center — matches Flutter's `Transform.rotate`, so a `pro_image_editor` layer rotation can be forwarded directly). `offset`/`size` keep describing the layout box before rotation. Web/Windows/Linux ignore the field.
 

--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ var task = VideoRenderData(
     endTime: const Duration(seconds: 20),
     blur: 10,
     bitrate: 5000000,
+    maxFrameRate: 30, // cap output at 30 fps (drops surplus frames)
     enableAudio: false,
     audioTracks: [
       VideoAudioTrack(

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyFrameRate.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyFrameRate.kt
@@ -1,0 +1,25 @@
+import androidx.media3.common.Effect
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.effect.FrameDropEffect
+import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
+
+/**
+ * Caps the output frame rate at [maxFrameRate] frames per second.
+ *
+ * Uses Media3's [FrameDropEffect], which only ever drops frames to approximate
+ * the target frame rate — it never duplicates them. A source that already runs
+ * at or below [maxFrameRate] is therefore left untouched, so this acts as an
+ * upper limit rather than a fixed target.
+ *
+ * No effect when [maxFrameRate] is null or not positive.
+ *
+ * @param videoEffects List to add the frame-drop effect to
+ * @param maxFrameRate Maximum output frame rate in fps (null = keep source fps)
+ */
+@UnstableApi
+fun applyMaxFrameRate(videoEffects: MutableList<Effect>, maxFrameRate: Int?) {
+    if (maxFrameRate == null || maxFrameRate <= 0) return
+
+    Log.d(RENDER_TAG, "Capping output frame rate at $maxFrameRate fps")
+    videoEffects += FrameDropEffect.createDefaultFrameDropEffect(maxFrameRate.toFloat())
+}

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -340,6 +340,8 @@ data class RenderConfig(
     val scaleX: Float? = null,
     val scaleY: Float? = null,
     val bitrate: Int? = null,
+    /** Upper limit for the output frame rate (fps). Null = keep source fps. */
+    val maxFrameRate: Int? = null,
     val enableAudio: Boolean = true,
     val playbackSpeed: Float? = null,
     val colorFilters: List<ColorFilterConfig> = emptyList(),
@@ -454,6 +456,7 @@ data class RenderConfig(
                 scaleX = call.argument<Number>("scaleX")?.toFloat(),
                 scaleY = call.argument<Number>("scaleY")?.toFloat(),
                 bitrate = call.argument<Number>("bitrate")?.toInt(),
+                maxFrameRate = call.argument<Number>("maxFrameRate")?.toInt(),
                 enableAudio = call.argument<Boolean>("enableAudio") ?: true,
                 playbackSpeed = call.argument<Number>("playbackSpeed")?.toFloat(),
                 colorFilters = colorFilters,

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/utils/EffectsProcessor.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/utils/EffectsProcessor.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.audio.AudioProcessor
 import applyBlur
 import applyColorMatrix
 import applyFlip
+import applyMaxFrameRate
 import applyPlaybackSpeed
 import applyRotation
 import ch.waio.pro_video_editor.src.features.render.models.RenderConfig
@@ -36,6 +37,7 @@ class EffectsProcessor {
      * 4. Color Matrix - Applies color transformations (filters, adjustments)
      * 5. Blur - Applies blur effect
      * 6. Playback Speed - Adjusts video/audio speed
+     * 7. Frame Rate - Caps the output frame rate (drops surplus frames)
      *
      * @param config The render configuration containing effect parameters
      * @return ProcessedEffects containing lists of video and audio effects
@@ -55,6 +57,9 @@ class EffectsProcessor {
         applyColorMatrix(videoEffects, config.colorFilters)
         applyBlur(videoEffects, config.blur)
         applyPlaybackSpeed(videoEffects, audioEffects, config.playbackSpeed)
+        // Drop surplus frames last so the cap applies to the final timeline
+        // (after any playback-speed change).
+        applyMaxFrameRate(videoEffects, config.maxFrameRate)
 
         return ProcessedEffects(videoEffects, audioEffects)
     }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
@@ -276,9 +276,24 @@ class RenderVideo {
             )
           }
 
+          // Cap the output frame rate when a maximum was requested. The
+          // builders derive frameDuration from the source fps; lower the rate
+          // only when it exceeds the cap, so a slower source is left untouched.
+          var outputFrameDuration = videoCompConfig.frameDuration
+          if let maxFps = workingConfig.maxFrameRate, maxFps > 0 {
+            let current = outputFrameDuration
+            let currentFps =
+              current.value > 0 && current.timescale > 0
+              ? Double(current.timescale) / Double(current.value)
+              : Double(maxFps)
+            if Double(maxFps) < currentFps {
+              outputFrameDuration = CMTime(value: 1, timescale: CMTimeScale(maxFps))
+            }
+          }
+
           // Build the final AVMutableVideoComposition
           let videoComposition = AVMutableVideoComposition()
-          videoComposition.frameDuration = videoCompConfig.frameDuration
+          videoComposition.frameDuration = outputFrameDuration
           videoComposition.renderSize = finalRenderSize
           videoComposition.instructions = videoCompConfig.instructions
           videoComposition.customVideoCompositorClass = makeVideoCompositorSubclass(

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
@@ -311,6 +311,9 @@ struct RenderConfig: Sendable {
   /// Target bitrate in bits per second (nil = auto)
   let bitrate: Int?
 
+  /// Upper limit for the output frame rate in fps (nil = keep source fps)
+  let maxFrameRate: Int?
+
   /// Whether to include audio in output
   let enableAudio: Bool
 
@@ -362,6 +365,7 @@ struct RenderConfig: Sendable {
       scaleX: self.scaleX,
       scaleY: self.scaleY,
       bitrate: self.bitrate,
+      maxFrameRate: self.maxFrameRate,
       enableAudio: self.enableAudio,
       playbackSpeed: self.playbackSpeed,
       colorFilters: self.colorFilters,
@@ -428,6 +432,7 @@ struct RenderConfig: Sendable {
       scaleX: (args["scaleX"] as? NSNumber)?.floatValue,
       scaleY: (args["scaleY"] as? NSNumber)?.floatValue,
       bitrate: args["bitrate"] as? Int,
+      maxFrameRate: (args["maxFrameRate"] as? NSNumber)?.intValue,
       enableAudio: args["enableAudio"] as? Bool ?? true,
       playbackSpeed: (args["playbackSpeed"] as? NSNumber)?.floatValue,
       colorFilters: colorFilters,

--- a/example/integration_test/video_render_test.dart
+++ b/example/integration_test/video_render_test.dart
@@ -205,6 +205,28 @@ void main() {
     expect(originalMeta.resolution / factor, meta.resolution);
   });
 
+  testWidgets('limit frame rate (max 15 fps)', (tester) async {
+    final originalMeta = await ProVideoEditor.instance.getMetadata(inputVideo);
+    final meta = await testRender(
+      description: 'Limit fps to 15',
+      renderModel: VideoRenderData(
+        videoSegments: [VideoSegment(video: inputVideo)],
+        outputFormat: VideoOutputFormat.mp4,
+        maxFrameRate: 15,
+      ),
+    );
+
+    // Only meaningful when the source actually plays faster than the cap.
+    if ((originalMeta.frameRate ?? 0) > 15) {
+      expect(meta.frameRate, isNotNull, reason: 'fps missing in output');
+      expect(
+        meta.frameRate!,
+        lessThanOrEqualTo(16.5),
+        reason: 'output fps should be capped near 15',
+      );
+    }
+  });
+
   // Note: This test uses h264Video (demo.mp4, ~30s) since hevcVideo
   // is only ~2.5s
   testWidgets('trim video (7s - 20s)', (tester) async {

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -1512,7 +1512,7 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
   Future<void> _limitFrameRate() async {
     var data = VideoRenderData(
       videoSegments: [VideoSegment(video: _video)],
-      maxFrameRate: 30,
+      maxFrameRate: 5,
     );
 
     await _renderVideo(data);
@@ -2098,7 +2098,7 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           onTap: _limitFrameRate,
           leading: const Icon(Icons.speed_outlined),
           title: const Text('Limit frame rate'),
-          subtitle: const Text('Cap the output at 30 fps'),
+          subtitle: const Text('Cap the output at 5 fps'),
         ),
         if (!kIsWeb && (Platform.isIOS || Platform.isMacOS))
           ListTile(

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -1504,6 +1504,20 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     await _renderVideo(data);
   }
 
+  /// Cap the output frame rate.
+  ///
+  /// [VideoRenderData.maxFrameRate] is an upper limit: a faster source is
+  /// slowed to it (here 30 fps) while a slower source is left untouched. This
+  /// reduces the encoding workload and output file size.
+  Future<void> _limitFrameRate() async {
+    var data = VideoRenderData(
+      videoSegments: [VideoSegment(video: _video)],
+      maxFrameRate: 30,
+    );
+
+    await _renderVideo(data);
+  }
+
   Future<void> _generateMov() async {
     var data = VideoRenderData(
       outputFormat: VideoOutputFormat.mov,
@@ -2079,6 +2093,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           onTap: _bitrate,
           leading: const Icon(Icons.animation),
           title: const Text('Bitrate'),
+        ),
+        ListTile(
+          onTap: _limitFrameRate,
+          leading: const Icon(Icons.speed_outlined),
+          title: const Text('Limit frame rate'),
+          subtitle: const Text('Cap the output at 30 fps'),
         ),
         if (!kIsWeb && (Platform.isIOS || Platform.isMacOS))
           ListTile(

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -36,6 +36,7 @@ class VideoRenderData {
     this.audioTracks = const [],
     this.blur,
     this.bitrate,
+    this.maxFrameRate,
     this.shouldOptimizeForNetworkUse = false,
     this.imageBytesWithCropping = false,
   })  : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
@@ -58,6 +59,10 @@ class VideoRenderData {
         assert(
           bitrate == null || bitrate > 0,
           '[bitrate] must be greater than 0',
+        ),
+        assert(
+          maxFrameRate == null || maxFrameRate > 0,
+          '[maxFrameRate] must be greater than 0',
         );
 
   /// Creates a [VideoRenderData] with a predefined quality preset.
@@ -90,6 +95,7 @@ class VideoRenderData {
     Duration? endTime,
     double? blur,
     int? bitrateOverride,
+    int? maxFrameRate,
     List<ColorFilter> colorFilters = const [],
     List<VideoAudioTrack> audioTracks = const [],
     bool shouldOptimizeForNetworkUse = false,
@@ -110,6 +116,7 @@ class VideoRenderData {
       endTime: endTime,
       blur: blur,
       bitrate: bitrateOverride ?? qualityConfig.bitrate,
+      maxFrameRate: maxFrameRate,
       colorFilters: colorFilters,
       audioTracks: audioTracks,
       qualityConfig: qualityConfig,
@@ -212,6 +219,19 @@ class VideoRenderData {
   /// bitrate, instant it will choose a preset which is the most near to the
   /// applied bitrate.
   final int? bitrate;
+
+  /// Caps the frame rate (frames per second) of the exported video.
+  ///
+  /// This is an upper limit, not a target: when the source plays faster than
+  /// [maxFrameRate], frames are dropped to bring it down (e.g. a 60 fps source
+  /// capped at `30` is exported at 30 fps). A source that is already at or
+  /// below the cap is left untouched.
+  ///
+  /// Lowering the frame rate reduces the encoding workload and output file
+  /// size. When `null` (default), the source frame rate is preserved.
+  ///
+  /// **Note:** Ignored on Web, Windows and Linux.
+  final int? maxFrameRate;
 
   /// Whether to optimize the video for network streaming (fast start).
   ///
@@ -348,6 +368,7 @@ class VideoRenderData {
       'outputFormat': outputFormat.name,
       'blur': blur,
       'bitrate': bitrate,
+      'maxFrameRate': maxFrameRate,
       'scaleX': scaleX,
       'scaleY': scaleY,
       // Global trim across the whole timeline (for videoSegments and
@@ -375,6 +396,7 @@ class VideoRenderData {
     List<VideoAudioTrack>? audioTracks,
     double? blur,
     int? bitrate,
+    int? maxFrameRate,
     bool? shouldOptimizeForNetworkUse,
     bool? imageBytesWithCropping,
   }) {
@@ -393,6 +415,7 @@ class VideoRenderData {
       audioTracks: audioTracks ?? this.audioTracks,
       blur: blur ?? this.blur,
       bitrate: bitrate ?? this.bitrate,
+      maxFrameRate: maxFrameRate ?? this.maxFrameRate,
       shouldOptimizeForNetworkUse:
           shouldOptimizeForNetworkUse ?? this.shouldOptimizeForNetworkUse,
       imageBytesWithCropping:
@@ -416,6 +439,7 @@ class VideoRenderData {
       'audioTracks': audioTracks.map((x) => x.toMap()).toList(),
       'blur': blur,
       'bitrate': bitrate,
+      'maxFrameRate': maxFrameRate,
       'shouldOptimizeForNetworkUse': shouldOptimizeForNetworkUse,
       'imageBytesWithCropping': imageBytesWithCropping,
     };
@@ -471,6 +495,9 @@ class VideoRenderData {
       ),
       blur: tryParseDouble(map['blur']),
       bitrate: map['bitrate'] != null ? safeParseInt(map['bitrate']) : null,
+      maxFrameRate: map['maxFrameRate'] != null
+          ? safeParseInt(map['maxFrameRate'])
+          : null,
       shouldOptimizeForNetworkUse: map['shouldOptimizeForNetworkUse'] as bool,
       imageBytesWithCropping: map['imageBytesWithCropping'] as bool,
     );
@@ -497,6 +524,7 @@ class VideoRenderData {
         'audioTracks: $audioTracks, '
         'blur: $blur, '
         'bitrate: $bitrate, '
+        'maxFrameRate: $maxFrameRate, '
         'shouldOptimizeForNetworkUse: $shouldOptimizeForNetworkUse, '
         'imageBytesWithCropping: $imageBytesWithCropping)';
   }
@@ -519,6 +547,7 @@ class VideoRenderData {
         listEquals(other.audioTracks, audioTracks) &&
         other.blur == blur &&
         other.bitrate == bitrate &&
+        other.maxFrameRate == maxFrameRate &&
         other.shouldOptimizeForNetworkUse == shouldOptimizeForNetworkUse &&
         other.imageBytesWithCropping == imageBytesWithCropping;
   }
@@ -539,6 +568,7 @@ class VideoRenderData {
         audioTracks.hashCode ^
         blur.hashCode ^
         bitrate.hashCode ^
+        maxFrameRate.hashCode ^
         shouldOptimizeForNetworkUse.hashCode ^
         imageBytesWithCropping.hashCode;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/

--- a/test/core/models/video/video_render_data_model_test.dart
+++ b/test/core/models/video/video_render_data_model_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_video_editor/core/models/video/editor_video_model.dart';
+import 'package:pro_video_editor/core/models/video/video_quality_preset.dart';
+import 'package:pro_video_editor/core/models/video/video_render_data_model.dart';
+import 'package:pro_video_editor/core/models/video/video_segment_model.dart';
+
+void main() {
+  group('VideoRenderData maxFrameRate', () {
+    VideoRenderData buildData({int? maxFrameRate}) {
+      return VideoRenderData(
+        id: 'test',
+        videoSegments: [VideoSegment(video: EditorVideo.file('test.mp4'))],
+        maxFrameRate: maxFrameRate,
+      );
+    }
+
+    test('defaults to null', () {
+      expect(buildData().maxFrameRate, isNull);
+    });
+
+    test('asserts a positive value', () {
+      expect(
+        () => buildData(maxFrameRate: 0),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => buildData(maxFrameRate: -5),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('toMap serializes the value', () {
+      expect(buildData(maxFrameRate: 30).toMap()['maxFrameRate'], 30);
+      expect(buildData().toMap()['maxFrameRate'], isNull);
+    });
+
+    test('toMap / fromMap roundtrip preserves the value', () {
+      final restored =
+          VideoRenderData.fromMap(buildData(maxFrameRate: 24).toMap());
+      expect(restored.maxFrameRate, 24);
+
+      final restoredNull = VideoRenderData.fromMap(buildData().toMap());
+      expect(restoredNull.maxFrameRate, isNull);
+    });
+
+    test('fromMap parses numeric strings safely', () {
+      final map = buildData().toMap()..['maxFrameRate'] = '60';
+      expect(VideoRenderData.fromMap(map).maxFrameRate, 60);
+    });
+
+    test('copyWith overrides and otherwise keeps the value', () {
+      final overridden = buildData(maxFrameRate: 30).copyWith(maxFrameRate: 60);
+      expect(overridden.maxFrameRate, 60);
+      expect(buildData(maxFrameRate: 30).copyWith().maxFrameRate, 30);
+    });
+
+    test('withQualityPreset forwards the value', () {
+      final data = VideoRenderData.withQualityPreset(
+        videoSegments: [VideoSegment(video: EditorVideo.file('test.mp4'))],
+        qualityPreset: VideoQualityPreset.p720,
+        maxFrameRate: 30,
+      );
+      expect(data.maxFrameRate, 30);
+    });
+  });
+}

--- a/test/pro_video_editor_method_channel_test.mocks.dart
+++ b/test/pro_video_editor_method_channel_test.mocks.dart
@@ -429,6 +429,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
     List<_i4.VideoAudioTrack>? audioTracks,
     double? blur,
     int? bitrate,
+    int? maxFrameRate,
     bool? shouldOptimizeForNetworkUse,
     bool? imageBytesWithCropping,
   }) =>
@@ -451,6 +452,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
             #audioTracks: audioTracks,
             #blur: blur,
             #bitrate: bitrate,
+            #maxFrameRate: maxFrameRate,
             #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
             #imageBytesWithCropping: imageBytesWithCropping,
           },
@@ -475,6 +477,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
               #audioTracks: audioTracks,
               #blur: blur,
               #bitrate: bitrate,
+              #maxFrameRate: maxFrameRate,
               #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
               #imageBytesWithCropping: imageBytesWithCropping,
             },


### PR DESCRIPTION
Closes #126

## What

The exported video frame rate can now be capped via a new `maxFrameRate` field on `VideoRenderData`.

- **Upper limit, not a target**: a source that plays faster than the cap is reduced to it (e.g. 60 → 30 fps); a source already at or below the cap is left untouched.
- Lowering the frame rate reduces the encoding workload and output file size.
- `int?`, defaults to `null` (keep source fps); asserts `> 0`.

```dart
VideoRenderData(
  videoSegments: [VideoSegment(video: EditorVideo.file('input.mp4'))],
  maxFrameRate: 30, // cap at 30 fps
);
```

## How

- **Dart** (`VideoRenderData`): new field + serialization, `withQualityPreset`, `copyWith`, equality, `toString`.
- **Android**: drop surplus frames with Media3's `FrameDropEffect` (`createDefaultFrameDropEffect`, which only drops — never duplicates — so it acts as a cap). Added last in the effect pipeline so it applies to the final timeline after any playback-speed change; covers both the single-track and composition render paths.
- **iOS/macOS**: cap the composition `frameDuration` centrally in `RenderVideo` after the builders derive it from the source fps (covers single-track and composition paths in one place).
- **Web/Windows/Linux**: ignore the field, consistent with other render features.

## Tests

- New unit tests for `maxFrameRate` (defaults, positive-value assert, `toMap`/`fromMap` roundtrip, safe string parsing, `copyWith`, `withQualityPreset`).
- New integration test capping a faster source at 15 fps and asserting the output fps.
- New "Limit frame rate" entry on the render example page.

Verified: `flutter analyze` clean, full `flutter test` green (248), Android Kotlin `BUILD SUCCESSFUL`.