### PR TITLE
fix(darwin): cancel active tasks and clear event sinks on FlutterEngine teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.2
+- **FIX**(iOS, macOS): Cancel active tasks and clear event sinks when the FlutterEngine is torn down. In-flight render/audio/waveform callbacks no longer message a stopped engine, fixing `NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run` crashes on app termination or surface recreation.
+
 ## 2.1.1
 - **FIX**(android): The global output trim now respects per-clip and global `playbackSpeed`. A sped-up composition capped by `endTime` was trimmed against the source timeline, cutting the output far shorter than the preview; the cap now limits the post-speed output length, matching iOS.
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
@@ -54,6 +54,33 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
     eventChannel.setStreamHandler(instance)
     waveformStreamChannel.setStreamHandler(WaveformStreamHandler(plugin: instance))
     logChannel.setStreamHandler(LogStreamHandler(plugin: instance))
+
+    // Publishing the instance keeps it alive for the registrar and ensures
+    // `detachFromEngine(for:)` is invoked when the FlutterEngine is torn down.
+    registrar.publish(instance)
+  }
+
+  /// Tears down all in-flight work when the FlutterEngine is detached.
+  ///
+  /// Invoked by the registrar on the platform/main thread during engine
+  /// teardown (e.g. app termination or surface recreation). Cancels every
+  /// active task and clears every event sink so already-dispatched callbacks
+  /// no-op instead of messaging a messenger whose engine is no longer running,
+  /// which would otherwise raise an
+  /// `NSInternalInconsistencyException: Sending a message before the
+  /// FlutterEngine has been run`.
+  public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+    activeRenderTasks.values.forEach { $0.cancel() }
+    activeAudioTasks.values.forEach { $0.cancel() }
+    activeWaveformTasks.values.forEach { $0.cancel() }
+    activeRenderTasks.removeAll()
+    activeAudioTasks.removeAll()
+    activeWaveformTasks.removeAll()
+
+    eventSink = nil
+    waveformStreamSink = nil
+    logSink = nil
+    PluginLog.sink = nil
   }
 
   /// Routes incoming method calls to appropriate handlers.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Problem

Crashlytics (consumer app build 1.0.13) shows a cluster of iOS fatal crashes:

```
ProVideoEditorPlugin.postProgress →
NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run
```

When the `FlutterEngine` is torn down (app termination, surface recreation), in-flight render/audio/waveform callbacks keep firing `self.eventSink?(...)` against a messenger whose engine is no longer running, which throws.

The plugin previously had **no** `detachFromEngine(for:)`, and the sinks (`eventSink`, `waveformStreamSink`, `logSink`, `PluginLog.sink`) were cleared **only** in `onCancel`, which is not reliably called during engine teardown.

## Fix

- Add `detachFromEngine(for:)` to the `FlutterPlugin` conformance in `ProVideoEditorPlugin.swift`. It cancels every active render/audio/waveform task and nils every event sink, running on the platform/main thread during teardown.
- Call `registrar.publish(instance)` in `register(with:)` so the registrar retains the instance and actually invokes `detachFromEngine(for:)` on teardown — on both iOS and macOS (the Darwin source is shared).
- Existing sink call sites stay nil-safe: they read `self.eventSink?(...)` at block-execution time, so once `detach` nils the sinks on main, any already-dispatched blocks no-op instead of throwing.

## Verification

- `dart analyze` — clean.
- `flutter build ios --no-codesign` (in `example/`) — succeeds.
- `flutter build macos` (in `example/`) — succeeds.

⚠️ **A real device run is still required for final confirmation**: start a render/export, then pop the editor / background the app while progress is active, and terminate/relaunch to confirm no `NSInternalInconsistencyException`.