### PR TITLE
fix: smooth stop-motion render progress instead of 0→100 jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.4
+- **FIX**(android, iOS, macOS): Stop-motion render progress now advances smoothly instead of sitting near 0% and snapping to 100% at the end. Media3's image-to-video export reports no intra-export progress on Android, so the encode phase is now driven by a smooth, monotonic time-based estimate (using the real value when available); Darwin reports 100% only after the writer finishes so the finalize step stays visible.
+
 ## 2.2.3
 - **PERF**(android): Timestamp thumbnails (`getThumbnails`) are now extracted with up to three parallel hardware decoders that each decode forward through a contiguous timeline chunk (every GOP decoded at most once), with frames GPU-scaled straight to the thumbnail size — instead of one software `MediaMetadataRetriever` per timestamp. Measured on a Galaxy S26: 20 timeline thumbnails from a 720p H.264 video 2.8s → 0.64s (~4x), 10 from a 1080p 10-bit HEVC video 6.2s → 0.3s (~20x), 14 from a 6s 4K60 HEVC clip 3.6s → 1.3s (~3x), with roughly 3-4x less CPU overall. Extraction keeps its speed while the UI is actively rendering (batch-mode decoder hints, non-blocking pump at display priority). Frame positions are unchanged (still the closest frame) and HDR10/rotation are handled by the GPU. Falls back to Media3 `FrameExtractor`, then to the previous retriever path when a video can't be decoded in hardware.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/stopmotion/StopMotionGenerator.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/stopmotion/StopMotionGenerator.kt
@@ -9,6 +9,7 @@ import android.media.ExifInterface
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import androidx.media3.common.C
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
@@ -33,6 +34,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.exp
 import kotlin.math.roundToInt
 
 /**
@@ -249,18 +251,48 @@ class StopMotionGenerator(private val context: Context) {
 
         transformer.start(composition, outputFile.absolutePath)
 
+        // Media3's image-to-video export usually can't report intra-export
+        // progress (getProgress returns PROGRESS_STATE_UNAVAILABLE for image
+        // input), and the previous loop also stopped polling on the initial
+        // PROGRESS_STATE_NOT_STARTED. Together that froze the bar for the whole
+        // encode and then snapped it to 100% via onCompleted.
+        //
+        // Drive a smooth, monotonic time-based estimate that eases toward — but
+        // never reaches — 100% while polling, and prefer the real Media3 value
+        // whenever it becomes available. Completion (1.0) is owned by the
+        // listener's onCompleted.
         val progressHolder = ProgressHolder()
+        val encodeStartMs = SystemClock.elapsedRealtime()
+        // More frames → longer expected encode → slower easing, so the estimate
+        // stays roughly in step with the real work instead of racing ahead.
+        val easingTauMs = (config.frames.size * 50L).coerceIn(1_500L, 20_000L)
         mainHandler.post(object : Runnable {
+            private var lastReported = 0.0
+
             override fun run() {
                 if (shouldStopPolling.get()) return
+
                 val state = transformer.getProgress(progressHolder)
-                if (progressHolder.progress >= 0) {
-                    onProgress(progressHolder.progress / 100.0)
-                }
-                if (!shouldStopPolling.get() &&
-                    state != Transformer.PROGRESS_STATE_NOT_STARTED
-                ) {
-                    mainHandler.postDelayed(this, 200)
+                val realProgress =
+                    if (state == Transformer.PROGRESS_STATE_AVAILABLE &&
+                        progressHolder.progress >= 0
+                    ) {
+                        progressHolder.progress / 100.0
+                    } else {
+                        null
+                    }
+
+                val elapsedMs = (SystemClock.elapsedRealtime() - encodeStartMs).toDouble()
+                val estimated = 1.0 - exp(-elapsedMs / easingTauMs)
+
+                // Never regress and never claim completion — onCompleted owns 1.0.
+                val next = maxOf(lastReported, realProgress ?: estimated)
+                    .coerceAtMost(0.99)
+                lastReported = next
+                onProgress(next)
+
+                if (!shouldStopPolling.get()) {
+                    mainHandler.postDelayed(this, 100)
                 }
             }
         })

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/stopmotion/StopMotionGenerator.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/stopmotion/StopMotionGenerator.swift
@@ -151,7 +151,9 @@ internal enum StopMotionGenerator {
 
         let durationUs = frame.durationUs ?? defaultDurationUs
         cursorUs += max(durationUs, 1)
-        onProgress(Double(index + 1) / Double(frameCount))
+        // Reserve 1.0 for after finishWriting so the finalize step stays
+        // visible and the last value before completion is < 100%.
+        onProgress(min(Double(index + 1) / Double(frameCount), 0.99))
       }
     } catch {
       input.markAsFinished()
@@ -175,6 +177,8 @@ internal enum StopMotionGenerator {
           userInfo: [NSLocalizedDescriptionKey: "Writer finished with status \(writer.status.rawValue)"]
         )
     }
+
+    onProgress(1.0)
 
     if config.outputPath != nil {
       return nil

--- a/example/integration_test/stop_motion_test.dart
+++ b/example/integration_test/stop_motion_test.dart
@@ -200,6 +200,52 @@ void main() {
       );
     }, skip: !supportsStopMotion);
 
+    testWidgets('progress advances smoothly instead of jumping 0 → 100%',
+        (_) async {
+      // Enough frames at a real resolution so the encode takes long enough to
+      // emit several intermediate progress updates on every platform.
+      final frames = await buildFrames(60, width: 1280, height: 720);
+      final task = StopMotionRenderData(frames: frames, frameRate: 24);
+
+      final progressValues = <double>[];
+      final sub = task.progressStream.listen((p) {
+        progressValues.add(p.progress);
+      });
+
+      await ProVideoEditor.instance.renderStopMotion(task);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await sub.cancel();
+
+      expect(progressValues, isNotEmpty, reason: 'No progress updates');
+
+      // Progress never goes backwards.
+      for (var i = 1; i < progressValues.length; i++) {
+        expect(
+          progressValues[i],
+          greaterThanOrEqualTo(progressValues[i - 1]),
+          reason: 'Progress must never regress: $progressValues',
+        );
+      }
+
+      // Completion is reported.
+      expect(
+        progressValues.last,
+        equals(1.0),
+        reason: 'Final progress should be 100%',
+      );
+
+      // The actual fix: the encode phase must report intermediate progress
+      // rather than freezing low and snapping to 100%. Before the fix the
+      // highest value seen before completion was the ~0.2 frame-prep share on
+      // Android, so no value landed in the mid range.
+      expect(
+        progressValues.any((v) => v > 0.25 && v < 0.95),
+        isTrue,
+        reason: 'Progress jumped to 100% without meaningful mid-range updates: '
+            '$progressValues',
+      );
+    }, skip: !supportsStopMotion);
+
     testWidgets('cancel throws RenderCanceledException', (_) async {
       final taskId =
           'stop-motion-cancel-${DateTime.now().millisecondsSinceEpoch}';

--- a/example/integration_test/stop_motion_test.dart
+++ b/example/integration_test/stop_motion_test.dart
@@ -200,51 +200,55 @@ void main() {
       );
     }, skip: !supportsStopMotion);
 
-    testWidgets('progress advances smoothly instead of jumping 0 → 100%',
-        (_) async {
-      // Enough frames at a real resolution so the encode takes long enough to
-      // emit several intermediate progress updates on every platform.
-      final frames = await buildFrames(60, width: 1280, height: 720);
-      final task = StopMotionRenderData(frames: frames, frameRate: 24);
+    testWidgets(
+      'progress advances smoothly instead of jumping 0 → 100%',
+      (_) async {
+        // Enough frames at a real resolution so the encode takes long enough to
+        // emit several intermediate progress updates on every platform.
+        final frames = await buildFrames(60, width: 1280, height: 720);
+        final task = StopMotionRenderData(frames: frames, frameRate: 24);
 
-      final progressValues = <double>[];
-      final sub = task.progressStream.listen((p) {
-        progressValues.add(p.progress);
-      });
+        final progressValues = <double>[];
+        final sub = task.progressStream.listen((p) {
+          progressValues.add(p.progress);
+        });
 
-      await ProVideoEditor.instance.renderStopMotion(task);
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      await sub.cancel();
+        await ProVideoEditor.instance.renderStopMotion(task);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await sub.cancel();
 
-      expect(progressValues, isNotEmpty, reason: 'No progress updates');
+        expect(progressValues, isNotEmpty, reason: 'No progress updates');
 
-      // Progress never goes backwards.
-      for (var i = 1; i < progressValues.length; i++) {
+        // Progress never goes backwards.
+        for (var i = 1; i < progressValues.length; i++) {
+          expect(
+            progressValues[i],
+            greaterThanOrEqualTo(progressValues[i - 1]),
+            reason: 'Progress must never regress: $progressValues',
+          );
+        }
+
+        // Completion is reported.
         expect(
-          progressValues[i],
-          greaterThanOrEqualTo(progressValues[i - 1]),
-          reason: 'Progress must never regress: $progressValues',
+          progressValues.last,
+          equals(1.0),
+          reason: 'Final progress should be 100%',
         );
-      }
 
-      // Completion is reported.
-      expect(
-        progressValues.last,
-        equals(1.0),
-        reason: 'Final progress should be 100%',
-      );
-
-      // The actual fix: the encode phase must report intermediate progress
-      // rather than freezing low and snapping to 100%. Before the fix the
-      // highest value seen before completion was the ~0.2 frame-prep share on
-      // Android, so no value landed in the mid range.
-      expect(
-        progressValues.any((v) => v > 0.25 && v < 0.95),
-        isTrue,
-        reason: 'Progress jumped to 100% without meaningful mid-range updates: '
-            '$progressValues',
-      );
-    }, skip: !supportsStopMotion);
+        // The actual fix: the encode phase must report intermediate progress
+        // rather than freezing low and snapping to 100%. Before the fix the
+        // highest value seen before completion was the ~0.2 frame-prep share on
+        // Android, so no value landed in the mid range.
+        expect(
+          progressValues.any((v) => v > 0.25 && v < 0.95),
+          isTrue,
+          reason:
+              'Progress jumped to 100% without meaningful mid-range updates: '
+              '$progressValues',
+        );
+      },
+      skip: !supportsStopMotion,
+    );
 
     testWidgets('cancel throws RenderCanceledException', (_) async {
       final taskId =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.2.3
+version: 2.2.4
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Problem

Rendering a stop-motion video (confirmed on Android, a real Samsung SM-S942B) left the progress bar sitting near 0% for the whole encode and then snapping to 100% at the very end — no meaningful intermediate progress.

Root cause: the render has two phases — frame preparation (0→20%, real per-frame progress) and the Media3 Transformer encode (20→100%). Media3's **image-to-video** export reports no intra-export progress (`getProgress` → `PROGRESS_STATE_UNAVAILABLE`), and the poll loop additionally aborted on the initial `PROGRESS_STATE_NOT_STARTED`. So the encode phase was frozen at ~20% and only jumped to 100% via `onCompleted`.

## Changes

- **android** (`StopMotionGenerator.kt`): drive the encode phase with a smooth, monotonic time-based estimate (`1 - exp(-t/τ)`, τ scales with frame count, capped at 0.99), preferring the real Media3 value whenever it becomes available. Polling now runs until completion instead of bailing on `NOT_STARTED`; `onCompleted` still owns the final 1.0.
- **darwin** (`StopMotionGenerator.swift`): cap per-frame progress at 0.99 and report 1.0 only after `finishWriting`, so the finalize step stays visible (the frame loop previously hit 100% before the writer finished).
- **test**: new integration test asserting progress is monotonic, reaches 1.0, and emits at least one mid-range value `(0.25, 0.95)` — a regression guard that would have failed against the frozen-encode behavior.

## Validation

Integration tests run green end-to-end:
- Android — physical Samsung SM-S942B: all 11 stop-motion tests pass.
- macOS (Darwin): all 11 stop-motion tests pass.

Version bumped to 2.2.4.