### PR TITLE
feat: wrap last-segment transition into a seamless loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.0
+- **FEAT**(android, iOS, macOS): A `ClipTransition` on the **last (or only)** `VideoSegment` now wraps back into the first segment, so a single-track render loops seamlessly — e.g. a `dissolve` on one segment cross-dissolves on restart. Overlap types (dissolve/slide/push/wipe) shorten the output by the transition duration and require a single clip longer than 2× the duration (otherwise the wrap is skipped); dip types (fadeToBlack/fadeToWhite) keep the length and dip through the color at the seam. Previously a transition on the last segment was silently ignored.
+
 ## 2.4.0
 - **FIX**(android, iOS, macOS): The render `bitrate` is now enforced as a real maximum instead of being silently ignored (Android transmuxed the source untouched; iOS/macOS picked an `AVAssetExportSession` preset with its own bitrate). A source above the cap is re-encoded down to it, a source already within it keeps a lossless fast path (transmux / passthrough), and a `null` bitrate is unchanged. Note: an over-cap source that used to export losslessly is now re-encoded.
 

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/RenderVideo.kt
@@ -119,7 +119,10 @@ class RenderVideo(private val context: Context) {
 
         val needsPreTranscode = needsPreTranscoding(config)
         val needsPreReverse = config.videoClips.any { it.reverseVideo }
-        val needsPreTransitions = config.videoClips.size > 1 &&
+        // An overlap transition on a non-last clip blends into the next clip; on
+        // the last (or only) clip it wraps into the first for a seamless loop.
+        // Both are baked by [preRenderTransitions], so either needs the stage.
+        val needsPreTransitions =
                 config.videoClips.any { it.transition?.isOverlap == true }
 
         // Progress split across the slow pre-render stages and the transformer.
@@ -350,9 +353,15 @@ class RenderVideo(private val context: Context) {
         collectPath: (String) -> Unit,
         onProgress: (Float) -> Unit,
     ): List<VideoClip> {
-        if (clips.size < 2) return clips
-        val total = (0 until clips.size - 1)
-            .count { clips[it].transition?.isOverlap == true }
+        // An overlap transition on the last/only clip loops back into the first
+        // clip (seamless loop). Captured before the between-clip pass clears it.
+        val wrapTransition = clips.lastOrNull()?.transition?.takeIf {
+            it.isOverlap && !clips.last().reverseVideo && !clips.first().reverseVideo
+        }
+        val betweenCount = if (clips.size >= 2) {
+            (0 until clips.size - 1).count { clips[it].transition?.isOverlap == true }
+        } else 0
+        val total = betweenCount + (if (wrapTransition != null) 1 else 0)
         if (total == 0) return clips
 
         val work = clips.toMutableList()
@@ -446,6 +455,92 @@ class RenderVideo(private val context: Context) {
             doneCount++
             onProgress((doneCount.toFloat() / total).coerceIn(0f, 1f))
             i++
+        }
+
+        // Wrap pass: render the last clip's tail dissolving into the first
+        // clip's head and append it, so any looping player restarts seamlessly.
+        // Overlap transitions between clips already rewrote `result`, so its
+        // first/last entries are the original first/last clips (blends only ever
+        // sit between them).
+        if (wrapTransition != null && !shouldStop.get() && result.isNotEmpty()) {
+            val lastIdx = result.size - 1
+            val first = result[0]
+            val last = result[lastIdx]
+            val singleClip = lastIdx == 0
+
+            val firstStart = first.startUs ?: 0L
+            val firstEnd = first.endUs ?: MediaInfoExtractor.getVideoDuration(first.inputPath)
+            val lastStart = last.startUs ?: 0L
+            val lastEnd = last.endUs ?: MediaInfoExtractor.getVideoDuration(last.inputPath)
+
+            // Single-clip loops carve the head and tail from the same source, so
+            // they need the stricter head+tail<L guard; multi-clip loops keep two
+            // independent sources and reuse the ordinary overlap geometry.
+            val plan = if (singleClip) {
+                ClipTransitionGeometry.planWrap(
+                    sourceDurationUs = lastEnd - lastStart,
+                    transitionDurationUs = wrapTransition.durationUs,
+                    speed = last.playbackSpeed,
+                )
+            } else {
+                ClipTransitionGeometry.planOverlap(
+                    outgoingSourceDurationUs = lastEnd - lastStart,
+                    incomingSourceDurationUs = firstEnd - firstStart,
+                    transitionDurationUs = wrapTransition.durationUs,
+                    outgoingSpeed = last.playbackSpeed,
+                    incomingSpeed = first.playbackSpeed,
+                )
+            }
+
+            if (plan == null) {
+                Log.w(RENDER_TAG, "Loop wrap: not enough content, seamless loop skipped")
+            } else {
+                val tailSrc = plan.outgoingTailSourceUs
+                val headSrc = plan.incomingHeadSourceUs
+                val rendered = ClipTransitionRenderer.renderSync(
+                    context = context,
+                    outgoingPath = last.inputPath,
+                    outTailStartUs = lastEnd - tailSrc,
+                    outTailEndUs = lastEnd,
+                    incomingPath = first.inputPath,
+                    inHeadStartUs = firstStart,
+                    inHeadEndUs = firstStart + headSrc,
+                    outputDurationUs = plan.outputDurationUs,
+                    type = wrapTransition.type,
+                    direction = wrapTransition.direction,
+                    curve = wrapTransition.curve,
+                    includeAudio = enableAudio &&
+                            (last.volume ?: 1.0f) > 0f && (first.volume ?: 1.0f) > 0f,
+                    onProgress = { f ->
+                        onProgress(((doneCount + f) / total).coerceIn(0f, 1f))
+                    },
+                )
+                if (rendered != null) {
+                    collectPath(rendered.outputPath)
+                    if (singleClip) {
+                        // Trim both ends of the one clip; the carved head/tail
+                        // moved into the appended blend.
+                        result[0] = first.copy(
+                            startUs = firstStart + headSrc,
+                            endUs = lastEnd - tailSrc,
+                        )
+                    } else {
+                        result[0] = first.copy(startUs = firstStart + headSrc)
+                        result[lastIdx] = last.copy(endUs = lastEnd - tailSrc)
+                    }
+                    result.add(
+                        VideoClip(
+                            inputPath = rendered.outputPath,
+                            startUs = 0L,
+                            endUs = rendered.durationUs.takeIf { it > 0 },
+                        )
+                    )
+                } else {
+                    Log.w(RENDER_TAG, "Loop wrap render failed, seamless loop skipped")
+                }
+            }
+            doneCount++
+            onProgress((doneCount.toFloat() / total).coerceIn(0f, 1f))
         }
 
         return result

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionGeometry.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionGeometry.kt
@@ -89,6 +89,46 @@ internal object ClipTransitionGeometry {
     }
 
     /**
+     * Resolves the overlap geometry for a **seamless loop wrap** where the
+     * outgoing tail and incoming head are carved from the *same* single clip
+     * (its whole start-to-end range).
+     *
+     * Unlike [planOverlap] the two sides share one source, so the head
+     * `[0, head)` and tail `[L - tail, L)` must not overlap — a positive middle
+     * body must remain (`head + tail < sourceDuration`). Because both sides are
+     * the same clip they also share its playback [speed], so `head == tail`.
+     * Returns `null` when no body would remain (caller falls back to no wrap).
+     *
+     * Multi-clip loops (last clip ≠ first clip) use [planOverlap] instead, since
+     * each side then keeps its own independent source.
+     *
+     * @param sourceDurationUs Trimmed source duration of the single looping clip.
+     * @param transitionDurationUs Requested wrap duration in output time.
+     * @param speed The clip's playback speed (null/<=0 → 1×).
+     */
+    fun planWrap(
+        sourceDurationUs: Long,
+        transitionDurationUs: Long,
+        speed: Float?,
+    ): OverlapPlan? {
+        if (sourceDurationUs <= 0L) return null
+        val s = validSpeedOrOne(speed)
+        val outputDur = sourceDurationUs / s
+        // Both sides consume `dOut * speed` of the same source; head + tail must
+        // leave a positive middle body, so dOut is capped just below outputDur/2.
+        val dOut = minOf(transitionDurationUs.toDouble(), outputDur / 2.0)
+        if (dOut <= 0.0) return null
+        val outputDurationUs = dOut.roundToLong()
+        val sideSourceUs = (dOut * s).roundToLong()
+        if (outputDurationUs <= 0L || sourceDurationUs - 2L * sideSourceUs <= 0L) return null
+        return OverlapPlan(
+            outputDurationUs = outputDurationUs,
+            outgoingTailSourceUs = sideSourceUs,
+            incomingHeadSourceUs = sideSourceUs,
+        )
+    }
+
+    /**
      * Number of OUTPUT frames the blended clip should emit so the decoded
      * outgoing tail ([decodedTailFrames] frames covering [tailSourceDurationUs]
      * of source) is replayed across [outputDurationUs] of output. When the

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/VideoSequenceBuilder.kt
@@ -497,17 +497,28 @@ class VideoSequenceBuilder(
      * `duration/2`, and clip *i+1* fades in from the color over its first
      * `duration/2`. Overlap transitions (dissolve/slide/push/wipe) are handled
      * separately by [ClipTransitionRenderer] and never reach this method.
+     *
+     * A dip transition on the **last** clip is the loop wrap: it fades that clip
+     * out to the color at the very end AND fades the **first** clip in from the
+     * color at the very start, so a looping player dips through the color at the
+     * restart seam. (Overlap wraps are baked into an appended blend clip by
+     * [ClipTransitionRenderer], so by the time they reach here the last entry is
+     * that blend and carries no transition.)
      */
     private fun computeFadeInfos(clips: List<VideoClip>): List<ClipFadeInfo?> {
         return clips.indices.map { i ->
             val clip = clips[i]
             val prev = clips.getOrNull(i - 1)
+            // The first clip has no previous clip; its fade-in is seeded by the
+            // loop wrap (the last clip's dip transition) instead.
+            val incomingTransition =
+                prev?.transition ?: if (i == 0) clips.lastOrNull()?.transition else null
 
             val outgoingColor = dipColorFor(clip.transition)
-            val incomingColor = dipColorFor(prev?.transition)
+            val incomingColor = dipColorFor(incomingTransition)
 
             val outgoingUs = if (outgoingColor != null) clip.transition!!.durationUs else 0L
-            val incomingUs = if (incomingColor != null) prev!!.transition!!.durationUs else 0L
+            val incomingUs = if (incomingColor != null) incomingTransition!!.durationUs else 0L
 
             if (outgoingColor == null && incomingColor == null) {
                 null
@@ -518,7 +529,7 @@ class VideoSequenceBuilder(
                 val curve = if (outgoingColor != null) {
                     clip.transition!!.curve
                 } else {
-                    prev!!.transition!!.curve
+                    incomingTransition!!.curve
                 }
                 ClipFadeInfo(
                     clipDurationUs = outDur,

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -25,6 +25,10 @@ data class TransitionConfig(
         get() = type == "dissolve" || type == "slide" || type == "push" ||
                 type == "wipe"
 
+    /** True when this transition dips through a solid color (no overlap). */
+    val isDip: Boolean
+        get() = type == "fadeToBlack" || type == "fadeToWhite"
+
     companion object {
         fun fromMap(map: Map<String, Any?>): TransitionConfig {
             return TransitionConfig(
@@ -46,7 +50,9 @@ data class TransitionConfig(
  * @property volume Volume multiplier for this clip (null = unchanged, 0.0=mute, 1.0=original)
  * @property playbackSpeed Speed multiplier for this clip (null = unchanged, 0.5=half, 2.0=double)
  * @property reverseVideo Whether to render this clip backwards
- * @property transition Transition into the next clip (null = hard cut). Ignored on the last clip.
+ * @property transition Transition into the next clip (null = hard cut). On the
+ *  **last** clip it wraps into the first clip, making the track loop seamlessly
+ *  (see the wrap handling in RenderVideo/VideoSequenceBuilder).
  */
 data class VideoClip(
     val inputPath: String,

--- a/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
+++ b/android/src/main/kotlin/ch/waio/pro_video_editor/src/features/render/models/RenderConfig.kt
@@ -25,10 +25,6 @@ data class TransitionConfig(
         get() = type == "dissolve" || type == "slide" || type == "push" ||
                 type == "wipe"
 
-    /** True when this transition dips through a solid color (no overlap). */
-    val isDip: Boolean
-        get() = type == "fadeToBlack" || type == "fadeToWhite"
-
     companion object {
         fun fromMap(map: Map<String, Any?>): TransitionConfig {
             return TransitionConfig(

--- a/android/src/test/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionGeometryTest.kt
+++ b/android/src/test/kotlin/ch/waio/pro_video_editor/src/features/render/helpers/ClipTransitionGeometryTest.kt
@@ -119,6 +119,79 @@ internal class ClipTransitionGeometryTest {
     }
 
     @Test
+    fun planWrap_carvesEqualHeadAndTailAtOneX() {
+        // A 4s clip with a 500ms wrap: head and tail each consume 500ms of the
+        // same source, leaving a 3s middle body.
+        val plan = ClipTransitionGeometry.planWrap(
+            sourceDurationUs = 4_000_000L,
+            transitionDurationUs = 500_000L,
+            speed = null,
+        )
+        assertEquals(
+            ClipTransitionGeometry.OverlapPlan(500_000L, 500_000L, 500_000L),
+            plan,
+        )
+    }
+
+    @Test
+    fun planWrap_consumesDoubleSourceAtDoubleSpeed() {
+        // 300ms of OUTPUT at 2× consumes 600ms of source on each side; a 4s clip
+        // keeps a 2.8s middle body.
+        val plan = ClipTransitionGeometry.planWrap(
+            sourceDurationUs = 4_000_000L,
+            transitionDurationUs = 300_000L,
+            speed = 2.0f,
+        )
+        assertEquals(
+            ClipTransitionGeometry.OverlapPlan(300_000L, 600_000L, 600_000L),
+            plan,
+        )
+    }
+
+    @Test
+    fun planWrap_returnsNullWhenHeadAndTailWouldOverlap() {
+        // A 1s clip with a 600ms wrap: head + tail (1200ms) exceed the source,
+        // so no middle body remains → null (no wrap, hard restart).
+        assertNull(
+            ClipTransitionGeometry.planWrap(
+                sourceDurationUs = 1_000_000L,
+                transitionDurationUs = 600_000L,
+                speed = null,
+            )
+        )
+    }
+
+    @Test
+    fun planWrap_returnsNullAtExactlyHalf() {
+        // A wrap of exactly half the clip leaves a zero-length body → null.
+        assertNull(
+            ClipTransitionGeometry.planWrap(
+                sourceDurationUs = 1_000_000L,
+                transitionDurationUs = 500_000L,
+                speed = null,
+            )
+        )
+    }
+
+    @Test
+    fun planWrap_returnsNullForInvalidDurations() {
+        assertNull(
+            ClipTransitionGeometry.planWrap(
+                sourceDurationUs = 0L,
+                transitionDurationUs = 100_000L,
+                speed = null,
+            )
+        )
+        assertNull(
+            ClipTransitionGeometry.planWrap(
+                sourceDurationUs = 1_000_000L,
+                transitionDurationUs = 0L,
+                speed = null,
+            )
+        )
+    }
+
+    @Test
     fun outputFrameCount_keepsFramesAtOneX() {
         // 333ms tail at 1× → same frame count, played at the same rate.
         assertEquals(

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
@@ -150,10 +150,10 @@ class RenderVideo {
 
         // Pre-render overlap clip transitions (dissolve/slide/push/wipe) into
         // short blended clips spliced between the neighbours, so the main
-        // composition still sees plain forward clips.
-        if workingConfig.videoClips.count > 1,
-          workingConfig.videoClips.contains(where: { $0.transition?.isOverlap == true })
-        {
+        // composition still sees plain forward clips. An overlap transition on
+        // the last/only clip wraps into the first clip for a seamless loop and
+        // is baked the same way, so a single clip can also need this stage.
+        if workingConfig.videoClips.contains(where: { $0.transition?.isOverlap == true }) {
           let (newClips, urls) = await preRenderTransitions(
             clips: workingConfig.videoClips,
             enableAudio: workingConfig.enableAudio,
@@ -534,6 +534,15 @@ class RenderVideo {
   private static func preRenderTransitions(
     clips: [VideoClip], enableAudio: Bool, outputFormat: String
   ) async -> ([VideoClip], [URL]) {
+    // An overlap transition on the last/only clip loops back into the first clip
+    // (seamless loop). Captured before the between-clip pass clears it.
+    let wrapTransition: ClipTransitionConfig? = {
+      guard let t = clips.last?.transition, t.isOverlap,
+        !(clips.last?.reverseVideo ?? false), !(clips.first?.reverseVideo ?? false)
+      else { return nil }
+      return t
+    }()
+
     var work = clips
     var result: [VideoClip] = []
     var urls: [URL] = []
@@ -624,6 +633,92 @@ class RenderVideo {
         result.append(clearedOverlap(current))
       }
       i += 1
+    }
+
+    // Wrap pass: render the last clip's tail dissolving into the first clip's
+    // head and append it, so any looping player restarts seamlessly. The
+    // between-clip pass only inserts blends *between* clips, so result's first
+    // and last entries are still the original first/last clips.
+    if let wrap = wrapTransition, !result.isEmpty {
+      let lastIdx = result.count - 1
+      let first = result[0]
+      let last = result[lastIdx]
+      let singleClip = lastIdx == 0
+
+      let firstStart = first.startUs ?? 0
+      let lastStart = last.startUs ?? 0
+      let firstEnd: Int64
+      if let e = first.endUs {
+        firstEnd = e
+      } else {
+        firstEnd = await clipDurationUs(first.inputPath)
+      }
+      let lastEnd: Int64
+      if let e = last.endUs {
+        lastEnd = e
+      } else {
+        lastEnd = await clipDurationUs(last.inputPath)
+      }
+
+      // Single-clip loops carve head and tail from the same source, so they need
+      // the stricter head+tail<L guard; multi-clip loops keep two independent
+      // sources and reuse the ordinary overlap geometry.
+      let plan: ClipTransitionGeometry.OverlapPlan? =
+        singleClip
+        ? ClipTransitionGeometry.planWrap(
+          sourceDurationUs: lastEnd - lastStart,
+          transitionDurationUs: wrap.durationUs,
+          speed: last.playbackSpeed)
+        : ClipTransitionGeometry.planOverlap(
+          outgoingSourceDurationUs: lastEnd - lastStart,
+          incomingSourceDurationUs: firstEnd - firstStart,
+          transitionDurationUs: wrap.durationUs,
+          outgoingSpeed: last.playbackSpeed,
+          incomingSpeed: first.playbackSpeed)
+
+      if let plan = plan {
+        let tailSrc = plan.outgoingTailSourceUs
+        let headSrc = plan.incomingHeadSourceUs
+        let includeAudio =
+          enableAudio && (last.volume ?? 1.0) > 0 && (first.volume ?? 1.0) > 0
+        let rendered = await ClipTransitionRenderer.render(
+          outgoingPath: last.inputPath,
+          outTailStartUs: lastEnd - tailSrc, outTailEndUs: lastEnd,
+          incomingPath: first.inputPath,
+          inHeadStartUs: firstStart, inHeadEndUs: firstStart + headSrc,
+          outputDurationUs: plan.outputDurationUs,
+          type: wrap.type, direction: wrap.direction, curve: wrap.curve,
+          includeAudio: includeAudio, outputFormat: outputFormat)
+
+        if let rendered = rendered {
+          urls.append(rendered.outputURL)
+          if singleClip {
+            // Trim both ends of the one clip; the carved head/tail moved into
+            // the appended blend.
+            result[0] = VideoClip(
+              inputPath: first.inputPath, startUs: firstStart + headSrc,
+              endUs: lastEnd - tailSrc, volume: first.volume,
+              playbackSpeed: first.playbackSpeed, reverseVideo: false, transition: nil)
+          } else {
+            result[0] = VideoClip(
+              inputPath: first.inputPath, startUs: firstStart + headSrc,
+              endUs: first.endUs, volume: first.volume,
+              playbackSpeed: first.playbackSpeed, reverseVideo: false,
+              transition: first.transition)
+            result[lastIdx] = VideoClip(
+              inputPath: last.inputPath, startUs: last.startUs, endUs: lastEnd - tailSrc,
+              volume: last.volume, playbackSpeed: last.playbackSpeed,
+              reverseVideo: false, transition: nil)
+          }
+          result.append(
+            VideoClip(
+              inputPath: rendered.outputURL.path, startUs: 0, endUs: rendered.durationUs))
+        } else {
+          PluginLog.print("⚠️ Loop wrap render failed; seamless loop skipped")
+        }
+      } else {
+        PluginLog.print("⚠️ Loop wrap: not enough content; seamless loop skipped")
+      }
     }
 
     return (result, urls)

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/RenderVideo.swift
@@ -647,12 +647,6 @@ class RenderVideo {
 
       let firstStart = first.startUs ?? 0
       let lastStart = last.startUs ?? 0
-      let firstEnd: Int64
-      if let e = first.endUs {
-        firstEnd = e
-      } else {
-        firstEnd = await clipDurationUs(first.inputPath)
-      }
       let lastEnd: Int64
       if let e = last.endUs {
         lastEnd = e
@@ -663,18 +657,26 @@ class RenderVideo {
       // Single-clip loops carve head and tail from the same source, so they need
       // the stricter head+tail<L guard; multi-clip loops keep two independent
       // sources and reuse the ordinary overlap geometry.
-      let plan: ClipTransitionGeometry.OverlapPlan? =
-        singleClip
-        ? ClipTransitionGeometry.planWrap(
+      let plan: ClipTransitionGeometry.OverlapPlan?
+      if singleClip {
+        plan = ClipTransitionGeometry.planWrap(
           sourceDurationUs: lastEnd - lastStart,
           transitionDurationUs: wrap.durationUs,
           speed: last.playbackSpeed)
-        : ClipTransitionGeometry.planOverlap(
+      } else {
+        let firstEnd: Int64
+        if let e = first.endUs {
+          firstEnd = e
+        } else {
+          firstEnd = await clipDurationUs(first.inputPath)
+        }
+        plan = ClipTransitionGeometry.planOverlap(
           outgoingSourceDurationUs: lastEnd - lastStart,
           incomingSourceDurationUs: firstEnd - firstStart,
           transitionDurationUs: wrap.durationUs,
           outgoingSpeed: last.playbackSpeed,
           incomingSpeed: first.playbackSpeed)
+      }
 
       if let plan = plan {
         let tailSrc = plan.outgoingTailSourceUs

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ClipTransitionGeometry.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/ClipTransitionGeometry.swift
@@ -67,6 +67,40 @@ internal enum ClipTransitionGeometry {
     )
   }
 
+  /// Resolves the overlap geometry for a **seamless loop wrap** where the
+  /// outgoing tail and incoming head are carved from the *same* single clip
+  /// (its whole start-to-end range).
+  ///
+  /// Unlike `planOverlap` the two sides share one source, so the head
+  /// `[0, head)` and tail `[L - tail, L)` must not overlap — a positive middle
+  /// body must remain (`head + tail < sourceDuration`). Because both sides are
+  /// the same clip they also share its playback speed, so `head == tail`.
+  /// Returns `nil` when no body would remain (caller falls back to no wrap).
+  ///
+  /// Multi-clip loops (last clip != first clip) use `planOverlap` instead, since
+  /// each side then keeps its own independent source.
+  static func planWrap(
+    sourceDurationUs: Int64,
+    transitionDurationUs: Int64,
+    speed: Float?
+  ) -> OverlapPlan? {
+    guard sourceDurationUs > 0 else { return nil }
+    let s = validSpeedOrOne(speed)
+    let outputDur = Double(sourceDurationUs) / s
+    // Both sides consume `dOut * speed` of the same source; head + tail must
+    // leave a positive middle body, so dOut is capped just below outputDur/2.
+    let dOut = min(Double(transitionDurationUs), outputDur / 2.0)
+    guard dOut > 0 else { return nil }
+    let outputDurationUs = Int64(dOut.rounded())
+    let sideSourceUs = Int64((dOut * s).rounded())
+    guard outputDurationUs > 0, sourceDurationUs - 2 * sideSourceUs > 0 else { return nil }
+    return OverlapPlan(
+      outputDurationUs: outputDurationUs,
+      outgoingTailSourceUs: sideSourceUs,
+      incomingHeadSourceUs: sideSourceUs
+    )
+  }
+
   private static func validSpeedOrOne(_ speed: Float?) -> Double {
     if let speed = speed, speed > 0 { return Double(speed) }
     return 1.0

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/CompositionBuilder.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/helpers/CompositionBuilder.swift
@@ -234,6 +234,41 @@ internal class CompositionBuilder {
           toWhite: toWhite
         ))
     }
+
+    // Loop wrap: a dip transition on the LAST clip dips the restart seam — fade
+    // the last clip out to the color at the very end and the first clip in from
+    // the color at the very start, so a looping player dips through the color on
+    // restart. (Overlap wraps are baked into an appended blend clip, so the last
+    // clip here carries no dip transition for them.)
+    if let wrap = videoClips.last?.transition, wrap.isDip,
+      let lastInstr = clipInstructions.last, let firstInstr = clipInstructions.first
+    {
+      let toWhite = wrap.type == "fadeToWhite"
+      let dHalfUs = wrap.durationUs / 2
+      let lastStartUs = Int64(CMTimeGetSeconds(lastInstr.timeRange.start) * 1_000_000)
+      let lastEndUs = Int64(CMTimeGetSeconds(CMTimeRangeGetEnd(lastInstr.timeRange)) * 1_000_000)
+      let firstStartUs = Int64(CMTimeGetSeconds(firstInstr.timeRange.start) * 1_000_000)
+      let firstEndUs = Int64(CMTimeGetSeconds(CMTimeRangeGetEnd(firstInstr.timeRange)) * 1_000_000)
+
+      // Fade the last clip out to the color at the very end.
+      windows.append(
+        FadeWindow(
+          startUs: max(lastStartUs, lastEndUs - dHalfUs),
+          endUs: lastEndUs,
+          fadeIn: false,
+          curve: wrap.curve,
+          toWhite: toWhite
+        ))
+      // Fade the first clip in from the color at the very start.
+      windows.append(
+        FadeWindow(
+          startUs: firstStartUs,
+          endUs: min(firstEndUs, firstStartUs + dHalfUs),
+          fadeIn: true,
+          curve: wrap.curve,
+          toWhite: toWhite
+        ))
+    }
     return windows
   }
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/RenderConfig.swift
@@ -56,6 +56,11 @@ struct ClipTransitionConfig {
     type == "dissolve" || type == "slide" || type == "push" || type == "wipe"
   }
 
+  /// True when this transition dips through a solid color (no overlap).
+  var isDip: Bool {
+    type == "fadeToBlack" || type == "fadeToWhite"
+  }
+
   static func fromArguments(_ args: [String: Any]?) -> ClipTransitionConfig? {
     guard let args = args,
       let type = args["type"] as? String,

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/VideoClip.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/render/models/VideoClip.swift
@@ -8,7 +8,9 @@ internal struct VideoClip: Sendable {
   let volume: Float?
   let playbackSpeed: Float?
   let reverseVideo: Bool
-  /// Transition into the next clip (nil = hard cut). Ignored on the last clip.
+  /// Transition into the next clip (nil = hard cut). On the **last** clip it
+  /// wraps into the first clip, making the track loop seamlessly (handled by the
+  /// wrap pass in RenderVideo / the dip windows in CompositionBuilder).
   let transition: ClipTransitionConfig?
   /// Start position on the layer timeline in microseconds (composition only).
   /// `nil` = right after the previous clip on the same layer.

--- a/example/integration_test/clip_transition_test.dart
+++ b/example/integration_test/clip_transition_test.dart
@@ -338,12 +338,12 @@ void main() {
   });
 
   // ───────────────────────────────────────────────────────────
-  // A transition on the last/only segment is a no-op
+  // Loop wrap — a transition on the last/only segment wraps into the first
   // ───────────────────────────────────────────────────────────
-  group('Clip transitions — edge cases', () {
-    testWidgets('transition on the only segment is ignored', (_) async {
+  group('Clip transitions — loop wrap', () {
+    testWidgets('overlap on the only segment shortens like a wrap', (_) async {
       final meta = await render(
-        'last-segment-ignored',
+        'single-segment-loop-wrap',
         VideoRenderData(
           outputFormat: VideoOutputFormat.mp4,
           videoSegments: [
@@ -359,11 +359,65 @@ void main() {
           ],
         ),
       );
-      // No following clip → transition ignored → full clip duration.
+      // The end cross-dissolves into the start → output shortened by the
+      // overlap duration, exactly like an overlap between two clips.
+      expectDuration(
+        meta,
+        clipDuration - overlapDuration,
+        'a dissolve on the only segment must wrap and shorten the output',
+      );
+    });
+
+    testWidgets('dip on the only segment keeps the duration', (_) async {
+      final meta = await render(
+        'single-segment-dip-wrap',
+        VideoRenderData(
+          outputFormat: VideoOutputFormat.mp4,
+          videoSegments: [
+            VideoSegment(
+              video: inputVideo,
+              startTime: Duration.zero,
+              endTime: clipDuration,
+              transition: const ClipTransition(
+                type: ClipTransitionType.fadeToBlack,
+                duration: dipDuration,
+              ),
+            ),
+          ],
+        ),
+      );
+      // Dip wrap fades out at the end and in at the start → length unchanged.
       expectDuration(
         meta,
         clipDuration,
-        'transition on the last segment must not change the duration',
+        'a dip wrap must not change the duration',
+      );
+    });
+
+    testWidgets('wrap is skipped when the clip is too short', (_) async {
+      // A 1s clip with an 800ms wrap: head + tail (1.6s) exceed the source, so
+      // no middle body remains → wrap skipped → full clip duration.
+      final meta = await render(
+        'single-segment-wrap-too-short',
+        VideoRenderData(
+          outputFormat: VideoOutputFormat.mp4,
+          videoSegments: [
+            VideoSegment(
+              video: inputVideo,
+              startTime: Duration.zero,
+              endTime: const Duration(seconds: 1),
+              transition: const ClipTransition(
+                type: ClipTransitionType.dissolve,
+                duration: overlapDuration,
+              ),
+            ),
+          ],
+        ),
+      );
+      expectDuration(
+        meta,
+        const Duration(seconds: 1),
+        'too-short clip must fall back to no wrap (full duration)',
       );
     });
   });

--- a/example/lib/features/render/video_renderer_page.dart
+++ b/example/lib/features/render/video_renderer_page.dart
@@ -498,6 +498,30 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
     await _renderVideo(data);
   }
 
+  /// Seamless loop: a single clip whose end cross-dissolves into its start.
+  ///
+  /// The transition on the last (here: only) segment wraps back into the first
+  /// segment, so a looping player restarts without a visible cut. The output is
+  /// shortened by the 800ms overlap.
+  Future<void> _clipLoopWrap() async {
+    var data = VideoRenderData(
+      videoSegments: [
+        VideoSegment(
+          video: _video,
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 5),
+          transition: const ClipTransition(
+            type: ClipTransitionType.dissolve,
+            duration: Duration(milliseconds: 800),
+            curve: AnimationCurve.easeInOut,
+          ),
+        ),
+      ],
+    );
+
+    await _renderVideo(data);
+  }
+
   /// Fade-to-black (dip-to-black) transition between two split clips.
   ///
   /// The outgoing clip dips to black and the incoming rises from black at the
@@ -2188,6 +2212,12 @@ class _VideoRendererPageState extends State<VideoRendererPage> {
           leading: const Icon(Icons.gradient_outlined),
           title: const Text('Dissolve'),
           subtitle: const Text('800ms cross-dissolve between two clips'),
+        ),
+        ListTile(
+          onTap: _clipLoopWrap,
+          leading: const Icon(Icons.loop_outlined),
+          title: const Text('Loop wrap (dissolve)'),
+          subtitle: const Text('One clip: end cross-dissolves into the start'),
         ),
         ListTile(
           onTap: _clipFadeToBlack,

--- a/lib/core/models/video/clip_transition_model.dart
+++ b/lib/core/models/video/clip_transition_model.dart
@@ -68,8 +68,14 @@ enum ClipTransitionDirection {
 ///
 /// Assign this to [VideoSegment.transition] to describe how that clip
 /// transitions **into the following clip** (dissolve, fade-to-black, wipe,
-/// etc.). The transition is ignored on the last segment (there is no following
-/// clip).
+/// etc.).
+///
+/// On the **last (or only)** segment there is no following clip, so the
+/// transition **wraps back into the first segment** and the track loops
+/// seamlessly — e.g. a [ClipTransitionType.dissolve] on a single segment makes
+/// a looping player cross-dissolve on restart. See [VideoSegment.transition]
+/// for the exact wrap behavior (overlap types shorten the output; dip types dip
+/// through the color at the seam).
 ///
 /// Clip transitions are currently supported on **Android** and
 /// **iOS/macOS** only. Other platforms ignore the field.

--- a/lib/core/models/video/video_render_data_model.dart
+++ b/lib/core/models/video/video_render_data_model.dart
@@ -143,6 +143,10 @@ class VideoRenderData {
   /// provided. Use this field for a single track of concatenated clips, and
   /// [composition] when layers overlap in time or space.
   ///
+  /// A [ClipTransition] on the **last (or only)** segment wraps back into the
+  /// first segment, making the track loop seamlessly (e.g. a dissolve on a
+  /// single segment cross-dissolves on restart). See [VideoSegment.transition].
+  ///
   /// **Example:**
   /// ```dart
   /// videoSegments: [

--- a/lib/core/models/video/video_segment_model.dart
+++ b/lib/core/models/video/video_segment_model.dart
@@ -85,8 +85,18 @@ class VideoSegment {
   /// The transition played between this clip and the **next** clip.
   ///
   /// Describes how this segment transitions into the following segment (e.g. a
-  /// dissolve or fade-to-black). The transition is ignored on the last segment
-  /// because there is no following clip.
+  /// dissolve or fade-to-black).
+  ///
+  /// **On the last (or only) segment** there is no following clip, so the
+  /// transition instead **wraps back into the first segment**, turning the
+  /// whole track into a seamless loop: the end dissolves (or dips) into the
+  /// beginning, so a looping player restarts without a visible cut. For overlap
+  /// transitions (dissolve/slide/push/wipe) the output is shortened by the
+  /// transition duration — exactly like an overlap transition between two clips
+  /// — and for a single segment the clip must be longer than twice the
+  /// transition duration (otherwise the wrap is skipped and the loop restarts
+  /// hard). Dip transitions (fadeToBlack/fadeToWhite) keep the duration and dip
+  /// through the color at the restart seam.
   ///
   /// Currently supported on Android and iOS/macOS only; other platforms
   /// ignore this field.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.4.0
+version: 2.5.0
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Summary

A `ClipTransition` on the **last (or only)** `VideoSegment` now wraps back into the first segment instead of being ignored, turning a single-track render into a seamless loop — e.g. a `dissolve` on one segment cross-dissolves on restart (motivating case: a video that plays in a loop).

- **Overlap** types (dissolve / slide / push / wipe): the end blends into the beginning, baked as a real overlap. The output is shortened by the transition duration; a single clip must be longer than 2× the duration (otherwise the wrap is skipped and the loop restarts hard).
- **Dip** types (fadeToBlack / fadeToWhite): the length is unchanged and the seam dips through the color (last clip fades out at the end, first clip fades in at the start).

Previously a transition on the last segment was silently ignored.

```dart
// One video, dissolve on restart:
videoSegments: [
  VideoSegment(
    video: myVideo,
    transition: ClipTransition(type: ClipTransitionType.dissolve, duration: ...),
  ),
]
```

## Implementation

- `ClipTransitionGeometry.planWrap` (Android + Darwin): single-clip geometry with the stricter `head + tail < L` guard so the carved head and tail can't overlap.
- Wrap orchestration in `RenderVideo.preRenderTransitions` (both platforms): the last clip's tail blends into the first clip's head, the blend is appended, and the first clip's head is trimmed. For a single clip both ends are trimmed and the blend is appended.
- Dip-wrap seeding in `VideoSequenceBuilder.computeFadeInfos` (Android) / `CompositionBuilder.computeFadeWindows` (Darwin): the first clip fades in from the last clip's dip transition.
- Reuses the existing overlap pre-render (`ClipTransitionRenderer`) unchanged — the "two clips" are just sub-ranges of the same track.

## Behavior change

A transition on the last/only segment used to be a no-op; it now defines the loop wrap. The existing edge-case test was updated accordingly.

## Tests

- `planWrap` unit tests (Kotlin).
- Integration tests for the loop wrap: overlap shortens the output, dip keeps the length, too-short clip falls back to no wrap.
- Verified end-to-end: macOS **40/40** and Galaxy SM S942B **40/40**; renderer logs confirm the wrap path executes (`out=4200..5000ms, in=0..800ms`, dip `fadeInUs/fadeOutUs`, and the too-short guard).

## Notes

Supported on Android and iOS/macOS (same as clip transitions). Other platforms ignore the field.
