### PR TITLE
fix(darwin): make FlutterEngine detach terminal for method-channel result delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.3
+- **FIX**(iOS, macOS): Make FlutterEngine detach terminal for method-channel result delivery. After detach, a late render/audio/waveform/metadata/thumbnail callback no longer calls a captured `FlutterResult` against a torn-down engine, closing the remaining `NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run` path from 2.1.2.
+
 ## 2.1.2
 - **FIX**(iOS, macOS): Cancel active tasks and clear event sinks when the FlutterEngine is torn down. In-flight render/audio/waveform callbacks no longer message a stopped engine, fixing `NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run` crashes on app termination or surface recreation.
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
@@ -33,6 +33,20 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
   private var activeAudioTasks: [String: AudioExtractTask] = [:]
   private var activeWaveformTasks: [String: WaveformTask] = [:]
 
+  /// Guards `engineDetached`. Metadata/thumbnail callbacks may complete off the
+  /// main thread, so the detach flag is read/written under a lock.
+  private let engineLock = NSLock()
+  private var engineDetached = false
+
+  /// Whether `tearDownForEngineDetach()` has run. Once true, every captured
+  /// `FlutterResult` would message a no-longer-running engine, so asynchronous
+  /// deliveries must become terminal no-ops.
+  private var isEngineDetached: Bool {
+    engineLock.lock()
+    defer { engineLock.unlock() }
+    return engineDetached
+  }
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     #if os(iOS)
       let messenger = registrar.messenger()
@@ -70,6 +84,21 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
   /// `NSInternalInconsistencyException: Sending a message before the
   /// FlutterEngine has been run`.
   public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+    tearDownForEngineDetach()
+  }
+
+  /// Performs the engine-detach teardown.
+  ///
+  /// Extracted from `detachFromEngine(for:)` so it can be exercised without a
+  /// `FlutterPluginRegistrar`. Sets `engineDetached` first so any callback that
+  /// races the teardown sees the flag and routes its delivery through
+  /// `deliverResult(_:_:)` as a no-op, then cancels every active task and
+  /// clears every event sink.
+  func tearDownForEngineDetach() {
+    engineLock.lock()
+    engineDetached = true
+    engineLock.unlock()
+
     activeRenderTasks.values.forEach { $0.cancel() }
     activeAudioTasks.values.forEach { $0.cancel() }
     activeWaveformTasks.values.forEach { $0.cancel() }
@@ -81,6 +110,17 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
     waveformStreamSink = nil
     logSink = nil
     PluginLog.sink = nil
+  }
+
+  /// Delivers an asynchronous method-channel result.
+  ///
+  /// After engine detach the captured `FlutterResult` would message a
+  /// not-running engine, raising `NSInternalInconsistencyException: Sending a
+  /// message before the FlutterEngine has been run`. Delivery is a terminal
+  /// no-op once detached.
+  func deliverResult(_ result: FlutterResult, _ value: Any?) {
+    guard !isEngineDetached else { return }
+    result(value)
   }
 
   /// Routes incoming method calls to appropriate handlers.
@@ -175,9 +215,10 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           inputPath: config.inputPath,
           ext: config.fileExtension,
           checkStreamingOptimization: config.checkStreamingOptimization)
-        result(meta)
+        self.deliverResult(result, meta)
       } catch {
-        result(
+        self.deliverResult(
+          result,
           FlutterError(code: "METADATA_ERROR", message: error.localizedDescription, details: nil))
       }
     }
@@ -198,9 +239,10 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
     Task {
       do {
         let hasAudio = try await VideoMetadata.checkAudioTrack(inputPath: config.inputPath)
-        result(hasAudio)
+        self.deliverResult(result, hasAudio)
       } catch {
-        result(
+        self.deliverResult(
+          result,
           FlutterError(code: "AUDIO_CHECK_ERROR", message: error.localizedDescription, details: nil)
         )
       }
@@ -229,10 +271,11 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
       },
       onComplete: { thumbnails in
         self.postProgress(id: config.id, progress: 1.0)
-        result(thumbnails)
+        self.deliverResult(result, thumbnails)
       },
       onError: { error in
-        result(
+        self.deliverResult(
+          result,
           FlutterError(
             code: "THUMBNAIL_ERROR", message: error.localizedDescription, details: nil))
       }
@@ -290,7 +333,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = self.activeRenderTasks.removeValue(forKey: id) {
             task.sendSuccess(outputData)
           } else {
-            result(outputData)
+            self.deliverResult(result, outputData)
           }
         }
       },
@@ -307,7 +350,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = task {
             task.sendError(flutterError)
           } else {
-            result(flutterError)
+            self.deliverResult(result, flutterError)
           }
         }
       }
@@ -367,7 +410,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = self.activeRenderTasks.removeValue(forKey: id) {
             task.sendSuccess(outputData)
           } else {
-            result(outputData)
+            self.deliverResult(result, outputData)
           }
         }
       },
@@ -384,7 +427,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = task {
             task.sendError(flutterError)
           } else {
-            result(flutterError)
+            self.deliverResult(result, flutterError)
           }
         }
       }
@@ -446,7 +489,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = self.activeAudioTasks.removeValue(forKey: id) {
             task.sendSuccess(outputData)
           } else {
-            result(outputData)
+            self.deliverResult(result, outputData)
           }
         }
       },
@@ -470,7 +513,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = task {
             task.sendError(flutterError)
           } else {
-            result(flutterError)
+            self.deliverResult(result, flutterError)
           }
         }
       }
@@ -529,7 +572,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = self.activeWaveformTasks.removeValue(forKey: id) {
             task.sendSuccess(waveformData)
           } else {
-            result(waveformData)
+            self.deliverResult(result, waveformData)
           }
         }
       },
@@ -552,7 +595,7 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
           if let task = task {
             task.sendError(flutterError)
           } else {
-            result(flutterError)
+            self.deliverResult(result, flutterError)
           }
         }
       }

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -85,4 +85,37 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(off.y, 0, accuracy: 1e-6)
   }
 
+  // MARK: - Engine-detach result delivery
+
+  // Before detach a captured FlutterResult delivers normally.
+  func testDeliverResultInvokesClosureBeforeDetach() {
+    let plugin = ProVideoEditorPlugin()
+
+    var deliveredCount = 0
+    var deliveredValue: Any?
+    plugin.deliverResult({ value in
+      deliveredCount += 1
+      deliveredValue = value
+    }, "payload")
+
+    XCTAssertEqual(deliveredCount, 1)
+    XCTAssertEqual(deliveredValue as? String, "payload")
+  }
+
+  // Regression guard for the `else`-after-detach hole: once the engine has been
+  // torn down, a late async delivery must be a terminal no-op so it never
+  // messages a no-longer-running FlutterEngine.
+  func testDeliverResultIsNoOpAfterDetach() {
+    let plugin = ProVideoEditorPlugin()
+
+    plugin.tearDownForEngineDetach()
+
+    var deliveredCount = 0
+    plugin.deliverResult({ _ in
+      deliveredCount += 1
+    }, "payload")
+
+    XCTAssertEqual(deliveredCount, 0)
+  }
+
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Why

2.1.2 added `detachFromEngine(for:)`, which cancels tasks, `removeAll()`s the task maps, and nils the event sinks. But the render/audio/waveform completion and error handlers still had a fallback `else { result(...) }` that calls the captured `FlutterResult` when the task is no longer in the map. After detach (map emptied), a late callback takes that `else` and messages a torn-down engine — the same `NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run` class the 2.1.2 bump was meant to fix.

The sink fix and this hole are coupled: detach only matters while a render is in flight, which is exactly when the `else` becomes reachable. The untracked deliveries (`getMetadata`, `hasAudioTrack`, `getThumbnails`) had the same exposure.

## What

Make asynchronous result delivery terminal after detach:

- Add a thread-safe `engineDetached` flag (`NSLock`-protected; metadata/thumbnail callbacks may complete off the main thread).
- Extract the teardown body into `tearDownForEngineDetach()`, which sets the flag **first**, then does the existing cancel / `removeAll` / sink-nil work; `detachFromEngine(for:)` just calls it.
- Route every async terminal delivery through a single `deliverResult(_:_:)` guard that no-ops once detached:
  - render / stop-motion / audio / waveform `onComplete` + `onError` `else` branches
  - `getMetadata`, `hasAudioTrack`, `getThumbnails` deliveries
- Left as-is: the `task.sendSuccess`/`sendError` paths (only reached pre-detach while the task is still in the map), the synchronous validation `result(...)` calls, and `handleStartWaveformStream`'s `result(nil)`.

## Test

Added a macOS `RunnerTests` regression test (`@testable import`):

- `deliverResult` invokes its closure **before** detach (delivers normally).
- After `tearDownForEngineDetach()`, `deliverResult` is a **no-op** — the regression guard for the `else`-after-detach hole.

Verified red against the unguarded delivery, then green with the guard.

## Verification

- `dart analyze` — clean.
- `example/` macOS build — succeeds; macOS `RunnerTests` pass.
- `example/` iOS build (simulator, `--no-codesign`) — succeeds.
- ⚠️ Manual iOS crash repro (long export → engine teardown while a render callback is in flight; reproduce on 2.1.1, confirm gone here) still pending — it requires triggering an engine teardown mid-render on a real run and can't be reliably automated. This run also confirms whether the detach fix closes #4400.

## Release

- Bumped `pubspec.yaml` 2.1.2 → 2.1.3 and added a `CHANGELOG.md` entry.
- **Not** published — the maintainer publishes 2.1.3.