### PR TITLE
fix(darwin): clip off-frame overlay to video frame before letterboxing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+- **FIX**(iOS, macOS): Fix a layer sliding in from an edge briefly shifting and shrinking the video (e.g. a black bar at the top) when a custom output resolution is set. Off-frame overlay content is now clipped to the video frame before letterboxing, so the frame no longer inflates during the animation.
+
 ## 2.2.0
 - **FEAT**(android, iOS, macOS): Add `ProVideoEditor.splitVideo` — a frame-accurate split that cuts one video into two files (`SplitVideoModel`). Each half is re-encoded from the exact cut frame without the render compositor/effects, making it far faster and more stall-resistant than splitting via `renderVideoToFile`; every export is guarded by a watchdog timeout. Cancellable and progress-reporting via the task `id`. Web/Windows/Linux throw `UnimplementedError`.
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/utils/VideoCompositor.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/utils/VideoCompositor.swift
@@ -653,6 +653,11 @@ class VideoCompositor: NSObject, AVVideoCompositing {
             rotated, over: outputImage, opacity: opacity, transform: animTransform)
         }
       }
+
+      // Clip overlay content that animated beyond the frame back to the frame
+      // extent so a subsequent crop and the final render operate on the exact
+      // video frame, not an extent inflated by an off-frame overlay.
+      outputImage = outputImage.cropped(to: imageRect)
     }
 
     // Cropping
@@ -768,6 +773,13 @@ class VideoCompositor: NSObject, AVVideoCompositing {
             rotated, over: outputImage, opacity: opacity, transform: animTransform)
         }
       }
+
+      // Clip any overlay content that animated beyond the frame (e.g. a layer
+      // sliding in from an edge) back to the video frame, so the composed
+      // extent stays exactly the frame size. Otherwise the inflated extent
+      // shifts and shrinks the frame in `letterbox` when a custom output
+      // resolution is set — briefly showing a black bar at the frame edge.
+      outputImage = outputImage.cropped(to: imageRect)
     }
 
     // Apply dip-to-color (fade-to-black / fade-to-white) clip transitions last,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.2.0
+version: 2.2.1-dev.1
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Problem

On iOS/macOS, when an image layer slides into the video from an edge (e.g. `SlideDirection.top`), the video briefly shifts and shrinks for the few frames while the overlay is still off-screen — showing a black bar at that edge. It only reproduces when a **custom output resolution** is set (so it appears in real apps but not in the example, which uses no custom resolution).

## Cause

While the overlay is off-frame, Core Image's `composited(over:)` grows the composed image's `extent` to include the overlay above/beside the frame. `letterbox()` then reads that inflated extent and scales-to-fit it into the target canvas, so the actual video is scaled down and pushed away from the edge.

The non-letterbox path is unaffected because `context.render(_:to:)` clips to the pixel buffer at origin. Android is unaffected because Media3 renders overlays into a fixed-size framebuffer that clips off-frame content automatically.

## Fix

After compositing overlays (in both the `imageBytesWithCropping` and default paths), crop the output back to the video-frame extent (`imageRect`). This clips off-frame overlay content — matching Android behavior — and keeps the extent exactly the frame size so `letterbox()` operates on the real frame.

## Notes

- Native Swift change only — consumers must rebuild the pods (`flutter clean` + rebuild) to pick it up.
- Version bumped to `2.2.1` + changelog entry.