### PR TITLE
feat: frame-accurate splitVideo across all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- **FEAT**(android, iOS, macOS): Add `ProVideoEditor.splitVideo` — a frame-accurate split that cuts one video into two files (`SplitVideoModel`). Each half is re-encoded from the exact cut frame without the render compositor/effects, making it far faster and more stall-resistant than splitting via `renderVideoToFile`; every export is guarded by a watchdog timeout. Cancellable and progress-reporting via the task `id`. Web/Windows/Linux throw `UnimplementedError`.
+
 ## 2.1.3
 - **FIX**(iOS, macOS): Make FlutterEngine detach terminal for method-channel result delivery. After detach, a late render/audio/waveform/metadata/thumbnail callback no longer calls a captured `FlutterResult` against a torn-down engine, closing the remaining `NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run` path from 2.1.2.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/ProVideoEditorPlugin.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/ProVideoEditorPlugin.kt
@@ -12,6 +12,7 @@ import ch.waio.pro_video_editor.src.features.render.RenderVideo
 import ch.waio.pro_video_editor.src.features.render.models.RenderConfig
 import ch.waio.pro_video_editor.src.features.render.models.RenderTask
 import ch.waio.pro_video_editor.src.features.render.models.VideoEncoderConfigurationException
+import ch.waio.pro_video_editor.src.features.split.SplitVideo
 import ch.waio.pro_video_editor.src.features.stopmotion.StopMotionGenerator
 import ch.waio.pro_video_editor.src.features.stopmotion.models.StopMotionConfig
 import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
@@ -56,6 +57,7 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
     private var logSink: EventChannel.EventSink? = null
 
     private lateinit var renderVideo: RenderVideo
+    private lateinit var splitVideo: SplitVideo
     private lateinit var stopMotionGenerator: StopMotionGenerator
     private lateinit var metadata: Metadata
     private lateinit var thumbnailGenerator: ThumbnailGenerator
@@ -124,6 +126,7 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
         })
 
         renderVideo = RenderVideo(flutterPluginBinding.applicationContext)
+        splitVideo = SplitVideo(flutterPluginBinding.applicationContext)
         stopMotionGenerator = StopMotionGenerator(flutterPluginBinding.applicationContext)
         metadata = Metadata(flutterPluginBinding.applicationContext)
         thumbnailGenerator = ThumbnailGenerator(flutterPluginBinding.applicationContext)
@@ -171,6 +174,7 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
             "getThumbnails" -> handleGetThumbnails(call, result)
             "renderVideo" -> handleRenderVideo(call, result)
             "renderStopMotion" -> handleRenderStopMotion(call, result)
+            "splitVideo" -> handleSplitVideo(call, result)
             "extractAudio" -> handleExtractAudio(call, result)
             "getWaveform" -> handleGetWaveform(call, result)
             "startWaveformStream" -> handleStartWaveformStream(call, result)
@@ -430,6 +434,100 @@ class ProVideoEditorPlugin : FlutterPlugin, MethodCallHandler {
         } catch (e: Exception) {
             activeRenderTasks.remove(id)
             result.error("RENDER_ERROR", "Failed to start stop-motion render: ${e.message}", null)
+        }
+    }
+
+    /**
+     * Splits a single video into two files at a frame-accurate position.
+     *
+     * Re-encodes each half from the exact split frame (no compositor/effects).
+     * Tracked by unique ID via the same render-task map so [handleCancelTask]
+     * works unchanged. Returns the two output paths on success.
+     */
+    private fun handleSplitVideo(call: MethodCall, result: MethodChannel.Result) {
+        val id = call.argument<String>("id") ?: ""
+        if (id.isBlank()) {
+            result.error("INVALID_ARGUMENTS", "Task id is required and cannot be empty", null)
+            return
+        }
+
+        if (activeRenderTasks.containsKey(id)) {
+            result.error(
+                "TASK_ALREADY_EXISTS",
+                "A render task with id '$id' is already active",
+                null
+            )
+            return
+        }
+
+        val inputPath = call.argument<String>("inputPath")
+        val startOutputPath = call.argument<String>("startOutputPath")
+        val endOutputPath = call.argument<String>("endOutputPath")
+        val splitUs = (call.argument<Number>("splitUs"))?.toLong()
+        if (inputPath == null || startOutputPath == null ||
+            endOutputPath == null || splitUs == null
+        ) {
+            result.error("INVALID_ARGUMENTS", "Missing parameters", null)
+            return
+        }
+
+        val outputFormat = call.argument<String>("outputFormat") ?: "mp4"
+        val bitrate = call.argument<Number>("bitrate")?.toInt()
+        val enableAudio = call.argument<Boolean>("enableAudio") ?: true
+
+        postProgress(id, 0.0)
+
+        val task = RenderTask(job = null, result = result)
+        activeRenderTasks[id] = task
+
+        try {
+            val jobHandle = splitVideo.split(
+                inputPath = inputPath,
+                splitUs = splitUs,
+                startOutputPath = startOutputPath,
+                endOutputPath = endOutputPath,
+                outputFormat = outputFormat,
+                bitrate = bitrate,
+                enableAudio = enableAudio,
+                mainHandler = mainHandler,
+                onProgress = { progress -> postProgress(id, progress) },
+                onComplete = { outputPaths ->
+                    mainHandler.post {
+                        postProgress(id, 1.0)
+                        val removedTask = activeRenderTasks.remove(id)
+                        removedTask?.sendSuccess(outputPaths)
+                    }
+                },
+                onError = { error ->
+                    Log.e(
+                        "SplitVideo",
+                        "Error splitting video: ${error::class.java.name}: ${error.message}",
+                        error
+                    )
+                    mainHandler.post {
+                        val removedTask = activeRenderTasks.remove(id)
+                        val code = when {
+                            removedTask?.canceled?.get() == true -> "CANCELED"
+                            error is java.util.concurrent.CancellationException -> "CANCELED"
+                            else -> "SPLIT_ERROR"
+                        }
+                        val message = error.message
+                            ?: "${error::class.java.simpleName} (no message)"
+                        removedTask?.sendError(code, message)
+                    }
+                }
+            )
+
+            task.job = jobHandle
+            if (task.canceled.get()) {
+                jobHandle.cancel()
+            }
+        } catch (e: IllegalArgumentException) {
+            activeRenderTasks.remove(id)
+            result.error("INVALID_ARGUMENTS", e.message, null)
+        } catch (e: Exception) {
+            activeRenderTasks.remove(id)
+            result.error("SPLIT_ERROR", "Failed to start split: ${e.message}", null)
         }
     }
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/split/SplitVideo.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/split/SplitVideo.kt
@@ -1,0 +1,271 @@
+package ch.waio.pro_video_editor.src.features.split
+
+import mapFormatToMimeType
+import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.transformer.Composition
+import androidx.media3.transformer.EditedMediaItem
+import androidx.media3.transformer.ExportException
+import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.ProgressHolder
+import androidx.media3.transformer.Transformer
+import ch.waio.pro_video_editor.src.features.render.helpers.ResilientVideoEncoderFactory
+import ch.waio.pro_video_editor.src.features.render.models.RenderJobHandle
+import ch.waio.pro_video_editor.src.shared.logging.PluginLog as Log
+import java.io.File
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Frame-accurate splitting of a single video into two files.
+ *
+ * Each half is re-encoded from the exact split frame using a Media3
+ * [Transformer] with a [MediaItem.ClippingConfiguration]. Because clipping at an
+ * arbitrary (non-keyframe) position forces a transcode, the cut is
+ * frame-accurate — unlike a transmux, which would snap to a keyframe.
+ *
+ * The two halves run sequentially (one encoder at a time) and every half is
+ * guarded by a watchdog ([EXPORT_TIMEOUT_MS]). Crucially, [Transformer.cancel]
+ * does not invoke the listener, so cancellation and timeout deliver the terminal
+ * result explicitly through a single job-level guard. The job therefore always
+ * terminates — success, error, cancellation or timeout — and never leaves the
+ * method-channel result pending.
+ */
+@UnstableApi
+class SplitVideo(private val context: Context) {
+    companion object {
+        private const val TAG = "SplitVideo"
+
+        /** Max time a single half may export before it is force-cancelled. */
+        private const val EXPORT_TIMEOUT_MS = 120_000L
+
+        private const val POLL_INTERVAL_MS = 200L
+    }
+
+    /**
+     * Starts a frame-accurate split. Writes `0 → splitUs` to [startOutputPath]
+     * and `splitUs → end` to [endOutputPath], reporting both paths via
+     * [onComplete].
+     */
+    fun split(
+        inputPath: String,
+        splitUs: Long,
+        startOutputPath: String,
+        endOutputPath: String,
+        outputFormat: String,
+        bitrate: Int?,
+        enableAudio: Boolean,
+        mainHandler: Handler,
+        onProgress: (Double) -> Unit,
+        onComplete: (List<String>) -> Unit,
+        onError: (Throwable) -> Unit
+    ): RenderJobHandle {
+        val finished = AtomicBoolean(false)
+        val pollStop = AtomicBoolean(false)
+        val transformerRef = AtomicReference<Transformer?>(null)
+        val timeoutRef = AtomicReference<Runnable?>(null)
+
+        fun disarmTimeout() {
+            timeoutRef.getAndSet(null)?.let { mainHandler.removeCallbacks(it) }
+        }
+
+        fun finishSuccess(paths: List<String>) {
+            if (!finished.compareAndSet(false, true)) return
+            pollStop.set(true)
+            disarmTimeout()
+            onProgress(1.0)
+            onComplete(paths)
+        }
+
+        fun finishError(error: Throwable) {
+            if (!finished.compareAndSet(false, true)) return
+            pollStop.set(true)
+            disarmTimeout()
+            // Release the active encoder if a half is still running.
+            mainHandler.post { transformerRef.getAndSet(null)?.cancel() }
+            onError(error)
+        }
+
+        val handle = RenderJobHandle {
+            finishError(CancellationException("Split canceled"))
+        }
+
+        if (splitUs <= 0L) {
+            finishError(IllegalArgumentException("splitUs must be greater than 0"))
+            return handle
+        }
+
+        val inputFile = File(inputPath)
+        if (!inputFile.exists()) {
+            finishError(IllegalArgumentException("Input file not found: $inputPath"))
+            return handle
+        }
+
+        // Half 1: 0 → split. On success, chain Half 2: split → end.
+        mainHandler.post {
+            if (finished.get()) return@post
+            exportHalf(
+                inputPath = inputPath,
+                startUs = 0L,
+                endUs = splitUs,
+                outputPath = startOutputPath,
+                outputFormat = outputFormat,
+                bitrate = bitrate,
+                enableAudio = enableAudio,
+                mainHandler = mainHandler,
+                pollStop = pollStop,
+                transformerRef = transformerRef,
+                timeoutRef = timeoutRef,
+                onProgress = { onProgress(it * 0.5) },
+                onHalfComplete = {
+                    if (!finished.get()) {
+                        pollStop.set(false)
+                        exportHalf(
+                            inputPath = inputPath,
+                            startUs = splitUs,
+                            endUs = null,
+                            outputPath = endOutputPath,
+                            outputFormat = outputFormat,
+                            bitrate = bitrate,
+                            enableAudio = enableAudio,
+                            mainHandler = mainHandler,
+                            pollStop = pollStop,
+                            transformerRef = transformerRef,
+                            timeoutRef = timeoutRef,
+                            onProgress = { onProgress(0.5 + it * 0.5) },
+                            onHalfComplete = {
+                                finishSuccess(listOf(startOutputPath, endOutputPath))
+                            },
+                            onHalfError = { finishError(it) }
+                        )
+                    }
+                },
+                onHalfError = { finishError(it) }
+            )
+        }
+
+        return handle
+    }
+
+    /**
+     * Re-encodes a single clipped range to [outputPath]. Must be called on the
+     * [mainHandler] thread (Media3 [Transformer] requires a Looper).
+     */
+    private fun exportHalf(
+        inputPath: String,
+        startUs: Long,
+        endUs: Long?,
+        outputPath: String,
+        outputFormat: String,
+        bitrate: Int?,
+        enableAudio: Boolean,
+        mainHandler: Handler,
+        pollStop: AtomicBoolean,
+        transformerRef: AtomicReference<Transformer?>,
+        timeoutRef: AtomicReference<Runnable?>,
+        onProgress: (Double) -> Unit,
+        onHalfComplete: () -> Unit,
+        onHalfError: (Throwable) -> Unit
+    ) {
+        val outputFile = File(outputPath)
+        outputFile.parentFile?.mkdirs()
+        if (outputFile.exists()) outputFile.delete()
+
+        val mimeType = mapFormatToMimeType(outputFormat)
+        val encoderFactory = ResilientVideoEncoderFactory(
+            context = context,
+            mimeType = mimeType,
+            bitrate = bitrate,
+        )
+
+        // Frame-accurate clipping: a non-keyframe start forces Media3 to
+        // transcode, cutting at the exact requested microsecond.
+        val clipping = MediaItem.ClippingConfiguration.Builder()
+            .setStartPositionUs(startUs)
+        if (endUs != null) clipping.setEndPositionUs(endUs)
+
+        val mediaItem = MediaItem.Builder()
+            .setUri(Uri.fromFile(File(inputPath)))
+            .setClippingConfiguration(clipping.build())
+            .build()
+        val editedMediaItem = EditedMediaItem.Builder(mediaItem)
+            .setRemoveAudio(!enableAudio)
+            .build()
+
+        val halfDone = AtomicBoolean(false)
+
+        val transformer = Transformer.Builder(context)
+            .setEncoderFactory(encoderFactory)
+            .setVideoMimeType(mimeType)
+            .addListener(object : Transformer.Listener {
+                override fun onCompleted(composition: Composition, result: ExportResult) {
+                    if (!halfDone.compareAndSet(false, true)) return
+                    pollStop.set(true)
+                    timeoutRef.getAndSet(null)?.let { mainHandler.removeCallbacks(it) }
+                    onProgress(1.0)
+                    onHalfComplete()
+                }
+
+                override fun onError(
+                    composition: Composition,
+                    result: ExportResult,
+                    exception: ExportException
+                ) {
+                    if (!halfDone.compareAndSet(false, true)) return
+                    pollStop.set(true)
+                    timeoutRef.getAndSet(null)?.let { mainHandler.removeCallbacks(it) }
+                    outputFile.delete()
+                    onHalfError(exception)
+                }
+            })
+            .build()
+        transformerRef.set(transformer)
+
+        // Watchdog: a stalled export is force-cancelled and surfaced as an error
+        // instead of hanging (Transformer.cancel does not call the listener).
+        val timeout = Runnable {
+            if (!halfDone.compareAndSet(false, true)) return@Runnable
+            pollStop.set(true)
+            Log.e(TAG, "Split half timed out after ${EXPORT_TIMEOUT_MS}ms")
+            try {
+                transformer.cancel()
+            } catch (_: Exception) {
+            }
+            outputFile.delete()
+            onHalfError(
+                IllegalStateException("Split export timed out after ${EXPORT_TIMEOUT_MS}ms")
+            )
+        }
+        timeoutRef.set(timeout)
+        mainHandler.postDelayed(timeout, EXPORT_TIMEOUT_MS)
+
+        try {
+            transformer.start(editedMediaItem, outputPath)
+        } catch (e: Exception) {
+            if (halfDone.compareAndSet(false, true)) {
+                pollStop.set(true)
+                timeoutRef.getAndSet(null)?.let { mainHandler.removeCallbacks(it) }
+                outputFile.delete()
+                onHalfError(e)
+            }
+            return
+        }
+
+        // Progress polling.
+        val progressHolder = ProgressHolder()
+        mainHandler.post(object : Runnable {
+            override fun run() {
+                if (pollStop.get() || halfDone.get()) return
+                transformer.getProgress(progressHolder)
+                if (progressHolder.progress >= 0) {
+                    onProgress(progressHolder.progress / 100.0)
+                }
+                mainHandler.postDelayed(this, POLL_INTERVAL_MS)
+            }
+        })
+    }
+}

--- a/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/ProVideoEditorPlugin.swift
@@ -154,6 +154,9 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
     case "renderStopMotion":
       handleRenderStopMotion(call: call, result: result)
 
+    case "splitVideo":
+      handleSplitVideo(call: call, result: result)
+
     case "extractAudio":
       handleExtractAudio(call: call, result: result)
 
@@ -419,6 +422,90 @@ public class ProVideoEditorPlugin: NSObject, FlutterPlugin {
         DispatchQueue.main.async {
           let task = self.activeRenderTasks.removeValue(forKey: id)
           let code = (task?.isCanceled == true) ? "CANCELED" : "RENDER_ERROR"
+          let flutterError = FlutterError(
+            code: code,
+            message: error.localizedDescription,
+            details: nil
+          )
+          if let task = task {
+            task.sendError(flutterError)
+          } else {
+            self.deliverResult(result, flutterError)
+          }
+        }
+      }
+    )
+
+    task.attachHandle(handle)
+  }
+
+  /// Splits a single video into two files at a frame-accurate position.
+  ///
+  /// Re-encodes each half from the exact split frame (no compositor/effects).
+  /// Tracked by unique ID via the same render-task map so `cancelTask` works
+  /// unchanged. Returns the two output paths on success.
+  private func handleSplitVideo(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard let args = call.arguments as? [String: Any],
+      let id = args["id"] as? String,
+      let inputPath = args["inputPath"] as? String,
+      let startOutputPath = args["startOutputPath"] as? String,
+      let endOutputPath = args["endOutputPath"] as? String,
+      let splitUs = (args["splitUs"] as? NSNumber)?.int64Value
+    else {
+      result(
+        FlutterError(code: "INVALID_ARGUMENTS", message: "Missing parameters", details: nil))
+      return
+    }
+
+    guard !id.isEmpty else {
+      result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing task id", details: nil))
+      return
+    }
+
+    if activeRenderTasks[id] != nil {
+      result(
+        FlutterError(
+          code: "TASK_ALREADY_RUNNING", message: "Task with id \(id) is already running",
+          details: nil))
+      return
+    }
+
+    let outputFormat = (args["outputFormat"] as? String) ?? "mp4"
+    let bitrate = (args["bitrate"] as? NSNumber)?.intValue
+    let enableAudio = (args["enableAudio"] as? Bool) ?? true
+
+    postProgress(id: id, progress: 0.0)
+
+    let task = RenderTask(result: result)
+    activeRenderTasks[id] = task
+
+    let handle = SplitVideo.split(
+      inputPath: inputPath,
+      splitUs: splitUs,
+      startOutputPath: startOutputPath,
+      endOutputPath: endOutputPath,
+      outputFormat: outputFormat,
+      bitrate: bitrate,
+      enableAudio: enableAudio,
+      onProgress: { progress in
+        self.postProgress(id: id, progress: progress)
+      },
+      onComplete: { outputPaths in
+        DispatchQueue.main.async {
+          self.postProgress(id: id, progress: 1.0)
+          if let task = self.activeRenderTasks.removeValue(forKey: id) {
+            task.sendSuccess(outputPaths)
+          } else {
+            self.deliverResult(result, outputPaths)
+          }
+        }
+      },
+      onError: { error in
+        PluginLog.print("❌ Split failed: \(error.localizedDescription)")
+        DispatchQueue.main.async {
+          let task = self.activeRenderTasks.removeValue(forKey: id)
+          let code = (task?.isCanceled == true || error is CancellationError)
+            ? "CANCELED" : "SPLIT_ERROR"
           let flutterError = FlutterError(
             code: code,
             message: error.localizedDescription,

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/split/SplitVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/split/SplitVideo.swift
@@ -1,0 +1,266 @@
+import AVFoundation
+import Foundation
+
+/// Service for frame-accurate splitting of a single video into two files.
+///
+/// Unlike a passthrough (stream-copy) split — which can only cut on keyframe
+/// boundaries — this re-encodes each half from the exact split frame, so the
+/// cut is frame-accurate. It deliberately does **not** use the rendering
+/// compositor or any effects pipeline; it is just two trimmed
+/// `AVAssetExportSession` re-encodes, which keeps it fast and predictable.
+///
+/// The two halves are exported sequentially so only one decoder/encoder is
+/// active at a time, and every export is guarded by a watchdog
+/// (``exportTimeout``) that force-cancels a stalled session. The job therefore
+/// always terminates — success, failure, cancellation or timeout — and never
+/// leaves the method-channel result pending forever.
+class SplitVideo {
+  static let queue = DispatchQueue(label: "SplitVideoQueue")
+
+  /// Maximum time a single half may export before it is force-cancelled and
+  /// reported as a failure. Prevents a stalled `AVAssetExportSession` from
+  /// hanging the method-channel result indefinitely.
+  static let exportTimeout: TimeInterval = 120
+
+  /// Starts an asynchronous frame-accurate split job.
+  ///
+  /// Writes `0 → splitUs` to `startOutputPath` and `splitUs → end` to
+  /// `endOutputPath`, then reports the two paths via `onComplete`.
+  @discardableResult
+  static func split(
+    inputPath: String,
+    splitUs: Int64,
+    startOutputPath: String,
+    endOutputPath: String,
+    outputFormat: String,
+    bitrate: Int?,
+    enableAudio: Bool,
+    onProgress: @escaping (Double) -> Void,
+    onComplete: @escaping ([String]) -> Void,
+    onError: @escaping (Error) -> Void
+  ) -> RenderJobHandle {
+    let handle = RenderJobHandle()
+    queue.async {
+      let task = Task {
+        do {
+          guard FileManager.default.fileExists(atPath: inputPath) else {
+            throw NSError(
+              domain: "SplitVideo", code: 404,
+              userInfo: [NSLocalizedDescriptionKey: "Input file not found: \(inputPath)"])
+          }
+
+          let asset = AVURLAsset(url: URL(fileURLWithPath: inputPath))
+          let duration = try await loadDuration(of: asset)
+          let splitTime = CMTime(value: splitUs, timescale: 1_000_000)
+
+          guard splitTime > .zero, splitTime < duration else {
+            throw NSError(
+              domain: "SplitVideo", code: 1,
+              userInfo: [
+                NSLocalizedDescriptionKey:
+                  "Split position \(splitUs)us is outside the video duration"
+              ])
+          }
+
+          let preset = applyBitrate(requestedBitrate: bitrate)
+          let fileType = mapFormatToMimeType(format: outputFormat)
+
+          // Source for export: the original asset keeps audio + orientation;
+          // for a silent split we re-wrap into a video-only composition.
+          let exportAsset: AVAsset =
+            enableAudio ? asset : try await videoOnlyAsset(from: asset, duration: duration)
+
+          PluginLog.print(
+            "✂️ Splitting at \(String(format: "%.3f", CMTimeGetSeconds(splitTime)))s "
+              + "(\(outputFormat), preset \(preset), audio: \(enableAudio))")
+
+          // First half: 0 → split.
+          try await exportSegment(
+            asset: exportAsset,
+            timeRange: CMTimeRange(start: .zero, duration: splitTime),
+            outputPath: startOutputPath,
+            fileType: fileType,
+            preset: preset,
+            handle: handle,
+            onProgress: { onProgress($0 * 0.5) })
+
+          try Task.checkCancellation()
+
+          // Second half: split → end.
+          try await exportSegment(
+            asset: exportAsset,
+            timeRange: CMTimeRange(
+              start: splitTime, duration: CMTimeSubtract(duration, splitTime)),
+            outputPath: endOutputPath,
+            fileType: fileType,
+            preset: preset,
+            handle: handle,
+            onProgress: { onProgress(0.5 + $0 * 0.5) })
+
+          onComplete([startOutputPath, endOutputPath])
+        } catch {
+          onError(error)
+        }
+      }
+      handle.attach(task: task)
+    }
+    return handle
+  }
+
+  // MARK: - Helpers
+
+  /// Re-encodes a single time range of `asset` to `outputPath`, frame-accurate
+  /// at the range start, guarded by ``exportTimeout``.
+  private static func exportSegment(
+    asset: AVAsset,
+    timeRange: CMTimeRange,
+    outputPath: String,
+    fileType: AVFileType,
+    preset: String,
+    handle: RenderJobHandle,
+    onProgress: @escaping (Double) -> Void
+  ) async throws {
+    let outputURL = URL(fileURLWithPath: outputPath)
+    try? FileManager.default.createDirectory(
+      at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    // AVAssetExportSession refuses to overwrite an existing file.
+    try? FileManager.default.removeItem(at: outputURL)
+
+    guard let export = AVAssetExportSession(asset: asset, presetName: preset) else {
+      throw NSError(
+        domain: "SplitVideo", code: 3,
+        userInfo: [NSLocalizedDescriptionKey: "Export session creation failed"])
+    }
+
+    export.outputURL = outputURL
+    export.outputFileType = fileType
+    // A re-encoding preset honours `timeRange` sample-accurately (decodes from
+    // the preceding keyframe and re-encodes from the exact start), which is what
+    // makes the cut frame-accurate. Passthrough would snap to a keyframe.
+    export.timeRange = timeRange
+    export.shouldOptimizeForNetworkUse = true
+
+    handle.attach(export: export)
+
+    try await runExportWithTimeout(export, onProgress: onProgress)
+  }
+
+  /// Runs the export and races it against the watchdog timeout. On timeout the
+  /// session is cancelled and a timeout error is thrown.
+  private static func runExportWithTimeout(
+    _ export: AVAssetExportSession,
+    onProgress: @escaping (Double) -> Void
+  ) async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try await runExport(export, onProgress: onProgress)
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(exportTimeout * 1_000_000_000))
+        export.cancelExport()
+        throw NSError(
+          domain: "SplitVideo", code: 408,
+          userInfo: [
+            NSLocalizedDescriptionKey:
+              "Split export timed out after \(Int(exportTimeout))s"
+          ])
+      }
+      // Surface whichever finishes first (success, error or timeout), then
+      // cancel the loser.
+      try await group.next()
+      group.cancelAll()
+    }
+  }
+
+  /// Drives the export to completion, reporting fractional progress.
+  private static func runExport(
+    _ export: AVAssetExportSession,
+    onProgress: @escaping (Double) -> Void
+  ) async throws {
+    let updateInterval: TimeInterval = 0.2
+    if #available(iOS 18.0, macOS 15.0, *) {
+      let progressTask = Task {
+        for try await state in export.states(updateInterval: updateInterval) {
+          if case .exporting(let progress) = state {
+            onProgress(progress.fractionCompleted)
+          }
+        }
+      }
+      try await export.export(to: export.outputURL!, as: export.outputFileType!)
+      try await progressTask.value
+    } else {
+      let intervalNs = UInt64(updateInterval * 1_000_000_000)
+      export.exportAsynchronously {}
+      while export.status == .waiting || export.status == .exporting {
+        if export.status == .exporting {
+          onProgress(Double(min(max(export.progress, 0), 1.0)))
+        }
+        try await Task.sleep(nanoseconds: intervalNs)
+      }
+      guard export.status == .completed else {
+        if export.status == .cancelled {
+          throw CancellationError()
+        }
+        throw export.error
+          ?? NSError(
+            domain: "SplitVideo", code: 4,
+            userInfo: [
+              NSLocalizedDescriptionKey:
+                "Export failed with status \(export.status.rawValue)"
+            ])
+      }
+    }
+  }
+
+  /// Builds a video-only composition (dropping audio) while preserving the
+  /// source orientation, used for silent splits.
+  private static func videoOnlyAsset(from asset: AVAsset, duration: CMTime) async throws
+    -> AVAsset
+  {
+    let composition = AVMutableComposition()
+    let videoTrack = try await loadVideoTrack(from: asset)
+    guard
+      let compTrack = composition.addMutableTrack(
+        withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+    else {
+      throw NSError(
+        domain: "SplitVideo", code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to create video track"])
+    }
+    try compTrack.insertTimeRange(
+      CMTimeRange(start: .zero, duration: duration), of: videoTrack, at: .zero)
+
+    if #available(iOS 15.0, macOS 13.0, *) {
+      compTrack.preferredTransform = try await videoTrack.load(.preferredTransform)
+    } else {
+      compTrack.preferredTransform = videoTrack.preferredTransform
+    }
+    return composition
+  }
+
+  private static func loadDuration(of asset: AVAsset) async throws -> CMTime {
+    if #available(iOS 15.0, macOS 13.0, *) {
+      return try await asset.load(.duration)
+    }
+    return asset.duration
+  }
+
+  private static func loadVideoTrack(from asset: AVAsset) async throws -> AVAssetTrack {
+    if #available(iOS 15.0, macOS 13.0, *) {
+      let tracks = try await asset.loadTracks(withMediaType: .video)
+      guard let track = tracks.first else {
+        throw NSError(
+          domain: "SplitVideo", code: 5,
+          userInfo: [NSLocalizedDescriptionKey: "No video track found"])
+      }
+      return track
+    } else {
+      guard let track = asset.tracks(withMediaType: .video).first else {
+        throw NSError(
+          domain: "SplitVideo", code: 5,
+          userInfo: [NSLocalizedDescriptionKey: "No video track found"])
+      }
+      return track
+    }
+  }
+}

--- a/example/integration_test/split_video_test.dart
+++ b/example/integration_test/split_video_test.dart
@@ -49,7 +49,8 @@ void main() {
     expect(
       diff <= tolerance,
       isTrue,
-      reason: '$reason (actual: ${actual.inMilliseconds}ms, '
+      reason:
+          '$reason (actual: ${actual.inMilliseconds}ms, '
           'expected: ${expected.inMilliseconds}ms, '
           'diff: ${diff.inMilliseconds}ms)',
     );
@@ -209,8 +210,10 @@ void main() {
     );
 
     final future = pve.splitVideo(model);
-    final captured =
-        future.then<Object?>((_) => null, onError: (Object e) => e);
+    final captured = future.then<Object?>(
+      (_) => null,
+      onError: (Object e) => e,
+    );
 
     await Future<void>.delayed(const Duration(milliseconds: 50));
 

--- a/example/integration_test/split_video_test.dart
+++ b/example/integration_test/split_video_test.dart
@@ -1,0 +1,233 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor_example/core/constants/example_constants.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final pve = ProVideoEditor.instance;
+  final source = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+  final isWindows = defaultTargetPlatform == TargetPlatform.windows;
+  final isLinux = defaultTargetPlatform == TargetPlatform.linux;
+
+  /// Splitting is implemented on Android, iOS, and macOS only.
+  final skipPlatform = kIsWeb || isWindows || isLinux;
+
+  /// Re-encoding adds/drops at most a frame at the boundary, so allow a small
+  /// duration tolerance when asserting the cut.
+  const tolerance = Duration(milliseconds: 250);
+
+  bool hasAudio(VideoMetadata meta) =>
+      meta.audioDuration != null && meta.audioDuration != Duration.zero;
+
+  Future<String> tempPath(String suffix) async {
+    final dir = await getTemporaryDirectory();
+    final stamp = DateTime.now().microsecondsSinceEpoch;
+    return '${dir.path}/split_${stamp}_$suffix.mp4';
+  }
+
+  Future<void> cleanUp(List<String> paths) async {
+    for (final path in paths) {
+      final file = File(path);
+      if (await file.exists()) await file.delete();
+    }
+  }
+
+  void expectClose(
+    Duration actual,
+    Duration expected, {
+    required String reason,
+  }) {
+    final diff = (actual - expected).abs();
+    expect(
+      diff <= tolerance,
+      isTrue,
+      reason: '$reason (actual: ${actual.inMilliseconds}ms, '
+          'expected: ${expected.inMilliseconds}ms, '
+          'diff: ${diff.inMilliseconds}ms)',
+    );
+  }
+
+  testWidgets('splits a video into two files at the midpoint', (tester) async {
+    final meta = await pve.getMetadata(source);
+    final splitPos = meta.duration ~/ 2;
+
+    final startPath = await tempPath('start');
+    final endPath = await tempPath('end');
+
+    final paths = await pve.splitVideo(
+      SplitVideoModel(
+        video: source,
+        splitPosition: splitPos,
+        startOutputPath: startPath,
+        endOutputPath: endPath,
+      ),
+    );
+
+    expect(paths, [startPath, endPath]);
+    expect(await File(startPath).exists(), isTrue);
+    expect(await File(endPath).exists(), isTrue);
+
+    final startMeta = await pve.getMetadata(EditorVideo.file(startPath));
+    final endMeta = await pve.getMetadata(EditorVideo.file(endPath));
+
+    expectClose(
+      startMeta.duration,
+      splitPos,
+      reason: 'start half should end at the split position',
+    );
+    expectClose(
+      endMeta.duration,
+      meta.duration - splitPos,
+      reason: 'end half should cover the remainder',
+    );
+    expectClose(
+      startMeta.duration + endMeta.duration,
+      meta.duration,
+      reason: 'both halves together should match the source duration',
+    );
+
+    await cleanUp([startPath, endPath]);
+  }, skip: skipPlatform);
+
+  testWidgets('keeps audio in both halves by default', (tester) async {
+    final meta = await pve.getMetadata(source);
+    if (!hasAudio(meta)) return; // source must have audio for this assertion
+
+    final startPath = await tempPath('audio_start');
+    final endPath = await tempPath('audio_end');
+
+    await pve.splitVideo(
+      SplitVideoModel(
+        video: source,
+        splitPosition: meta.duration ~/ 2,
+        startOutputPath: startPath,
+        endOutputPath: endPath,
+      ),
+    );
+
+    final startMeta = await pve.getMetadata(EditorVideo.file(startPath));
+    final endMeta = await pve.getMetadata(EditorVideo.file(endPath));
+
+    expect(hasAudio(startMeta), isTrue, reason: 'start half should keep audio');
+    expect(hasAudio(endMeta), isTrue, reason: 'end half should keep audio');
+
+    await cleanUp([startPath, endPath]);
+  }, skip: skipPlatform);
+
+  testWidgets('enableAudio:false produces silent halves', (tester) async {
+    final meta = await pve.getMetadata(source);
+
+    final startPath = await tempPath('silent_start');
+    final endPath = await tempPath('silent_end');
+
+    await pve.splitVideo(
+      SplitVideoModel(
+        video: source,
+        splitPosition: meta.duration ~/ 2,
+        startOutputPath: startPath,
+        endOutputPath: endPath,
+        enableAudio: false,
+      ),
+    );
+
+    final startMeta = await pve.getMetadata(EditorVideo.file(startPath));
+    final endMeta = await pve.getMetadata(EditorVideo.file(endPath));
+
+    expect(hasAudio(startMeta), isFalse);
+    expect(hasAudio(endMeta), isFalse);
+
+    await cleanUp([startPath, endPath]);
+  }, skip: skipPlatform);
+
+  testWidgets('reports progress from 0 to 1', (tester) async {
+    final meta = await pve.getMetadata(source);
+
+    final startPath = await tempPath('progress_start');
+    final endPath = await tempPath('progress_end');
+
+    final model = SplitVideoModel(
+      video: source,
+      splitPosition: meta.duration ~/ 2,
+      startOutputPath: startPath,
+      endOutputPath: endPath,
+    );
+
+    var maxProgress = 0.0;
+    final sub = model.progressStream.listen((p) {
+      maxProgress = p.progress > maxProgress ? p.progress : maxProgress;
+    });
+
+    await pve.splitVideo(model);
+    await sub.cancel();
+
+    expect(maxProgress, greaterThan(0.0));
+
+    await cleanUp([startPath, endPath]);
+  }, skip: skipPlatform);
+
+  testWidgets('throws when the split position is out of range', (tester) async {
+    final meta = await pve.getMetadata(source);
+
+    final startPath = await tempPath('oob_start');
+    final endPath = await tempPath('oob_end');
+
+    await expectLater(
+      pve.splitVideo(
+        SplitVideoModel(
+          video: source,
+          // Far beyond the end of the clip.
+          splitPosition: meta.duration * 2,
+          startOutputPath: startPath,
+          endOutputPath: endPath,
+        ),
+      ),
+      throwsA(isA<PlatformException>()),
+    );
+
+    await cleanUp([startPath, endPath]);
+  }, skip: skipPlatform);
+
+  testWidgets('can be cancelled mid-split', (tester) async {
+    final meta = await pve.getMetadata(source);
+
+    final startPath = await tempPath('cancel_start');
+    final endPath = await tempPath('cancel_end');
+
+    final model = SplitVideoModel(
+      video: source,
+      splitPosition: meta.duration ~/ 2,
+      startOutputPath: startPath,
+      endOutputPath: endPath,
+    );
+
+    final future = pve.splitVideo(model);
+    final captured =
+        future.then<Object?>((_) => null, onError: (Object e) => e);
+
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    // The split may already be done on fast machines; a missing task surfaces
+    // as a no-op (Android) or TASK_NOT_FOUND (iOS/macOS), both tolerated.
+    try {
+      await pve.cancel(model.id);
+    } on PlatformException catch (e) {
+      if (e.code != 'TASK_NOT_FOUND') rethrow;
+    }
+
+    final error = await captured;
+    if (error != null) {
+      expect(error, isA<RenderCanceledException>());
+    }
+    // else: the split finished before the cancel arrived — no error expected.
+
+    await cleanUp([startPath, endPath]);
+  }, skip: skipPlatform);
+}

--- a/example/lib/features/split/split_example_page.dart
+++ b/example/lib/features/split/split_example_page.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '/core/constants/example_constants.dart';
+
+/// A sample page demonstrating the frame-accurate [ProVideoEditor.splitVideo]
+/// API: it cuts the demo video in half and shows the two resulting files.
+class SplitExamplePage extends StatefulWidget {
+  /// Creates a [SplitExamplePage] widget.
+  const SplitExamplePage({super.key});
+
+  @override
+  State<SplitExamplePage> createState() => _SplitExamplePageState();
+}
+
+class _SplitExamplePageState extends State<SplitExamplePage> {
+  final _pve = ProVideoEditor.instance;
+
+  bool _isSplitting = false;
+  double _progress = 0;
+  String? _error;
+  _SplitResult? _result;
+  StreamSubscription<ProgressModel>? _progressSub;
+
+  @override
+  void dispose() {
+    _progressSub?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _split() async {
+    setState(() {
+      _isSplitting = true;
+      _progress = 0;
+      _error = null;
+      _result = null;
+    });
+
+    final source = EditorVideo.asset(kVideoEditorExampleH264Path);
+
+    try {
+      final meta = await _pve.getMetadata(source);
+      final dir = await getTemporaryDirectory();
+      final stamp = DateTime.now().millisecondsSinceEpoch;
+
+      final model = SplitVideoModel(
+        video: source,
+        // Cut exactly in the middle.
+        splitPosition: meta.duration ~/ 2,
+        startOutputPath: '${dir.path}/split_${stamp}_start.mp4',
+        endOutputPath: '${dir.path}/split_${stamp}_end.mp4',
+      );
+
+      await _progressSub?.cancel();
+      _progressSub = model.progressStream.listen((p) {
+        if (mounted) setState(() => _progress = p.progress);
+      });
+
+      final paths = await _pve.splitVideo(model);
+
+      // Read back both halves to confirm the cut.
+      final startMeta = await _pve.getMetadata(EditorVideo.file(paths[0]));
+      final endMeta = await _pve.getMetadata(EditorVideo.file(paths[1]));
+
+      if (!mounted) return;
+      setState(() {
+        _result = _SplitResult(
+          sourceDuration: meta.duration,
+          startPath: paths[0],
+          startDuration: startMeta.duration,
+          endPath: paths[1],
+          endDuration: endMeta.duration,
+        );
+      });
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      await _progressSub?.cancel();
+      _progressSub = null;
+      if (mounted) setState(() => _isSplitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Split')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'Frame-accurate split of the demo video at its midpoint into two '
+            'separate files.',
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: _isSplitting ? null : _split,
+            icon: const Icon(Icons.content_cut),
+            label: const Text('Split demo video in half'),
+          ),
+          if (_isSplitting) ...[
+            const SizedBox(height: 24),
+            LinearProgressIndicator(value: _progress == 0 ? null : _progress),
+            const SizedBox(height: 8),
+            Text('${(_progress * 100).toStringAsFixed(0)}%'),
+          ],
+          if (_error != null) ...[
+            const SizedBox(height: 24),
+            Text(
+              _error!,
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ],
+          if (_result != null) ...[
+            const Divider(height: 32),
+            Text('Source', style: Theme.of(context).textTheme.titleMedium),
+            Text('Duration: ${_fmt(_result!.sourceDuration)}'),
+            const SizedBox(height: 16),
+            Text('Start clip', style: Theme.of(context).textTheme.titleMedium),
+            Text('Duration: ${_fmt(_result!.startDuration)}'),
+            Text(_result!.startPath, style: const TextStyle(fontSize: 11)),
+            const SizedBox(height: 16),
+            Text('End clip', style: Theme.of(context).textTheme.titleMedium),
+            Text('Duration: ${_fmt(_result!.endDuration)}'),
+            Text(_result!.endPath, style: const TextStyle(fontSize: 11)),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _fmt(Duration d) => '${(d.inMilliseconds / 1000).toStringAsFixed(2)}s';
+}
+
+class _SplitResult {
+  _SplitResult({
+    required this.sourceDuration,
+    required this.startPath,
+    required this.startDuration,
+    required this.endPath,
+    required this.endDuration,
+  });
+
+  final Duration sourceDuration;
+  final String startPath;
+  final Duration startDuration;
+  final String endPath;
+  final Duration endDuration;
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:pro_video_editor_example/features/editor/pages/video_editor_grou
 import 'features/audio/audio_extract_example_page.dart';
 import 'features/metadata/video_metadata_example_page.dart';
 import 'features/render/video_renderer_page.dart';
+import 'features/split/split_example_page.dart';
 import 'features/stop_motion/stop_motion_example_page.dart';
 import 'features/thumbnail/thumbnail_example_page.dart';
 
@@ -81,6 +82,11 @@ class _HomePageState extends State<HomePage> {
       icon: Icons.burst_mode_outlined,
       title: 'Stop-Motion',
       pageBuilder: () => const StopMotionExamplePage(),
+    ),
+    _ExampleListItem(
+      icon: Icons.content_cut,
+      title: 'Split',
+      pageBuilder: () => const SplitExamplePage(),
     ),
     _ExampleListItem(
       icon: Icons.edit,

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,83 +1,15 @@
 PODS:
-  - audioplayers_darwin (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - file_picker (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - fvp (0.36.1):
-    - Flutter
-    - FlutterMacOS
-    - mdk (~> 0.36.0)
-  - mdk (0.36.0)
-  - package_info_plus (0.0.1):
-    - FlutterMacOS
-  - pro_image_editor (12.0.8):
-    - Flutter
-    - FlutterMacOS
-  - pro_video_editor (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - video_player_avfoundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - wakelock_plus (0.0.1):
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
-  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - fvp (from `Flutter/ephemeral/.symlinks/plugins/fvp/darwin`)
-  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - pro_image_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin`)
-  - pro_video_editor (from `Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
-  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
-
-SPEC REPOS:
-  trunk:
-    - mdk
 
 EXTERNAL SOURCES:
-  audioplayers_darwin:
-    :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin
-  file_picker:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
-  fvp:
-    :path: Flutter/ephemeral/.symlinks/plugins/fvp/darwin
-  package_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  pro_image_editor:
-    :path: Flutter/ephemeral/.symlinks/plugins/pro_image_editor/darwin
-  pro_video_editor:
-    :path: Flutter/ephemeral/.symlinks/plugins/pro_video_editor/darwin
-  shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  video_player_avfoundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
-  wakelock_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
-  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
-  file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  fvp: f8b3b61cf8c696ecaa5608ae0d282ba710e65ae9
-  mdk: 3bfb53e0bcc9643180eaa864360051f281e4c17b
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  pro_image_editor: e57a76b305fd8c2e06d57f92aec82b9c6a6e8d9f
-  pro_video_editor: 71c273c0a82a72996526e2bfc5c2fbd2bb35aaaa
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
-  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
 
 PODFILE CHECKSUM: d53808ad3e260398c64f5e8ffae8c72d2669e2a5
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -247,7 +247,6 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				A6CE73A679E1E3A4B65E3E9D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -394,23 +393,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A6CE73A679E1E3A4B65E3E9D /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CFCEFF0CF31A69A06884CF83 /* [CP] Check Pods Manifest.lock */ = {

--- a/lib/core/models/video/split_video_model.dart
+++ b/lib/core/models/video/split_video_model.dart
@@ -1,0 +1,92 @@
+// ignore_for_file: sort_constructors_first
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+/// Configuration for a frame-accurate video split.
+///
+/// Cuts a single source video at [splitPosition] into two separate files
+/// ([startOutputPath] and [endOutputPath]). The cut is frame-accurate: unlike a
+/// stream-copy (passthrough) split, which can only cut on keyframe boundaries,
+/// this re-encodes from the exact split frame so both halves start and end
+/// precisely where requested.
+///
+/// This is a dedicated, lightweight operation — it does not run the full
+/// rendering pipeline (no compositor, effects, overlays or audio mixing), which
+/// makes it much faster and far less likely to stall than splitting via
+/// [VideoRenderData].
+class SplitVideoModel {
+  /// Creates a [SplitVideoModel].
+  ///
+  /// [video] is the source clip, [splitPosition] is the absolute cut position
+  /// within that source, and [startOutputPath] / [endOutputPath] are the
+  /// destinations for the two resulting files.
+  SplitVideoModel({
+    String? id,
+    required this.video,
+    required this.splitPosition,
+    required this.startOutputPath,
+    required this.endOutputPath,
+    this.outputFormat = VideoOutputFormat.mp4,
+    this.qualityConfig,
+    this.bitrate,
+    this.enableAudio = true,
+  })  : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
+        assert(
+          splitPosition > Duration.zero,
+          'splitPosition must be greater than zero',
+        ),
+        assert(
+          startOutputPath != endOutputPath,
+          'startOutputPath and endOutputPath must differ',
+        ),
+        assert(
+          bitrate == null || bitrate > 0,
+          '[bitrate] must be greater than 0',
+        );
+
+  /// Unique ID for the task, used for progress updates and cancellation.
+  final String id;
+
+  /// The source video to split.
+  final EditorVideo video;
+
+  /// The absolute position within [video] at which to cut.
+  ///
+  /// The first half covers `0 → splitPosition`, the second half covers
+  /// `splitPosition → end`.
+  final Duration splitPosition;
+
+  /// Absolute path where the first half (`0 → splitPosition`) is written.
+  final String startOutputPath;
+
+  /// Absolute path where the second half (`splitPosition → end`) is written.
+  final String endOutputPath;
+
+  /// The target container format for both output files.
+  final VideoOutputFormat outputFormat;
+
+  /// Optional quality configuration. When set, its bitrate is used unless
+  /// [bitrate] is provided explicitly.
+  final VideoQualityConfig? qualityConfig;
+
+  /// Optional bitrate in bits per second for the re-encoded output.
+  ///
+  /// **WARNING macOS/iOS:** A specific bitrate cannot be set directly; the
+  /// closest export preset is chosen instead.
+  final int? bitrate;
+
+  /// Whether to keep the source audio track in both halves.
+  ///
+  /// **Default**: `true`
+  final bool enableAudio;
+
+  /// A [Stream] of [ProgressModel] updates for this split, keyed by [id].
+  ///
+  /// Progress spans both halves: the first half maps to `0.0 → 0.5` and the
+  /// second half to `0.5 → 1.0`.
+  Stream<ProgressModel> get progressStream {
+    return ProVideoEditor.instance.progressStreamById(id);
+  }
+
+  /// The effective bitrate, falling back to [qualityConfig] when unset.
+  int? get effectiveBitrate => bitrate ?? qualityConfig?.bitrate;
+}

--- a/lib/core/platform/native_method_channel.dart
+++ b/lib/core/platform/native_method_channel.dart
@@ -18,6 +18,7 @@ import '/core/models/thumbnail/thumbnail_base_abstract.dart';
 import '/core/models/thumbnail/thumbnail_configs_model.dart';
 import '/core/models/video/editor_video_model.dart';
 import '/core/models/video/progress_model.dart';
+import '/core/models/video/split_video_model.dart';
 import '/core/models/video/video_metadata_model.dart';
 import '/core/platform/io/io_helper.dart';
 import '../models/video/stop_motion_render_data_model.dart';
@@ -540,6 +541,43 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
     } on PlatformException catch (error) {
       if (error.code == renderCanceledErrorCode) {
         throw const RenderCanceledException();
+      }
+      rethrow;
+    } finally {
+      _endDispatch(value.id);
+    }
+  }
+
+  @override
+  Future<List<String>> splitVideo(
+    SplitVideoModel value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    _beginDispatch(value.id);
+    try {
+      final inputPath = await value.video.safeFilePath();
+      _handoffToNative(value.id);
+
+      await methodChannel.invokeMethod<void>('splitVideo', {
+        'id': value.id,
+        'inputPath': inputPath,
+        'extension': _getFileExtension(inputPath),
+        'splitUs': value.splitPosition.inMicroseconds,
+        'startOutputPath': value.startOutputPath,
+        'endOutputPath': value.endOutputPath,
+        'outputFormat': value.outputFormat.name,
+        'bitrate': value.effectiveBitrate,
+        'enableAudio': value.enableAudio,
+        'nativeLogLevel': nativeLogLevel?.methodValue,
+      });
+
+      return [value.startOutputPath, value.endOutputPath];
+    } on PlatformException catch (error) {
+      if (error.code == renderCanceledErrorCode) {
+        throw const RenderCanceledException();
+      }
+      if (error.code == encoderNotSupportedErrorCode) {
+        throw RenderEncoderException(error.message);
       }
       rethrow;
     } finally {

--- a/lib/core/platform/platform_interface.dart
+++ b/lib/core/platform/platform_interface.dart
@@ -14,6 +14,7 @@ import '/core/models/thumbnail/single_thumbnail_configs_model.dart';
 import '/core/models/thumbnail/thumbnail_configs_model.dart';
 import '/core/models/video/editor_video_model.dart';
 import '/core/models/video/progress_model.dart';
+import '/core/models/video/split_video_model.dart';
 import '/core/models/video/video_metadata_model.dart';
 import '../models/video/stop_motion_render_data_model.dart';
 import '../models/video/video_render_data_model.dart';
@@ -604,6 +605,35 @@ abstract class ProVideoEditor extends PlatformInterface {
   /// ```
   Future<void> cancel(String taskId) {
     throw UnimplementedError('cancel() has not been implemented.');
+  }
+
+  /// Splits a single video into two files at a frame-accurate position.
+  ///
+  /// Cuts [SplitVideoModel.video] at [SplitVideoModel.splitPosition] and writes
+  /// the two halves to [SplitVideoModel.startOutputPath] and
+  /// [SplitVideoModel.endOutputPath].
+  ///
+  /// This is a dedicated, lightweight primitive: it re-encodes each half from
+  /// the exact split frame (so the cut is frame-accurate) but does **not** run
+  /// the full render pipeline (no compositor, effects, overlays or audio
+  /// mixing). That makes it considerably faster and far less likely to stall
+  /// than splitting via [renderVideoToFile].
+  ///
+  /// Returns the two output paths as `[startOutputPath, endOutputPath]`.
+  ///
+  /// Throws:
+  /// - [RenderCanceledException] if cancelled via [cancel]
+  /// - [ArgumentError] if the configuration is invalid
+  /// - [PlatformException] if splitting fails (including a timeout)
+  ///
+  /// Progress updates are emitted via [progressStreamById] using
+  /// [SplitVideoModel.id]; the first half maps to `0.0 → 0.5` and the second to
+  /// `0.5 → 1.0`.
+  Future<List<String>> splitVideo(
+    SplitVideoModel value, {
+    NativeLogLevel? nativeLogLevel,
+  }) {
+    throw UnimplementedError('splitVideo() has not been implemented.');
   }
 
   /// Stream of progress updates from native video tasks.

--- a/lib/core/platform/web_method_channel.dart
+++ b/lib/core/platform/web_method_channel.dart
@@ -16,6 +16,7 @@ import '/core/models/thumbnail/key_frames_configs_model.dart';
 import '/core/models/thumbnail/single_thumbnail_configs_model.dart';
 import '/core/models/thumbnail/thumbnail_configs_model.dart';
 import '/core/models/video/editor_video_model.dart';
+import '/core/models/video/split_video_model.dart';
 import '/core/models/video/video_metadata_model.dart';
 import '/core/services/web/web_manager.dart';
 import '../models/video/stop_motion_render_data_model.dart';
@@ -184,6 +185,14 @@ class ProVideoEditorWeb extends ProVideoEditor {
     throw UnimplementedError(
       'renderStopMotionToFile() is not supported on web.',
     );
+  }
+
+  @override
+  Future<List<String>> splitVideo(
+    SplitVideoModel value, {
+    NativeLogLevel? nativeLogLevel,
+  }) {
+    throw UnimplementedError('splitVideo() is not supported on web.');
   }
 
   @override

--- a/lib/pro_video_editor.dart
+++ b/lib/pro_video_editor.dart
@@ -23,6 +23,7 @@ export 'core/models/video/segment_transform_model.dart';
 export 'core/models/video/video_layer_model.dart';
 export 'core/models/video/video_composition_model.dart';
 export 'core/models/video/clip_transition_model.dart';
+export 'core/models/video/split_video_model.dart';
 export 'core/models/video/stop_motion_render_data_model.dart';
 export 'core/models/video/video_metadata_model.dart';
 export 'core/models/video/video_quality_preset.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.1.3
+version: 2.2.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Summary

Adds a dedicated, frame-accurate **`ProVideoEditor.splitVideo`** that cuts a single video into two files at a given position. It re-encodes each half from the exact cut frame (so the cut is frame-accurate, unlike a keyframe-snapping passthrough) but deliberately **does not** run the render compositor/effects pipeline — making it considerably faster and far more stall-resistant than splitting via `renderVideoToFile`.

Motivated by divinevideo/divine-mobile#4801, where splitting (which currently renders both halves through the full pipeline) could hang and silently wedge further splits. The new primitive is purpose-built for the operation and can never hang.

## API

```dart
final paths = await ProVideoEditor.instance.splitVideo(
  SplitVideoModel(
    video: EditorVideo.file(sourcePath),
    splitPosition: const Duration(seconds: 3),
    startOutputPath: startPath,
    endOutputPath: endPath,
    // optional: outputFormat, qualityConfig/bitrate, enableAudio
  ),
); // -> [startOutputPath, endOutputPath]
```

- Cancellable and progress-reporting via the task `id` (`progressStreamById`); the first half maps to `0.0 → 0.5`, the second to `0.5 → 1.0`.
- Web/Windows/Linux throw `UnimplementedError`.

## Implementation

- **Dart**: `SplitVideoModel`, abstract `splitVideo` on the platform interface, method-channel impl, web stub, public export.
- **Darwin (Swift)**: `SplitVideo` — two sequential `AVAssetExportSession` re-encodes with an exact `timeRange` (frame-accurate), reusing `applyBitrate`/`mapFormatToMimeType`/`RenderJobHandle`. Silent splits use a video-only composition. A per-export watchdog (120s) force-cancels a stalled session and surfaces a timeout error.
- **Android (Kotlin)**: `SplitVideo` — two sequential Media3 `Transformer` exports with `ClippingConfiguration` (a non-keyframe start forces a frame-accurate transcode). Because `Transformer.cancel()` does not invoke the listener, cancellation/timeout deliver the terminal result through a single job-level guard, so the Dart future always completes.
- Both run sequentially (one decoder/encoder at a time) to minimise resource pressure.

## Example

New **Split** page (`example/lib/features/split/`) that splits the demo video at its midpoint, shows live progress, and lists both resulting clips' durations.

## Tests

`example/integration_test/split_video_test.dart` (skipped on web/windows/linux):

- midpoint split → two files; start ≈ position, end ≈ remainder, sum ≈ source (±250ms re-encode tolerance)
- audio kept in both halves by default
- `enableAudio: false` → silent halves
- progress > 0
- out-of-range position → `PlatformException`
- cancel mid-split → `RenderCanceledException` (or clean completion if it finished first)

## Verification

- `flutter analyze` (package + example + integration_test): no issues
- macOS example build: ✓
- Android APK build: ✓
- Integration test not yet executed on a device/simulator.

## Notes

- Returns only the two paths by design (no bundled thumbnail). A thumbnail needs its own decode pass regardless of the split, and keeping it separate lets the app show it from the source immediately rather than gating it on the re-encode.
- Version bumped to `2.2.0` with a CHANGELOG entry.
