### PR TITLE
fix: animate open-ended layers out and smooth darwin clip transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+- **FIX**(android, iOS, macOS): Layer `animateOut` / `animateInOut` animations now play for layers that run until the end of the video (`endTime` unset). An open-ended layer's end previously resolved to "infinity", so the out-phase never triggered and the layer popped off at the last frame; it now resolves to the composition length, so the layer animates out. Only layers carrying an out-phase animation are affected.
+- **FIX**(iOS, macOS): Smoother clip transitions. The pre-rendered transition clip is now authored at the composition's frame rate (`max(30, source fps)`) instead of only the outgoing clip's, so a 25 fps source no longer stutters at the transition seams; directional `slide` / `push` transitions also use one easing ramp per output frame, removing velocity kinks with `bounce` / `elastic` curves.
+
 ## 2.2.1
 - **FIX**(iOS, macOS): Fix a layer sliding in from an edge briefly shifting and shrinking the video (e.g. a black bar at the top) when a custom output resolution is set. Off-frame overlay content is now clipped to the video frame before letterboxing, so the frame no longer inflates during the animation.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ApplyImageLayer.kt
@@ -53,6 +53,32 @@ fun applyImageLayer(
 }
 
 /**
+ * Rewrites layers that run "until the end" ([ImageLayerConfig.endUs] == -1)
+ * **and** carry an `animateOut`/`animateInOut` animation so their end resolves
+ * to [totalDurationUs], giving the out-phase a concrete point to animate toward.
+ *
+ * Without this, an open-ended layer's [AnimatedBitmapOverlay] treats its end as
+ * `Long.MAX_VALUE`, so the out-phase never triggers and the layer pops off at
+ * the last frame instead of animating out.
+ *
+ * Layers without an out-phase animation — and the whole list when
+ * [totalDurationUs] is not positive — are returned unchanged, so every untouched
+ * layer keeps its exact prior effect pipeline.
+ */
+internal fun resolveOpenEndedOutAnimations(
+    layers: List<VideoSequenceBuilder.ImageLayerConfig>,
+    totalDurationUs: Long,
+): List<VideoSequenceBuilder.ImageLayerConfig> {
+    if (totalDurationUs <= 0L) return layers
+    return layers.map { layer ->
+        val hasOutPhase = layer.endUs == -1L && layer.animations.any {
+            it.phase == "animateOut" || it.phase == "animateInOut"
+        }
+        if (hasOutPhase) layer.copy(endUs = totalDurationUs) else layer
+    }
+}
+
+/**
  * Applies time-based image overlays on video.
  *
  * Each image layer has a start and end time, and will only be visible during that time range.

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/LayeredCompositionBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/LayeredCompositionBuilder.kt
@@ -272,7 +272,14 @@ class LayeredCompositionBuilder(
         // Composition-level video effects: global color/blur first, then image
         // overlays on top, then the canvas presentation last.
         val compositionEffects = globalVideoEffects.toMutableList()
-        applyTimedImageLayers(compositionEffects, imageLayers, canvasW, canvasH)
+        // Resolve "until end" layers with an out-phase animation to the full
+        // composition length so their animateOut can play (the composition has a
+        // single global timeline, so this is unambiguous here).
+        applyTimedImageLayers(
+            compositionEffects,
+            resolveOpenEndedOutAnimations(imageLayers, globalDurationUs),
+            canvasW, canvasH
+        )
         compositionEffects += Presentation.createForWidthAndHeight(
             canvasW, canvasH, Presentation.LAYOUT_SCALE_TO_FIT
         )

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -301,6 +301,16 @@ class VideoSequenceBuilder(
         val timelineClips = expandReversedClips(trimmedClips)
         Log.d(RENDER_TAG, "After reverse expansion: ${timelineClips.size} timeline clips")
 
+        // Resolve layers that run "until the end" (endUs == -1) with an out-phase
+        // animation to a concrete end so their animateOut can play. Only for a
+        // single-clip sequence, where "until end" == that clip's output duration
+        // is unambiguous; multi-clip sequences keep their prior behavior.
+        if (timelineClips.size == 1) {
+            timedImageLayers = resolveOpenEndedOutAnimations(
+                timedImageLayers, clipOutputDurationUs(timelineClips[0])
+            )
+        }
+
         // Prepare normalized audio effects with channel mixing if needed
         val normalizedAudioEffects = if (needsAudioNormalization) {
             Log.d(RENDER_TAG, "Adding ChannelMixingAudioProcessor to normalize audio to stereo")

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
@@ -239,10 +239,15 @@ class RenderVideo {
             config: &effectsConfig,
             filters: workingConfig.colorFilters)
           applyBlur(config: &effectsConfig, sigma: workingConfig.blur)
+          // Total composition length, so layers that run "until the end"
+          // (endUs == -1) with an out-phase animation get a concrete end to
+          // animate toward instead of popping off at the last frame.
+          let compositionTotalUs = Int64(CMTimeGetSeconds(composition.duration) * 1_000_000)
           applyImageLayer(
             config: &effectsConfig,
             imageLayers: workingConfig.imageLayers,
-            withCropping: workingConfig.imageBytesWithCropping)
+            withCropping: workingConfig.imageBytesWithCropping,
+            totalDurationUs: compositionTotalUs)
 
           var finalRenderSize = videoCompConfig.renderSize
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ApplyImageLayer.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ApplyImageLayer.swift
@@ -20,13 +20,46 @@ import Foundation
 public func applyImageLayer(
   config: inout VideoCompositorConfig,
   imageLayers: [ImageLayerConfig],
-  withCropping: Bool = false
+  withCropping: Bool = false,
+  totalDurationUs: Int64 = 0
 ) {
-  config.imageLayerConfigs = imageLayers
+  let resolved = resolveOpenEndedOutAnimations(imageLayers, totalDurationUs: totalDurationUs)
+  config.imageLayerConfigs = resolved
   config.imageBytesWithCropping = withCropping
 
-  if !imageLayers.isEmpty {
+  if !resolved.isEmpty {
     PluginLog.print(
-      "[\(Tags.render)] 🖼️ Applying \(imageLayers.count) image layer(s) with timing")
+      "[\(Tags.render)] 🖼️ Applying \(resolved.count) image layer(s) with timing")
+  }
+}
+
+/// Rewrites layers that run "until the end" (`endUs == -1`) **and** carry an
+/// `animateOut`/`animateInOut` animation so their end resolves to
+/// `totalDurationUs`, giving the out-phase a concrete point to animate toward.
+///
+/// Without this the compositor treats an open-ended layer's end as `Int64.max`,
+/// so the out-phase never triggers and the layer pops off at the last frame
+/// instead of animating out. Layers without an out-phase animation — and the
+/// whole list when `totalDurationUs <= 0` — are returned unchanged, so every
+/// untouched layer keeps its exact prior behavior.
+func resolveOpenEndedOutAnimations(
+  _ layers: [ImageLayerConfig], totalDurationUs: Int64
+) -> [ImageLayerConfig] {
+  guard totalDurationUs > 0 else { return layers }
+  return layers.map { layer in
+    let hasOutPhase =
+      layer.endUs == -1
+      && layer.animations.contains {
+        $0.phase == "animateOut" || $0.phase == "animateInOut"
+      }
+    guard hasOutPhase else { return layer }
+    return ImageLayerConfig(
+      imageData: layer.imageData,
+      startUs: layer.startUs,
+      endUs: totalDurationUs,
+      x: layer.x, y: layer.y,
+      width: layer.width, height: layer.height,
+      rotation: layer.rotation, loop: layer.loop,
+      animations: layer.animations)
   }
 }

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ClipTransitionRenderer.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ClipTransitionRenderer.swift
@@ -24,9 +24,23 @@ import Foundation
 /// caller can fall back to a hard cut.
 internal enum ClipTransitionRenderer {
 
-  /// Number of piecewise steps used to approximate an easing curve in the
-  /// linear AVFoundation ramps.
-  private static let easingSteps = 30
+  /// Lower bound on the piecewise steps used to approximate an easing curve in
+  /// the linear AVFoundation ramps.
+  private static let minEasingSteps = 30
+
+  /// Upper bound on easing steps, to cap the instruction count on long/high-fps
+  /// transitions.
+  private static let maxEasingSteps = 240
+
+  /// Piecewise easing-step count for a transition of `durationUs` sampled at
+  /// `fps`: roughly one linear segment per output frame, clamped to
+  /// `[minEasingSteps, maxEasingSteps]`. With one segment per frame the linear
+  /// ramps track the easing curve closely, so `slide`/`push` no longer show
+  /// velocity kinks between the old fixed 30 segments.
+  private static func easingStepCount(durationUs: Int64, fps: Int) -> Int {
+    let frames = Int((Double(durationUs) / 1_000_000.0 * Double(fps)).rounded())
+    return min(maxEasingSteps, max(minEasingSteps, frames))
+  }
 
   struct RenderResult {
     let outputURL: URL
@@ -99,6 +113,16 @@ internal enum ClipTransitionRenderer {
       let displayA = naturalA.applying(transformA)
       let renderSize = CGSize(width: abs(displayA.width), height: abs(displayA.height))
 
+      // Author the transition at the same cadence the main composition uses
+      // (max(30, source fps); see LayeredCompositionBuilder). Deriving it from
+      // only the outgoing clip's fps left the pre-rendered transition below the
+      // composition's frame rate (e.g. 25 vs 30 fps), so it was re-timed on
+      // insertion and stuttered at the two seams.
+      let outFps = try await loadFrameRate(outVideo)
+      let inFps = try await loadFrameRate(inVideo)
+      let targetFps = max(30, Int(max(outFps, inFps).rounded()))
+      let steps = easingStepCount(durationUs: dUs, fps: targetFps)
+
       // Optional cross-faded audio.
       var audioMix: AVMutableAudioMix?
       if includeAudio {
@@ -119,7 +143,7 @@ internal enum ClipTransitionRenderer {
         type: type, direction: direction, curve: curve,
         layerA: layerA, layerB: layerB,
         transformA: transformA, transformB: transformB,
-        renderSize: renderSize, naturalB: naturalB, duration: d)
+        renderSize: renderSize, naturalB: naturalB, duration: d, steps: steps)
 
       let instruction = AVMutableVideoCompositionInstruction()
       instruction.timeRange = CMTimeRange(start: .zero, duration: d)
@@ -129,9 +153,7 @@ internal enum ClipTransitionRenderer {
 
       let videoComposition = AVMutableVideoComposition()
       videoComposition.renderSize = renderSize
-      let fps = try await loadFrameRate(outVideo)
-      videoComposition.frameDuration = CMTime(
-        value: 1, timescale: CMTimeScale(max(1, Int(fps.rounded()))))
+      videoComposition.frameDuration = CMTime(value: 1, timescale: CMTimeScale(targetFps))
       videoComposition.instructions = [instruction]
 
       // Export.
@@ -182,9 +204,8 @@ internal enum ClipTransitionRenderer {
     layerA: AVMutableVideoCompositionLayerInstruction,
     layerB: AVMutableVideoCompositionLayerInstruction,
     transformA: CGAffineTransform, transformB: CGAffineTransform,
-    renderSize: CGSize, naturalB: CGSize, duration d: CMTime
+    renderSize: CGSize, naturalB: CGSize, duration d: CMTime, steps: Int
   ) {
-    let steps = easingSteps
     for k in 0..<steps {
       let f0 = Double(k) / Double(steps)
       let f1 = Double(k + 1) / Double(steps)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.2.1
+version: 2.2.2
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Summary
Two rendering fixes for layer animations and clip transitions (bumps to 2.2.2).

### 1. `animateOut` for open-ended layers — android, iOS, macOS
A layer that runs "until the end of the video" (`endTime` unset) never played its `animateOut` / `animateInOut` phase: the open-ended end resolved to "infinity", so the out-phase condition never triggered and the layer popped off at the last frame. Its end now resolves to the composition length so the layer animates out.

- Only layers **with an out-phase animation** are rewritten; every other layer keeps its exact prior effect pipeline.
- Android: layered path via the composition duration; single-clip path only when the sequence has exactly one clip (where "until end" is unambiguous).
- Darwin: resolved via the built composition's duration (the compositor works in composition-global time, covering both the layered and single-track paths).

### 2. Smoother clip transitions — iOS, macOS
- The pre-rendered transition clip is authored at the composition's frame rate (`max(30, source fps)`) instead of only the outgoing clip's fps. A 25 fps source was previously written at 25 fps and re-timed into the 30 fps composition, stuttering at the two seams.
- Directional `slide` / `push` transitions now use one easing ramp segment per output frame instead of a fixed 30, removing velocity kinks with `bounce` / `elastic` curves.

## Verification
- **Android:** plugin unit tests pass; the `animateOut`-until-end case was pixel-verified on a real device — the overlay fades from opaque (R255) through R176 → R110 across the last second, while a control point outside the overlay is unchanged. A frame-timing measurement also confirmed the Android transition output is a constant 25 fps with no seam break, so no Android transition-fps change was needed.
- **Darwin:** compiles via `flutter build macos --debug` against the real FlutterMacOS framework. Not yet runtime-verified on iOS/macOS (no simulator available in this environment); the code path mirrors the device-verified Android behavior.

## Not included
Deliberately left out the higher-risk Android smoothness rewrites (sub-pixel transition blend, slide-anchor clamping) — those need a before/after comparison and their own PR.