### PR TITLE
chore(android): migrate Android module to Flutter's built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+- **CHORE**(android): Migrate the Android module to Flutter's built-in Kotlin (drop the manual Kotlin Gradle Plugin apply) so the plugin no longer triggers the KGP deprecation warning and stays AGP 9+ compatible. Now requires Flutter 3.44+.
+
 ## 2.2.4
 - **FIX**(android, iOS, macOS): Stop-motion render progress now advances smoothly instead of sitting near 0% and snapping to 100% at the end. Media3's image-to-video export reports no intra-export progress on Android, so the encode phase is now driven by a smooth, monotonic time-based estimate (using the real value when available); Darwin reports 100% only after the writer finishes so the finalize step stays visible.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,7 +28,6 @@ linter:
     - avoid_empty_else
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group = "ch.waio.pro_video_editor"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.11.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -22,7 +20,12 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "ch.waio.pro_video_editor"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,8 +1,13 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
 }
 
 android {
@@ -13,10 +18,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {

--- a/lib/core/models/audio/audio_extract_configs_model.dart
+++ b/lib/core/models/audio/audio_extract_configs_model.dart
@@ -26,8 +26,8 @@ class AudioExtractConfigs {
     this.endTime,
     this.speed = 1.0,
     String? id,
-  })  : assert(speed > 0, '[speed] must be greater than 0'),
-        id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
+  }) : assert(speed > 0, '[speed] must be greater than 0'),
+       id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
 
   /// The source video to extract audio from.
   final EditorVideo video;

--- a/lib/core/models/audio/audio_track_model.dart
+++ b/lib/core/models/audio/audio_track_model.dart
@@ -23,11 +23,11 @@ class VideoAudioTrack with TimeRangeMixin {
     this.audioEndTime,
     this.startTime,
     this.endTime,
-  })  : assert(volume >= 0, '[volume] must be greater than or equal to 0'),
-        assert(
-          startTime == null || endTime == null || startTime < endTime,
-          'startTime must be before endTime',
-        );
+  }) : assert(volume >= 0, '[volume] must be greater than or equal to 0'),
+       assert(
+         startTime == null || endTime == null || startTime < endTime,
+         'startTime must be before endTime',
+       );
 
   /// Path to the audio file.
   final String path;

--- a/lib/core/models/audio/waveform_data_model.dart
+++ b/lib/core/models/audio/waveform_data_model.dart
@@ -169,9 +169,9 @@ class WaveformData {
         .floor()
         .clamp(0, sampleCount);
     final endSample = (end.inMilliseconds / millisecondsPerSample).ceil().clamp(
-          0,
-          sampleCount,
-        );
+      0,
+      sampleCount,
+    );
     final length = endSample - startSample;
 
     if (length <= 0) {

--- a/lib/core/models/image/editor_layer_image_model.dart
+++ b/lib/core/models/image/editor_layer_image_model.dart
@@ -36,13 +36,13 @@ class EditorLayerImage {
     this.assetPath,
     this.file,
   }) : assert(
-          byteArray != null ||
-              file != null ||
-              networkUrl != null ||
-              assetPath != null,
-          'At least one of bytes, file, networkUrl, or assetPath must not '
-          'be null.',
-        );
+         byteArray != null ||
+             file != null ||
+             networkUrl != null ||
+             assetPath != null,
+         'At least one of bytes, file, networkUrl, or assetPath must not '
+         'be null.',
+       );
 
   /// Creates an [EditorLayerImage] from in-memory bytes.
   ///

--- a/lib/core/models/image/image_layer_model.dart
+++ b/lib/core/models/image/image_layer_model.dart
@@ -24,9 +24,9 @@ class ImageLayer with TimeRangeMixin {
     this.loop = true,
     this.animations = const [],
   }) : assert(
-          startTime == null || endTime == null || startTime < endTime,
-          'startTime must be before endTime',
-        );
+         startTime == null || endTime == null || startTime < endTime,
+         'startTime must be before endTime',
+       );
 
   /// The image to overlay on the video.
   ///
@@ -114,8 +114,9 @@ class ImageLayer with TimeRangeMixin {
       'startTime': startTime?.inMicroseconds,
       'endTime': endTime?.inMicroseconds,
       'offset': offset != null ? {'dx': offset!.dx, 'dy': offset!.dy} : null,
-      'size':
-          size != null ? {'width': size!.width, 'height': size!.height} : null,
+      'size': size != null
+          ? {'width': size!.width, 'height': size!.height}
+          : null,
       'rotation': rotation,
       'loop': loop,
       'animations': animations.map((a) => a.toMap()).toList(),
@@ -143,10 +144,12 @@ class ImageLayer with TimeRangeMixin {
               safeParseDouble((map['size'] as Map<String, dynamic>)['height']),
             )
           : null,
-      rotation:
-          map['rotation'] != null ? safeParseDouble(map['rotation']) : 0.0,
+      rotation: map['rotation'] != null
+          ? safeParseDouble(map['rotation'])
+          : 0.0,
       loop: map['loop'] as bool? ?? true,
-      animations: (map['animations'] as List<dynamic>?)
+      animations:
+          (map['animations'] as List<dynamic>?)
               ?.map((a) => LayerAnimation.fromMap(a as Map<String, dynamic>))
               .toList() ??
           const [],

--- a/lib/core/models/image/layer_animation_model.dart
+++ b/lib/core/models/image/layer_animation_model.dart
@@ -124,9 +124,9 @@ class LayerAnimation {
     this.slideDirection,
     this.scaleFrom,
   }) : assert(
-          type != LayerAnimationType.slide || slideDirection != null,
-          'slideDirection is required for slide animations',
-        );
+         type != LayerAnimationType.slide || slideDirection != null,
+         'slideDirection is required for slide animations',
+       );
 
   /// The kind of animation (fade, slide, scale).
   final LayerAnimationType type;

--- a/lib/core/models/thumbnail/thumbnail_base_abstract.dart
+++ b/lib/core/models/thumbnail/thumbnail_base_abstract.dart
@@ -18,11 +18,11 @@ abstract class ThumbnailBase {
     this.outputFormat = ThumbnailFormat.jpeg,
     this.boxFit = ThumbnailBoxFit.cover,
     String? id,
-  })  : assert(
-          jpegQuality >= 0 && jpegQuality <= 100,
-          'jpegQuality must be between 0 and 100',
-        ),
-        id = id ?? DateTime.now().microsecondsSinceEpoch.toString();
+  }) : assert(
+         jpegQuality >= 0 && jpegQuality <= 100,
+         'jpegQuality must be between 0 and 100',
+       ),
+       id = id ?? DateTime.now().microsecondsSinceEpoch.toString();
 
   /// Unique ID for the task, useful when running multiple tasks at once.
   final String id;

--- a/lib/core/models/thumbnail/thumbnail_configs_model.dart
+++ b/lib/core/models/thumbnail/thumbnail_configs_model.dart
@@ -30,8 +30,9 @@ class ThumbnailConfigs extends ThumbnailBase {
       'outputFormat': outputFormat.name,
       'outputWidth': outputSize.width.round(),
       'outputHeight': outputSize.height.round(),
-      'timestamps':
-          timestamps.map((timestamp) => timestamp.inMicroseconds).toList(),
+      'timestamps': timestamps
+          .map((timestamp) => timestamp.inMicroseconds)
+          .toList(),
     };
   }
 }

--- a/lib/core/models/video/color_filter_model.dart
+++ b/lib/core/models/video/color_filter_model.dart
@@ -17,10 +17,10 @@ class ColorFilter with TimeRangeMixin {
   /// Creates a [ColorFilter] with the given [matrix], [startTime],
   /// and optional [endTime].
   const ColorFilter({required this.matrix, this.startTime, this.endTime})
-      : assert(
-          startTime == null || endTime == null || startTime < endTime,
-          'startTime must be before endTime',
-        );
+    : assert(
+        startTime == null || endTime == null || startTime < endTime,
+        'startTime must be before endTime',
+      );
 
   /// A 4x5 color matrix used to apply color filters
   /// (e.g., saturation, brightness).

--- a/lib/core/models/video/editor_video_model.dart
+++ b/lib/core/models/video/editor_video_model.dart
@@ -18,8 +18,9 @@ class EditorVideo {
           ? Uint8List.fromList(List<int>.from(map['byteArray'] as List))
           : null,
       file: map['file'] != null ? map['file'] as String : null,
-      networkUrl:
-          map['networkUrl'] != null ? map['networkUrl'] as String : null,
+      networkUrl: map['networkUrl'] != null
+          ? map['networkUrl'] as String
+          : null,
       assetPath: map['assetPath'] != null ? map['assetPath'] as String : null,
     );
   }
@@ -30,15 +31,15 @@ class EditorVideo {
   /// At least one of `byteArray`, `file`, `networkUrl`, or `assetPath`
   /// must not be null.
   EditorVideo._({this.byteArray, this.networkUrl, this.assetPath, dynamic file})
-      : file = file == null ? null : ensureFileInstance(file),
-        assert(
-          byteArray != null ||
-              file != null ||
-              networkUrl != null ||
-              assetPath != null,
-          'At least one of bytes, file, networkUrl, or assetPath must not '
-          'be null.',
-        );
+    : file = file == null ? null : ensureFileInstance(file),
+      assert(
+        byteArray != null ||
+            file != null ||
+            networkUrl != null ||
+            assetPath != null,
+        'At least one of bytes, file, networkUrl, or assetPath must not '
+        'be null.',
+      );
 
   /// Creates an [EditorVideo] instance from any supported source.
   ///

--- a/lib/core/models/video/export_transform_model.dart
+++ b/lib/core/models/video/export_transform_model.dart
@@ -12,8 +12,9 @@ class ExportTransform {
       flipX: map['flipX'] as bool? ?? false,
       flipY: map['flipY'] as bool? ?? false,
       width: map['cropWidth'] != null ? safeParseInt(map['cropWidth']) : null,
-      height:
-          map['cropHeight'] != null ? safeParseInt(map['cropHeight']) : null,
+      height: map['cropHeight'] != null
+          ? safeParseInt(map['cropHeight'])
+          : null,
       x: map['cropX'] != null ? safeParseInt(map['cropX']) : null,
       y: map['cropY'] != null ? safeParseInt(map['cropY']) : null,
       scaleX: tryParseDouble(map['scaleX']),

--- a/lib/core/models/video/segment_transform_model.dart
+++ b/lib/core/models/video/segment_transform_model.dart
@@ -31,11 +31,7 @@ enum SegmentFit {
 /// it is stretched to fill the entire canvas.
 class SegmentTransform {
   /// Creates a [SegmentTransform].
-  const SegmentTransform({
-    this.offset,
-    this.size,
-    this.fit = SegmentFit.cover,
-  });
+  const SegmentTransform({this.offset, this.size, this.fit = SegmentFit.cover});
 
   /// Position of the segment's top-left corner within the canvas, in pixels.
   ///
@@ -55,11 +51,7 @@ class SegmentTransform {
   final SegmentFit fit;
 
   /// Creates a copy with updated values.
-  SegmentTransform copyWith({
-    Offset? offset,
-    Size? size,
-    SegmentFit? fit,
-  }) {
+  SegmentTransform copyWith({Offset? offset, Size? size, SegmentFit? fit}) {
     return SegmentTransform(
       offset: offset ?? this.offset,
       size: size ?? this.size,
@@ -70,8 +62,9 @@ class SegmentTransform {
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
       'offset': offset != null ? {'dx': offset!.dx, 'dy': offset!.dy} : null,
-      'size':
-          size != null ? {'width': size!.width, 'height': size!.height} : null,
+      'size': size != null
+          ? {'width': size!.width, 'height': size!.height}
+          : null,
       'fit': fit.name,
     };
   }

--- a/lib/core/models/video/split_video_model.dart
+++ b/lib/core/models/video/split_video_model.dart
@@ -29,19 +29,19 @@ class SplitVideoModel {
     this.qualityConfig,
     this.bitrate,
     this.enableAudio = true,
-  })  : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
-        assert(
-          splitPosition > Duration.zero,
-          'splitPosition must be greater than zero',
-        ),
-        assert(
-          startOutputPath != endOutputPath,
-          'startOutputPath and endOutputPath must differ',
-        ),
-        assert(
-          bitrate == null || bitrate > 0,
-          '[bitrate] must be greater than 0',
-        );
+  }) : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
+       assert(
+         splitPosition > Duration.zero,
+         'splitPosition must be greater than zero',
+       ),
+       assert(
+         startOutputPath != endOutputPath,
+         'startOutputPath and endOutputPath must differ',
+       ),
+       assert(
+         bitrate == null || bitrate > 0,
+         '[bitrate] must be greater than 0',
+       );
 
   /// Unique ID for the task, used for progress updates and cancellation.
   final String id;

--- a/lib/core/models/video/stop_motion_render_data_model.dart
+++ b/lib/core/models/video/stop_motion_render_data_model.dart
@@ -31,10 +31,10 @@ class StopMotionFrame {
   /// Creates a [StopMotionFrame] from the given [image] and optional
   /// [duration].
   const StopMotionFrame({required this.image, this.duration})
-      : assert(
-          duration == null || duration > Duration.zero,
-          '[duration] must be greater than zero',
-        );
+    : assert(
+        duration == null || duration > Duration.zero,
+        '[duration] must be greater than zero',
+      );
 
   /// The image source for this frame.
   ///
@@ -118,13 +118,13 @@ class StopMotionRenderData {
     this.outputFormat = VideoOutputFormat.mp4,
     this.qualityConfig,
     this.bitrate,
-  })  : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
-        assert(frames.isNotEmpty, 'frames must not be empty'),
-        assert(frameRate > 0, '[frameRate] must be greater than 0'),
-        assert(
-          bitrate == null || bitrate > 0,
-          '[bitrate] must be greater than 0',
-        );
+  }) : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
+       assert(frames.isNotEmpty, 'frames must not be empty'),
+       assert(frameRate > 0, '[frameRate] must be greater than 0'),
+       assert(
+         bitrate == null || bitrate > 0,
+         '[bitrate] must be greater than 0',
+       );
 
   /// Creates a [StopMotionRenderData] with a predefined quality preset.
   ///

--- a/lib/core/models/video/video_composition_model.dart
+++ b/lib/core/models/video/video_composition_model.dart
@@ -117,7 +117,8 @@ class VideoComposition {
       VideoComposition.fromMap(json.decode(source) as Map<String, dynamic>);
 
   @override
-  String toString() => 'VideoComposition(layers: $layers, '
+  String toString() =>
+      'VideoComposition(layers: $layers, '
       'canvasSize: $canvasSize, backgroundColor: $backgroundColor)';
 
   @override

--- a/lib/core/models/video/video_layer_model.dart
+++ b/lib/core/models/video/video_layer_model.dart
@@ -18,15 +18,9 @@ import 'package:pro_video_editor/shared/utils/parser/double_parser.dart';
 /// clip provides its own [VideoSegment.transform], placed using [transform].
 class VideoLayer {
   /// Creates a [VideoLayer] from a list of [clips].
-  const VideoLayer({
-    required this.clips,
-    this.opacity = 1.0,
-    this.transform,
-  })  : assert(clips.length > 0, 'A layer must contain at least one clip'),
-        assert(
-          opacity >= 0 && opacity <= 1,
-          '[opacity] must be between 0 and 1',
-        );
+  const VideoLayer({required this.clips, this.opacity = 1.0, this.transform})
+    : assert(clips.length > 0, 'A layer must contain at least one clip'),
+      assert(opacity >= 0 && opacity <= 1, '[opacity] must be between 0 and 1');
 
   /// The time-ordered sequence of clips on this layer.
   final List<VideoSegment> clips;

--- a/lib/core/models/video/video_metadata_model.dart
+++ b/lib/core/models/video/video_metadata_model.dart
@@ -100,8 +100,9 @@ class VideoMetadata {
       author: value['author'] ?? '',
       album: value['album'] ?? '',
       albumArtist: value['albumArtist'] ?? '',
-      date:
-          (value['date'] ?? '') != '' ? DateTime.tryParse(value['date']) : null,
+      date: (value['date'] ?? '') != ''
+          ? DateTime.tryParse(value['date'])
+          : null,
       isOptimizedForStreaming: value['isOptimizedForStreaming'] as bool?,
       gpsCoordinates: value['latitude'] != null && value['longitude'] != null
           ? GpsCoordinates(

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -39,31 +39,31 @@ class VideoRenderData {
     this.maxFrameRate,
     this.shouldOptimizeForNetworkUse = false,
     this.imageBytesWithCropping = false,
-  })  : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
-        assert(
-          (videoSegments != null ? 1 : 0) + (composition != null ? 1 : 0) == 1,
-          'You must provide exactly one of videoSegments or composition',
-        ),
-        assert(
-          videoSegments == null || videoSegments.isNotEmpty,
-          'videoSegments must not be empty if provided',
-        ),
-        assert(
-          startTime == null || endTime == null || startTime < endTime,
-          'startTime must be before endTime',
-        ),
-        assert(
-          blur == null || blur >= 0,
-          '[blur] must be greater than or equal to 0',
-        ),
-        assert(
-          bitrate == null || bitrate > 0,
-          '[bitrate] must be greater than 0',
-        ),
-        assert(
-          maxFrameRate == null || maxFrameRate > 0,
-          '[maxFrameRate] must be greater than 0',
-        );
+  }) : id = id ?? DateTime.now().microsecondsSinceEpoch.toString(),
+       assert(
+         (videoSegments != null ? 1 : 0) + (composition != null ? 1 : 0) == 1,
+         'You must provide exactly one of videoSegments or composition',
+       ),
+       assert(
+         videoSegments == null || videoSegments.isNotEmpty,
+         'videoSegments must not be empty if provided',
+       ),
+       assert(
+         startTime == null || endTime == null || startTime < endTime,
+         'startTime must be before endTime',
+       ),
+       assert(
+         blur == null || blur >= 0,
+         '[blur] must be greater than or equal to 0',
+       ),
+       assert(
+         bitrate == null || bitrate > 0,
+         '[bitrate] must be greater than 0',
+       ),
+       assert(
+         maxFrameRate == null || maxFrameRate > 0,
+         '[maxFrameRate] must be greater than 0',
+       );
 
   /// Creates a [VideoRenderData] with a predefined quality preset.
   ///
@@ -305,7 +305,8 @@ class VideoRenderData {
         outputWidth = resolution.width.round();
         outputHeight = resolution.height.round();
       } else {
-        final targetVideo = (videoSegments != null && videoSegments!.isNotEmpty
+        final targetVideo =
+            (videoSegments != null && videoSegments!.isNotEmpty
                 ? videoSegments!.first.video
                 : null) ??
             composition?.layers.first.clips.first.video;
@@ -377,8 +378,9 @@ class VideoRenderData {
       ...transform.toMap(),
       'id': id,
       'videoClips': videoSegmentsMaps,
-      'composition':
-          composition != null ? await composition!.toAsyncMap() : null,
+      'composition': composition != null
+          ? await composition!.toAsyncMap()
+          : null,
       'imageLayers': imageLayerMaps,
       'colorFilters': colorFilterMaps,
       'audioTracks': audioTrackMaps,

--- a/lib/core/models/video/video_segment_model.dart
+++ b/lib/core/models/video/video_segment_model.dart
@@ -21,18 +21,18 @@ class VideoSegment {
     this.transition,
     this.timelineStart,
     this.transform,
-  })  : assert(
-          startTime == null || endTime == null || startTime < endTime,
-          'startTime must be before endTime',
-        ),
-        assert(
-          volume == null || volume >= 0,
-          '[volume] must be greater than or equal to 0',
-        ),
-        assert(
-          playbackSpeed == null || playbackSpeed > 0,
-          '[playbackSpeed] must be greater than 0',
-        );
+  }) : assert(
+         startTime == null || endTime == null || startTime < endTime,
+         'startTime must be before endTime',
+       ),
+       assert(
+         volume == null || volume >= 0,
+         '[volume] must be greater than or equal to 0',
+       ),
+       assert(
+         playbackSpeed == null || playbackSpeed > 0,
+         '[playbackSpeed] must be greater than 0',
+       );
 
   /// The video source for this clip.
   ///

--- a/lib/core/platform/native_method_channel.dart
+++ b/lib/core/platform/native_method_channel.dart
@@ -151,12 +151,12 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
 
     final response =
         await methodChannel.invokeMethod<Map<dynamic, dynamic>>('getMetadata', {
-              'inputPath': inputPath,
-              'extension': extension,
-              'checkStreamingOptimization': checkStreamingOptimization,
-              'nativeLogLevel': nativeLogLevel?.methodValue,
-            }) ??
-            {};
+          'inputPath': inputPath,
+          'extension': extension,
+          'checkStreamingOptimization': checkStreamingOptimization,
+          'nativeLogLevel': nativeLogLevel?.methodValue,
+        }) ??
+        {};
 
     return VideoMetadata.fromMap(response, extension);
   }
@@ -183,13 +183,13 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
   }) async {
     var inputPath = await value.video.safeFilePath();
 
-    final response =
-        await methodChannel.invokeMethod<List<dynamic>>('getThumbnails', {
-      'inputPath': inputPath,
-      'extension': _getFileExtension(inputPath),
-      'nativeLogLevel': nativeLogLevel?.methodValue,
-      ...value.toMap(),
-    });
+    final response = await methodChannel
+        .invokeMethod<List<dynamic>>('getThumbnails', {
+          'inputPath': inputPath,
+          'extension': _getFileExtension(inputPath),
+          'nativeLogLevel': nativeLogLevel?.methodValue,
+          ...value.toMap(),
+        });
     final List<Uint8List> result = response?.cast<Uint8List>() ?? [];
 
     return result;
@@ -219,12 +219,12 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
     final bool isLastFrame = value.position == ThumbnailPosition.last;
     Duration timestamp;
     if (isLastFrame) {
-      final duration = value.videoDuration ??
+      final duration =
+          value.videoDuration ??
           (await getMetadata(
             value.video,
             nativeLogLevel: nativeLogLevel,
-          ))
-              .duration;
+          )).duration;
       timestamp = duration;
     } else {
       timestamp = Duration.zero;
@@ -255,13 +255,13 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
     try {
       var inputPath = await value.video.safeFilePath();
 
-      final Uint8List? result =
-          await methodChannel.invokeMethod<Uint8List>('extractAudio', {
-        'inputPath': inputPath,
-        'extension': _getFileExtension(inputPath),
-        'nativeLogLevel': nativeLogLevel?.methodValue,
-        ...value.toMap(),
-      });
+      final Uint8List? result = await methodChannel
+          .invokeMethod<Uint8List>('extractAudio', {
+            'inputPath': inputPath,
+            'extension': _getFileExtension(inputPath),
+            'nativeLogLevel': nativeLogLevel?.methodValue,
+            ...value.toMap(),
+          });
 
       if (result == null) {
         throw ArgumentError('Failed to extract audio from video');
@@ -316,11 +316,11 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
 
       final response = await methodChannel
           .invokeMethod<Map<dynamic, dynamic>>('getWaveform', {
-        'inputPath': inputPath,
-        'extension': _getFileExtension(inputPath),
-        'nativeLogLevel': nativeLogLevel?.methodValue,
-        ...value.toMap(),
-      });
+            'inputPath': inputPath,
+            'extension': _getFileExtension(inputPath),
+            'nativeLogLevel': nativeLogLevel?.methodValue,
+            ...value.toMap(),
+          });
 
       if (response == null) {
         throw ArgumentError('Failed to generate waveform data');
@@ -610,15 +610,18 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
     if (!kIsWeb && (Platform.isWindows || Platform.isLinux)) return;
 
     // Subscribe to native progress events
-    _progressChannel.receiveBroadcastStream().map((event) {
-      try {
-        return ProgressModel.fromMap(event);
-      } catch (e, stack) {
-        // Log parsing errors but don't crash - return error progress
-        debugPrint('Error parsing progress event: $e\n$stack');
-        return const ProgressModel(id: 'error', progress: 0);
-      }
-    }).listen(progressCtrl.add);
+    _progressChannel
+        .receiveBroadcastStream()
+        .map((event) {
+          try {
+            return ProgressModel.fromMap(event);
+          } catch (e, stack) {
+            // Log parsing errors but don't crash - return error progress
+            debugPrint('Error parsing progress event: $e\n$stack');
+            return const ProgressModel(id: 'error', progress: 0);
+          }
+        })
+        .listen(progressCtrl.add);
 
     // Subscribe to native log events
     _logChannel.receiveBroadcastStream().listen(

--- a/lib/core/platform/web_method_channel.dart
+++ b/lib/core/platform/web_method_channel.dart
@@ -108,7 +108,8 @@ class ProVideoEditorWeb extends ProVideoEditor {
   }) async {
     Duration timestamp;
     if (value.position == ThumbnailPosition.last) {
-      final duration = value.videoDuration ??
+      final duration =
+          value.videoDuration ??
           (await _manager.getMetadata(value.video)).duration;
       timestamp = duration;
     } else {

--- a/lib/core/services/web/web_thumbnail_generator.dart
+++ b/lib/core/services/web/web_thumbnail_generator.dart
@@ -102,14 +102,16 @@ class WebThumbnailGenerator {
   }
 
   Future<
-      (
-        web.HTMLVideoElement,
-        web.HTMLCanvasElement,
-        web.CanvasRenderingContext2D,
-        int,
-        int,
-        String,
-      )?> _prepareVideoRendering({
+    (
+      web.HTMLVideoElement,
+      web.HTMLCanvasElement,
+      web.CanvasRenderingContext2D,
+      int,
+      int,
+      String,
+    )?
+  >
+  _prepareVideoRendering({
     required Uint8List videoBytes,
     required int outputWidth,
   }) async {

--- a/lib/features/audio/widgets/audio_waveform.dart
+++ b/lib/features/audio/widgets/audio_waveform.dart
@@ -50,11 +50,11 @@ class AudioWaveform extends StatefulWidget {
     super.key,
     required this.waveform,
     this.style = const WaveformStyle(),
-  })  : config = null,
-        currentPosition = null,
-        onSeek = null,
-        showPositionIndicator = false,
-        onComplete = null;
+  }) : config = null,
+       currentPosition = null,
+       onSeek = null,
+       showPositionIndicator = false,
+       onComplete = null;
 
   /// Creates an interactive [AudioWaveform] with position indicator and
   /// seek support.
@@ -69,9 +69,9 @@ class AudioWaveform extends StatefulWidget {
     required this.currentPosition,
     required this.onSeek,
     this.style = const WaveformStyle(),
-  })  : config = null,
-        showPositionIndicator = true,
-        onComplete = null;
+  }) : config = null,
+       showPositionIndicator = true,
+       onComplete = null;
 
   /// Creates a streaming [AudioWaveform] that displays chunks progressively.
   ///
@@ -168,16 +168,17 @@ class _AudioWaveformState extends State<AudioWaveform> {
         child: widget.showPositionIndicator
             ? LayoutBuilder(
                 builder: (context, constraints) {
-                  final positionRatio = widget.currentPosition != null &&
+                  final positionRatio =
+                      widget.currentPosition != null &&
                           _duration > Duration.zero
                       ? widget.currentPosition!.inMilliseconds /
-                          _duration.inMilliseconds
+                            _duration.inMilliseconds
                       : 0.0;
                   final indicatorPosition =
                       (constraints.maxWidth * positionRatio).clamp(
-                    0.0,
-                    constraints.maxWidth - 2,
-                  );
+                        0.0,
+                        constraints.maxWidth - 2,
+                      );
 
                   return Stack(
                     alignment: AlignmentGeometry.center,
@@ -214,7 +215,8 @@ class _AudioWaveformState extends State<AudioWaveform> {
                           bottom: 0,
                           child: Container(
                             width: 2,
-                            color: widget.style.positionIndicatorColor ??
+                            color:
+                                widget.style.positionIndicatorColor ??
                                 widget.style.waveColor,
                           ),
                         ),

--- a/lib/features/audio/widgets/streaming_waveform.dart
+++ b/lib/features/audio/widgets/streaming_waveform.dart
@@ -116,10 +116,11 @@ class _StreamingWaveformState extends State<StreamingWaveform> {
 
     // Calculate expected total samples from duration and samplesPerSecond
     if (_expectedTotalSamples == 0 && lastChunk.totalDuration > Duration.zero) {
-      _expectedTotalSamples = (lastChunk.totalDuration.inMilliseconds /
-              1000 *
-              lastChunk.samplesPerSecond)
-          .round();
+      _expectedTotalSamples =
+          (lastChunk.totalDuration.inMilliseconds /
+                  1000 *
+                  lastChunk.samplesPerSecond)
+              .round();
     }
 
     // Report duration when it becomes available
@@ -162,8 +163,9 @@ class _StreamingWaveformState extends State<StreamingWaveform> {
     }
 
     final samplesPerBar = effectiveTotalSamples / barsCount;
-    final maxAmplitude =
-        _isStereo ? widget.style.height / 4 - 2 : widget.style.height / 2 - 2;
+    final maxAmplitude = _isStereo
+        ? widget.style.height / 4 - 2
+        : widget.style.height / 2 - 2;
 
     // Pre-calculate all bar heights (including zeros for bars without data yet)
     final heights = <double>[];
@@ -209,8 +211,9 @@ class _StreamingWaveformState extends State<StreamingWaveform> {
                   key: ValueKey('pro_image_editor_bar_${_id}_$i'),
                   height: i < _barHeights.length ? _barHeights[i] : 0.0,
                   style: widget.style,
-                  spacing:
-                      i < _totalBarsCount - 1 ? widget.style.barSpacing : 0,
+                  spacing: i < _totalBarsCount - 1
+                      ? widget.style.barSpacing
+                      : 0,
                 ),
             ],
           ),

--- a/lib/features/audio/widgets/waveform_painter.dart
+++ b/lib/features/audio/widgets/waveform_painter.dart
@@ -41,14 +41,15 @@ class WaveformPainter extends CustomPainter {
 
     final samplesPerBar = samples.length / barsCount;
     final centerY = size.height / 2;
-    final maxAmplitude =
-        waveform.isStereo ? size.height / 4 - 2 : size.height / 2 - 2;
+    final maxAmplitude = waveform.isStereo
+        ? size.height / 4 - 2
+        : size.height / 2 - 2;
 
     // Calculate position for played/unplayed coloring
     final positionRatio =
         currentPosition != null && waveform.duration.inMilliseconds > 0
-            ? currentPosition!.inMilliseconds / waveform.duration.inMilliseconds
-            : 0.0;
+        ? currentPosition!.inMilliseconds / waveform.duration.inMilliseconds
+        : 0.0;
     final playedBars = (barsCount * positionRatio).floor();
 
     // Prepare paints

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.2.4
+version: 2.3.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/
@@ -21,8 +21,8 @@ screenshots:
     path: assets/showcase1.jpg
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: ">=3.35.0"
+  sdk: '>=3.12.0 <4.0.0'
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/test/core/models/image/image_layer_model_test.dart
+++ b/test/core/models/image/image_layer_model_test.dart
@@ -86,19 +86,14 @@ void main() {
       });
 
       test('defaults rotation to 0 when absent from map', () {
-        final map = {
-          'image': image.toMap(),
-        };
+        final map = {'image': image.toMap()};
         final restored = ImageLayer.fromMap(map);
 
         expect(restored.rotation, 0.0);
       });
 
       test('parses numeric string for rotation safely', () {
-        final map = {
-          'image': image.toMap(),
-          'rotation': '0.75',
-        };
+        final map = {'image': image.toMap(), 'rotation': '0.75'};
         final restored = ImageLayer.fromMap(map);
 
         expect(restored.rotation, 0.75);

--- a/test/core/models/video/video_render_data_model_test.dart
+++ b/test/core/models/video/video_render_data_model_test.dart
@@ -22,14 +22,8 @@ void main() {
     });
 
     test('asserts a positive value', () {
-      expect(
-        () => buildData(maxFrameRate: 0),
-        throwsA(isA<AssertionError>()),
-      );
-      expect(
-        () => buildData(maxFrameRate: -5),
-        throwsA(isA<AssertionError>()),
-      );
+      expect(() => buildData(maxFrameRate: 0), throwsA(isA<AssertionError>()));
+      expect(() => buildData(maxFrameRate: -5), throwsA(isA<AssertionError>()));
     });
 
     test('toMap serializes the value', () {
@@ -38,8 +32,9 @@ void main() {
     });
 
     test('toMap / fromMap roundtrip preserves the value', () {
-      final restored =
-          VideoRenderData.fromMap(buildData(maxFrameRate: 24).toMap());
+      final restored = VideoRenderData.fromMap(
+        buildData(maxFrameRate: 24).toMap(),
+      );
       expect(restored.maxFrameRate, 24);
 
       final restoredNull = VideoRenderData.fromMap(buildData().toMap());
@@ -76,21 +71,23 @@ void main() {
       );
     }
 
-    test('custom resolution maps to an exact output canvas (no scale)',
-        () async {
-      final map = await buildData(
-        VideoQualityConfig.custom(
-          bitrate: 8000000,
-          resolution: const Size(1080, 1920),
-        ),
-      ).toAsyncMap();
+    test(
+      'custom resolution maps to an exact output canvas (no scale)',
+      () async {
+        final map = await buildData(
+          VideoQualityConfig.custom(
+            bitrate: 8000000,
+            resolution: const Size(1080, 1920),
+          ),
+        ).toAsyncMap();
 
-      // Exact output canvas → letterboxed natively, not a uniform scale.
-      expect(map['outputWidth'], 1080);
-      expect(map['outputHeight'], 1920);
-      expect(map['scaleX'], isNull);
-      expect(map['scaleY'], isNull);
-    });
+        // Exact output canvas → letterboxed natively, not a uniform scale.
+        expect(map['outputWidth'], 1080);
+        expect(map['outputHeight'], 1920);
+        expect(map['scaleX'], isNull);
+        expect(map['scaleY'], isNull);
+      },
+    );
 
     test('falls back to the quality config bitrate when none is set', () async {
       final map = await buildData(

--- a/test/pro_video_editor_method_channel_test.dart
+++ b/test/pro_video_editor_method_channel_test.dart
@@ -28,31 +28,31 @@ void main() {
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      switch (methodCall.method) {
-        case 'getPlatformVersion':
-          return '42';
-        case 'getMetadata':
-          // Native platforms now return display dimensions (after rotation)
-          // For a 90° rotated video, width and height are already swapped
-          return {
-            'duration': 1200,
-            'width': 1080, // Display width (after 90° rotation)
-            'height': 1920, // Display height (after 90° rotation)
-            'rotation': 90,
-            'extension': 'mp4',
-          };
-        case 'getThumbnails':
-          return [mockBytes, mockBytes];
-        case 'renderVideo':
-          return Uint8List(10);
-        case 'renderStopMotion':
-          return Uint8List(10);
-        case 'cancelTask':
-          return null;
-        default:
-          return null;
-      }
-    });
+          switch (methodCall.method) {
+            case 'getPlatformVersion':
+              return '42';
+            case 'getMetadata':
+              // Native platforms now return display dimensions (after rotation)
+              // For a 90° rotated video, width and height are already swapped
+              return {
+                'duration': 1200,
+                'width': 1080, // Display width (after 90° rotation)
+                'height': 1920, // Display height (after 90° rotation)
+                'rotation': 90,
+                'extension': 'mp4',
+              };
+            case 'getThumbnails':
+              return [mockBytes, mockBytes];
+            case 'renderVideo':
+              return Uint8List(10);
+            case 'renderStopMotion':
+              return Uint8List(10);
+            case 'cancelTask':
+              return null;
+            default:
+              return null;
+          }
+        });
   });
 
   tearDown(() {
@@ -117,8 +117,8 @@ void main() {
   test('renderVideo throws if result is null', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      return null;
-    });
+          return null;
+        });
 
     final mockModel = MockVideoRenderData();
 
@@ -150,9 +150,9 @@ void main() {
       MethodCall? capturedCall;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-        capturedCall = methodCall;
-        return null;
-      });
+            capturedCall = methodCall;
+            return null;
+          });
 
       final data = StopMotionRenderData(
         frames: [StopMotionFrame(image: EditorLayerImage.memory(mockBytes))],
@@ -174,9 +174,9 @@ void main() {
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      capturedCall = methodCall;
-      return null;
-    });
+          capturedCall = methodCall;
+          return null;
+        });
 
     const taskId = 'task-123';
     await platform.cancel(taskId);
@@ -234,21 +234,21 @@ void main() {
     test('returns null when native returns empty list', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-        switch (methodCall.method) {
-          case 'getThumbnails':
-            return <Uint8List>[];
-          case 'getMetadata':
-            return {
-              'duration': 1200,
-              'width': 1080,
-              'height': 1920,
-              'rotation': 0,
-              'extension': 'mp4',
-            };
-          default:
-            return null;
-        }
-      });
+            switch (methodCall.method) {
+              case 'getThumbnails':
+                return <Uint8List>[];
+              case 'getMetadata':
+                return {
+                  'duration': 1200,
+                  'width': 1080,
+                  'height': 1920,
+                  'rotation': 0,
+                  'extension': 'mp4',
+                };
+              default:
+                return null;
+            }
+          });
 
       final result = await platform.getSingleThumbnail(
         SingleThumbnailConfigs(
@@ -266,12 +266,12 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-        if (methodCall.method == 'getThumbnails') {
-          capturedArgs = methodCall.arguments as Map<dynamic, dynamic>;
-          return [mockBytes];
-        }
-        return null;
-      });
+            if (methodCall.method == 'getThumbnails') {
+              capturedArgs = methodCall.arguments as Map<dynamic, dynamic>;
+              return [mockBytes];
+            }
+            return null;
+          });
 
       await platform.getSingleThumbnail(
         SingleThumbnailConfigs(
@@ -291,12 +291,12 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-        if (methodCall.method == 'getThumbnails') {
-          capturedArgs = methodCall.arguments as Map<dynamic, dynamic>;
-          return [mockBytes];
-        }
-        return null;
-      });
+            if (methodCall.method == 'getThumbnails') {
+              capturedArgs = methodCall.arguments as Map<dynamic, dynamic>;
+              return [mockBytes];
+            }
+            return null;
+          });
 
       await platform.getSingleThumbnail(
         SingleThumbnailConfigs(

--- a/test/pro_video_editor_method_channel_test.mocks.dart
+++ b/test/pro_video_editor_method_channel_test.mocks.dart
@@ -35,34 +35,19 @@ import 'package:pro_video_editor/pro_video_editor.dart' as _i4;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeEditorVideo_0 extends _i1.SmartFake implements _i2.EditorVideo {
-  _FakeEditorVideo_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeEditorVideo_0(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeSize_1 extends _i1.SmartFake implements _i3.Size {
-  _FakeSize_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeSize_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 class _FakeVideoRenderData_2 extends _i1.SmartFake
     implements _i4.VideoRenderData {
-  _FakeVideoRenderData_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeVideoRenderData_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
 /// A class which mocks [EditorVideo].
@@ -74,82 +59,73 @@ class MockEditorVideo extends _i1.Mock implements _i2.EditorVideo {
   }
 
   @override
-  bool get hasBytes => (super.noSuchMethod(
-        Invocation.getter(#hasBytes),
-        returnValue: false,
-      ) as bool);
+  bool get hasBytes =>
+      (super.noSuchMethod(Invocation.getter(#hasBytes), returnValue: false)
+          as bool);
 
   @override
-  bool get hasNetworkUrl => (super.noSuchMethod(
-        Invocation.getter(#hasNetworkUrl),
-        returnValue: false,
-      ) as bool);
+  bool get hasNetworkUrl =>
+      (super.noSuchMethod(Invocation.getter(#hasNetworkUrl), returnValue: false)
+          as bool);
 
   @override
-  bool get hasFile => (super.noSuchMethod(
-        Invocation.getter(#hasFile),
-        returnValue: false,
-      ) as bool);
+  bool get hasFile =>
+      (super.noSuchMethod(Invocation.getter(#hasFile), returnValue: false)
+          as bool);
 
   @override
-  bool get hasAssetPath => (super.noSuchMethod(
-        Invocation.getter(#hasAssetPath),
-        returnValue: false,
-      ) as bool);
+  bool get hasAssetPath =>
+      (super.noSuchMethod(Invocation.getter(#hasAssetPath), returnValue: false)
+          as bool);
 
   @override
-  _i2.EditorVideoType get type => (super.noSuchMethod(
-        Invocation.getter(#type),
-        returnValue: _i2.EditorVideoType.file,
-      ) as _i2.EditorVideoType);
+  _i2.EditorVideoType get type =>
+      (super.noSuchMethod(
+            Invocation.getter(#type),
+            returnValue: _i2.EditorVideoType.file,
+          )
+          as _i2.EditorVideoType);
 
   @override
-  _i2.EditorVideoType get typePreferredFile => (super.noSuchMethod(
-        Invocation.getter(#typePreferredFile),
-        returnValue: _i2.EditorVideoType.file,
-      ) as _i2.EditorVideoType);
+  _i2.EditorVideoType get typePreferredFile =>
+      (super.noSuchMethod(
+            Invocation.getter(#typePreferredFile),
+            returnValue: _i2.EditorVideoType.file,
+          )
+          as _i2.EditorVideoType);
 
   @override
   set byteArray(_i5.Uint8List? value) => super.noSuchMethod(
-        Invocation.setter(
-          #byteArray,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#byteArray, value),
+    returnValueForMissingStub: null,
+  );
 
   @override
   set file(_i6.File? value) => super.noSuchMethod(
-        Invocation.setter(
-          #file,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#file, value),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  _i7.Future<_i5.Uint8List> safeByteArray() => (super.noSuchMethod(
-        Invocation.method(
-          #safeByteArray,
-          [],
-        ),
-        returnValue: _i7.Future<_i5.Uint8List>.value(_i5.Uint8List(0)),
-      ) as _i7.Future<_i5.Uint8List>);
+  _i7.Future<_i5.Uint8List> safeByteArray() =>
+      (super.noSuchMethod(
+            Invocation.method(#safeByteArray, []),
+            returnValue: _i7.Future<_i5.Uint8List>.value(_i5.Uint8List(0)),
+          )
+          as _i7.Future<_i5.Uint8List>);
 
   @override
-  _i7.Future<String> safeFilePath() => (super.noSuchMethod(
-        Invocation.method(
-          #safeFilePath,
-          [],
-        ),
-        returnValue: _i7.Future<String>.value(_i8.dummyValue<String>(
-          this,
-          Invocation.method(
-            #safeFilePath,
-            [],
-          ),
-        )),
-      ) as _i7.Future<String>);
+  _i7.Future<String> safeFilePath() =>
+      (super.noSuchMethod(
+            Invocation.method(#safeFilePath, []),
+            returnValue: _i7.Future<String>.value(
+              _i8.dummyValue<String>(
+                this,
+                Invocation.method(#safeFilePath, []),
+              ),
+            ),
+          )
+          as _i7.Future<String>);
 
   @override
   _i2.EditorVideo copyWith({
@@ -159,39 +135,31 @@ class MockEditorVideo extends _i1.Mock implements _i2.EditorVideo {
     String? assetPath,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #copyWith,
-          [],
-          {
-            #byteArray: byteArray,
-            #file: file,
-            #networkUrl: networkUrl,
-            #assetPath: assetPath,
-          },
-        ),
-        returnValue: _FakeEditorVideo_0(
-          this,
-          Invocation.method(
-            #copyWith,
-            [],
-            {
+            Invocation.method(#copyWith, [], {
               #byteArray: byteArray,
               #file: file,
               #networkUrl: networkUrl,
               #assetPath: assetPath,
-            },
-          ),
-        ),
-      ) as _i2.EditorVideo);
+            }),
+            returnValue: _FakeEditorVideo_0(
+              this,
+              Invocation.method(#copyWith, [], {
+                #byteArray: byteArray,
+                #file: file,
+                #networkUrl: networkUrl,
+                #assetPath: assetPath,
+              }),
+            ),
+          )
+          as _i2.EditorVideo);
 
   @override
-  Map<String, dynamic> toMap() => (super.noSuchMethod(
-        Invocation.method(
-          #toMap,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toMap() =>
+      (super.noSuchMethod(
+            Invocation.method(#toMap, []),
+            returnValue: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }
 
 /// A class which mocks [ThumbnailConfigs].
@@ -203,70 +171,73 @@ class MockThumbnailConfigs extends _i1.Mock implements _i4.ThumbnailConfigs {
   }
 
   @override
-  List<Duration> get timestamps => (super.noSuchMethod(
-        Invocation.getter(#timestamps),
-        returnValue: <Duration>[],
-      ) as List<Duration>);
+  List<Duration> get timestamps =>
+      (super.noSuchMethod(
+            Invocation.getter(#timestamps),
+            returnValue: <Duration>[],
+          )
+          as List<Duration>);
 
   @override
-  String get id => (super.noSuchMethod(
-        Invocation.getter(#id),
-        returnValue: _i8.dummyValue<String>(
-          this,
-          Invocation.getter(#id),
-        ),
-      ) as String);
+  String get id =>
+      (super.noSuchMethod(
+            Invocation.getter(#id),
+            returnValue: _i8.dummyValue<String>(this, Invocation.getter(#id)),
+          )
+          as String);
 
   @override
-  _i2.EditorVideo get video => (super.noSuchMethod(
-        Invocation.getter(#video),
-        returnValue: _FakeEditorVideo_0(
-          this,
-          Invocation.getter(#video),
-        ),
-      ) as _i2.EditorVideo);
+  _i2.EditorVideo get video =>
+      (super.noSuchMethod(
+            Invocation.getter(#video),
+            returnValue: _FakeEditorVideo_0(this, Invocation.getter(#video)),
+          )
+          as _i2.EditorVideo);
 
   @override
-  _i3.Size get outputSize => (super.noSuchMethod(
-        Invocation.getter(#outputSize),
-        returnValue: _FakeSize_1(
-          this,
-          Invocation.getter(#outputSize),
-        ),
-      ) as _i3.Size);
+  _i3.Size get outputSize =>
+      (super.noSuchMethod(
+            Invocation.getter(#outputSize),
+            returnValue: _FakeSize_1(this, Invocation.getter(#outputSize)),
+          )
+          as _i3.Size);
 
   @override
-  int get jpegQuality => (super.noSuchMethod(
-        Invocation.getter(#jpegQuality),
-        returnValue: 0,
-      ) as int);
+  int get jpegQuality =>
+      (super.noSuchMethod(Invocation.getter(#jpegQuality), returnValue: 0)
+          as int);
 
   @override
-  _i9.ThumbnailFormat get outputFormat => (super.noSuchMethod(
-        Invocation.getter(#outputFormat),
-        returnValue: _i9.ThumbnailFormat.jpeg,
-      ) as _i9.ThumbnailFormat);
+  _i9.ThumbnailFormat get outputFormat =>
+      (super.noSuchMethod(
+            Invocation.getter(#outputFormat),
+            returnValue: _i9.ThumbnailFormat.jpeg,
+          )
+          as _i9.ThumbnailFormat);
 
   @override
-  _i10.ThumbnailBoxFit get boxFit => (super.noSuchMethod(
-        Invocation.getter(#boxFit),
-        returnValue: _i10.ThumbnailBoxFit.cover,
-      ) as _i10.ThumbnailBoxFit);
+  _i10.ThumbnailBoxFit get boxFit =>
+      (super.noSuchMethod(
+            Invocation.getter(#boxFit),
+            returnValue: _i10.ThumbnailBoxFit.cover,
+          )
+          as _i10.ThumbnailBoxFit);
 
   @override
-  _i7.Stream<_i11.ProgressModel> get progressStream => (super.noSuchMethod(
-        Invocation.getter(#progressStream),
-        returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
-      ) as _i7.Stream<_i11.ProgressModel>);
+  _i7.Stream<_i11.ProgressModel> get progressStream =>
+      (super.noSuchMethod(
+            Invocation.getter(#progressStream),
+            returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
+          )
+          as _i7.Stream<_i11.ProgressModel>);
 
   @override
-  Map<String, dynamic> toMap() => (super.noSuchMethod(
-        Invocation.method(
-          #toMap,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toMap() =>
+      (super.noSuchMethod(
+            Invocation.method(#toMap, []),
+            returnValue: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }
 
 /// A class which mocks [KeyFramesConfigs].
@@ -278,70 +249,70 @@ class MockKeyFramesConfigs extends _i1.Mock implements _i4.KeyFramesConfigs {
   }
 
   @override
-  int get maxOutputFrames => (super.noSuchMethod(
-        Invocation.getter(#maxOutputFrames),
-        returnValue: 0,
-      ) as int);
+  int get maxOutputFrames =>
+      (super.noSuchMethod(Invocation.getter(#maxOutputFrames), returnValue: 0)
+          as int);
 
   @override
-  String get id => (super.noSuchMethod(
-        Invocation.getter(#id),
-        returnValue: _i8.dummyValue<String>(
-          this,
-          Invocation.getter(#id),
-        ),
-      ) as String);
+  String get id =>
+      (super.noSuchMethod(
+            Invocation.getter(#id),
+            returnValue: _i8.dummyValue<String>(this, Invocation.getter(#id)),
+          )
+          as String);
 
   @override
-  _i2.EditorVideo get video => (super.noSuchMethod(
-        Invocation.getter(#video),
-        returnValue: _FakeEditorVideo_0(
-          this,
-          Invocation.getter(#video),
-        ),
-      ) as _i2.EditorVideo);
+  _i2.EditorVideo get video =>
+      (super.noSuchMethod(
+            Invocation.getter(#video),
+            returnValue: _FakeEditorVideo_0(this, Invocation.getter(#video)),
+          )
+          as _i2.EditorVideo);
 
   @override
-  _i3.Size get outputSize => (super.noSuchMethod(
-        Invocation.getter(#outputSize),
-        returnValue: _FakeSize_1(
-          this,
-          Invocation.getter(#outputSize),
-        ),
-      ) as _i3.Size);
+  _i3.Size get outputSize =>
+      (super.noSuchMethod(
+            Invocation.getter(#outputSize),
+            returnValue: _FakeSize_1(this, Invocation.getter(#outputSize)),
+          )
+          as _i3.Size);
 
   @override
-  int get jpegQuality => (super.noSuchMethod(
-        Invocation.getter(#jpegQuality),
-        returnValue: 0,
-      ) as int);
+  int get jpegQuality =>
+      (super.noSuchMethod(Invocation.getter(#jpegQuality), returnValue: 0)
+          as int);
 
   @override
-  _i9.ThumbnailFormat get outputFormat => (super.noSuchMethod(
-        Invocation.getter(#outputFormat),
-        returnValue: _i9.ThumbnailFormat.jpeg,
-      ) as _i9.ThumbnailFormat);
+  _i9.ThumbnailFormat get outputFormat =>
+      (super.noSuchMethod(
+            Invocation.getter(#outputFormat),
+            returnValue: _i9.ThumbnailFormat.jpeg,
+          )
+          as _i9.ThumbnailFormat);
 
   @override
-  _i10.ThumbnailBoxFit get boxFit => (super.noSuchMethod(
-        Invocation.getter(#boxFit),
-        returnValue: _i10.ThumbnailBoxFit.cover,
-      ) as _i10.ThumbnailBoxFit);
+  _i10.ThumbnailBoxFit get boxFit =>
+      (super.noSuchMethod(
+            Invocation.getter(#boxFit),
+            returnValue: _i10.ThumbnailBoxFit.cover,
+          )
+          as _i10.ThumbnailBoxFit);
 
   @override
-  _i7.Stream<_i11.ProgressModel> get progressStream => (super.noSuchMethod(
-        Invocation.getter(#progressStream),
-        returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
-      ) as _i7.Stream<_i11.ProgressModel>);
+  _i7.Stream<_i11.ProgressModel> get progressStream =>
+      (super.noSuchMethod(
+            Invocation.getter(#progressStream),
+            returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
+          )
+          as _i7.Stream<_i11.ProgressModel>);
 
   @override
-  Map<String, dynamic> toMap() => (super.noSuchMethod(
-        Invocation.method(
-          #toMap,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toMap() =>
+      (super.noSuchMethod(
+            Invocation.method(#toMap, []),
+            returnValue: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }
 
 /// A class which mocks [VideoRenderData].
@@ -353,65 +324,75 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
   }
 
   @override
-  String get id => (super.noSuchMethod(
-        Invocation.getter(#id),
-        returnValue: _i8.dummyValue<String>(
-          this,
-          Invocation.getter(#id),
-        ),
-      ) as String);
+  String get id =>
+      (super.noSuchMethod(
+            Invocation.getter(#id),
+            returnValue: _i8.dummyValue<String>(this, Invocation.getter(#id)),
+          )
+          as String);
 
   @override
-  _i4.VideoOutputFormat get outputFormat => (super.noSuchMethod(
-        Invocation.getter(#outputFormat),
-        returnValue: _i4.VideoOutputFormat.mp4,
-      ) as _i4.VideoOutputFormat);
+  _i4.VideoOutputFormat get outputFormat =>
+      (super.noSuchMethod(
+            Invocation.getter(#outputFormat),
+            returnValue: _i4.VideoOutputFormat.mp4,
+          )
+          as _i4.VideoOutputFormat);
 
   @override
-  bool get enableAudio => (super.noSuchMethod(
-        Invocation.getter(#enableAudio),
-        returnValue: false,
-      ) as bool);
+  bool get enableAudio =>
+      (super.noSuchMethod(Invocation.getter(#enableAudio), returnValue: false)
+          as bool);
 
   @override
-  List<_i4.ColorFilter> get colorFilters => (super.noSuchMethod(
-        Invocation.getter(#colorFilters),
-        returnValue: <_i4.ColorFilter>[],
-      ) as List<_i4.ColorFilter>);
+  List<_i4.ColorFilter> get colorFilters =>
+      (super.noSuchMethod(
+            Invocation.getter(#colorFilters),
+            returnValue: <_i4.ColorFilter>[],
+          )
+          as List<_i4.ColorFilter>);
 
   @override
-  List<_i4.VideoAudioTrack> get audioTracks => (super.noSuchMethod(
-        Invocation.getter(#audioTracks),
-        returnValue: <_i4.VideoAudioTrack>[],
-      ) as List<_i4.VideoAudioTrack>);
+  List<_i4.VideoAudioTrack> get audioTracks =>
+      (super.noSuchMethod(
+            Invocation.getter(#audioTracks),
+            returnValue: <_i4.VideoAudioTrack>[],
+          )
+          as List<_i4.VideoAudioTrack>);
 
   @override
-  bool get shouldOptimizeForNetworkUse => (super.noSuchMethod(
-        Invocation.getter(#shouldOptimizeForNetworkUse),
-        returnValue: false,
-      ) as bool);
+  bool get shouldOptimizeForNetworkUse =>
+      (super.noSuchMethod(
+            Invocation.getter(#shouldOptimizeForNetworkUse),
+            returnValue: false,
+          )
+          as bool);
 
   @override
-  bool get imageBytesWithCropping => (super.noSuchMethod(
-        Invocation.getter(#imageBytesWithCropping),
-        returnValue: false,
-      ) as bool);
+  bool get imageBytesWithCropping =>
+      (super.noSuchMethod(
+            Invocation.getter(#imageBytesWithCropping),
+            returnValue: false,
+          )
+          as bool);
 
   @override
-  _i7.Stream<_i11.ProgressModel> get progressStream => (super.noSuchMethod(
-        Invocation.getter(#progressStream),
-        returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
-      ) as _i7.Stream<_i11.ProgressModel>);
+  _i7.Stream<_i11.ProgressModel> get progressStream =>
+      (super.noSuchMethod(
+            Invocation.getter(#progressStream),
+            returnValue: _i7.Stream<_i11.ProgressModel>.empty(),
+          )
+          as _i7.Stream<_i11.ProgressModel>);
 
   @override
-  _i7.Future<Map<String, dynamic>> toAsyncMap() => (super.noSuchMethod(
-        Invocation.method(
-          #toAsyncMap,
-          [],
-        ),
-        returnValue:
-            _i7.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i7.Future<Map<String, dynamic>>);
+  _i7.Future<Map<String, dynamic>> toAsyncMap() =>
+      (super.noSuchMethod(
+            Invocation.method(#toAsyncMap, []),
+            returnValue: _i7.Future<Map<String, dynamic>>.value(
+              <String, dynamic>{},
+            ),
+          )
+          as _i7.Future<Map<String, dynamic>>);
 
   @override
   _i4.VideoRenderData copyWith({
@@ -434,35 +415,7 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
     bool? imageBytesWithCropping,
   }) =>
       (super.noSuchMethod(
-        Invocation.method(
-          #copyWith,
-          [],
-          {
-            #id: id,
-            #qualityConfig: qualityConfig,
-            #outputFormat: outputFormat,
-            #videoSegments: videoSegments,
-            #composition: composition,
-            #imageLayers: imageLayers,
-            #transform: transform,
-            #enableAudio: enableAudio,
-            #startTime: startTime,
-            #endTime: endTime,
-            #colorFilters: colorFilters,
-            #audioTracks: audioTracks,
-            #blur: blur,
-            #bitrate: bitrate,
-            #maxFrameRate: maxFrameRate,
-            #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
-            #imageBytesWithCropping: imageBytesWithCropping,
-          },
-        ),
-        returnValue: _FakeVideoRenderData_2(
-          this,
-          Invocation.method(
-            #copyWith,
-            [],
-            {
+            Invocation.method(#copyWith, [], {
               #id: id,
               #qualityConfig: qualityConfig,
               #outputFormat: outputFormat,
@@ -480,32 +433,48 @@ class MockVideoRenderData extends _i1.Mock implements _i4.VideoRenderData {
               #maxFrameRate: maxFrameRate,
               #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
               #imageBytesWithCropping: imageBytesWithCropping,
-            },
-          ),
-        ),
-      ) as _i4.VideoRenderData);
+            }),
+            returnValue: _FakeVideoRenderData_2(
+              this,
+              Invocation.method(#copyWith, [], {
+                #id: id,
+                #qualityConfig: qualityConfig,
+                #outputFormat: outputFormat,
+                #videoSegments: videoSegments,
+                #composition: composition,
+                #imageLayers: imageLayers,
+                #transform: transform,
+                #enableAudio: enableAudio,
+                #startTime: startTime,
+                #endTime: endTime,
+                #colorFilters: colorFilters,
+                #audioTracks: audioTracks,
+                #blur: blur,
+                #bitrate: bitrate,
+                #maxFrameRate: maxFrameRate,
+                #shouldOptimizeForNetworkUse: shouldOptimizeForNetworkUse,
+                #imageBytesWithCropping: imageBytesWithCropping,
+              }),
+            ),
+          )
+          as _i4.VideoRenderData);
 
   @override
-  Map<String, dynamic> toMap() => (super.noSuchMethod(
-        Invocation.method(
-          #toMap,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toMap() =>
+      (super.noSuchMethod(
+            Invocation.method(#toMap, []),
+            returnValue: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 
   @override
-  String toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: _i8.dummyValue<String>(
-          this,
-          Invocation.method(
-            #toJson,
-            [],
-          ),
-        ),
-      ) as String);
+  String toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: _i8.dummyValue<String>(
+              this,
+              Invocation.method(#toJson, []),
+            ),
+          )
+          as String);
 }


### PR DESCRIPTION
## Summary

Migrates the Android module to Flutter's **built-in Kotlin** (available since Flutter 3.44), dropping the manual Kotlin Gradle Plugin (KGP) apply. This removes the plugin from Flutter's *"plugins that apply Kotlin Gradle Plugin (KGP)"* deprecation warning and keeps it building under **AGP 9+**.

Follows the official [plugin-author migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

## Changes

**`android/build.gradle`**
- Removed `ext.kotlin_version` and the `kotlin-gradle-plugin` classpath (kept the AGP classpath).
- Removed `apply plugin: "kotlin-android"` (kept `com.android.library`).
- Removed the `kotlinOptions { jvmTarget }` block from `android { }`.
- Added a top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }` block, preserving the original JVM 11 target.

**`pubspec.yaml`** — built-in Kotlin requires Flutter 3.44 / Dart 3.12:
- `sdk: '>=3.12.0 <4.0.0'`, `flutter: ">=3.44.0"`
- Version bumped `2.2.4 → 2.3.0` (minor, since the minimum Flutter version is raised).

**`example/android/app/build.gradle.kts`**
- Dropped the app's own `id("kotlin-android")` and `kotlinOptions` block; added the same top-level `kotlin { compilerOptions }` block.
- `example/android/settings.gradle.kts` is left untouched — it keeps `id("org.jetbrains.kotlin.android") … apply false` (2.2.21) for the third-party plugins that still apply KGP.

**`CHANGELOG.md`** — new `## 2.3.0` entry.

## Verification

`flutter build apk --debug` (Flutter 3.44.0) inside `example/` builds successfully, and `pro_video_editor` no longer appears in the KGP deprecation warning. The remaining plugins in that warning (`audioplayers_android`, `package_info_plus`, `pro_image_editor`, `shared_preferences_android`, `video_player_android`, `wakelock_plus`) are third-party and cannot be fixed here.