### PR TITLE
fix: prevent iOS/macOS thumbnail decoder wedge that froze the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.1
+- **FIX**(iOS, macOS): Loading many clips no longer freezes the editor. A thumbnail decoder race (out-of-order callbacks seen on iOS 26.5) could hang `getThumbnails` forever or map frames to the wrong timestamps; frames now stay index-aligned with their requested timestamps and the call always completes.
+
 ## 2.5.0
 - **FEAT**(android, iOS, macOS): A `ClipTransition` on the **last (or only)** `VideoSegment` now wraps back into the first segment, so a single-track render loops seamlessly — e.g. a `dissolve` on one segment cross-dissolves on restart. Overlap types (dissolve/slide/push/wipe) shorten the output by the transition duration and require a single clip longer than 2× the duration (otherwise the wrap is skipped); dip types (fadeToBlack/fadeToWhite) keep the length and dip through the color at the seam. Previously a transition on the last segment was silently ignored.
 

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/thumbnail/ThumbnailGenerator.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/thumbnail/ThumbnailGenerator.swift
@@ -136,14 +136,13 @@ class ThumbnailGenerator {
     config: ThumbnailConfig,
     onProgress: @escaping (Double) -> Void
   ) async -> [Data] {
-    let totalCount = times.count
-    var indices = indexMap(times: times)
-    var resultData = [Data?](repeating: nil, count: totalCount)
+    let (distinct, indicesByKey) = distinctTimesAndIndexMap(times)
+    var resultData = [Data?](repeating: nil, count: times.count)
     var completed = 0
     let start = Date().timeIntervalSince1970
 
-    for await frame in generator.images(for: times.map { $0.timeValue }) {
-      let index = indices[timeKey(frame.requestedTime)]?.popLast() ?? -1
+    for await frame in generator.images(for: distinct.map { $0.timeValue }) {
+      let indices = indicesByKey[timeKey(frame.requestedTime)] ?? []
 
       var data: Data?
       do {
@@ -151,17 +150,19 @@ class ThumbnailGenerator {
         let rendered = makeThumbnailData(cgImage, config: config)
         data = rendered
         let elapsed = Int((Date().timeIntervalSince1970 - start) * 1000)
-        PluginLog.print("[\(index)] ✅ frame in \(elapsed) ms (\(rendered.count) bytes)")
+        PluginLog.print("[\(indices.first ?? -1)] ✅ frame in \(elapsed) ms (\(rendered.count) bytes)")
       } catch {
-        PluginLog.print("[\(index)] ❌ frame failed: \(error.localizedDescription)")
+        PluginLog.print("[\(indices.first ?? -1)] ❌ frame failed: \(error.localizedDescription)")
       }
 
-      if index >= 0, index < totalCount {
+      // Fan the single decoded frame out to every index that requested this
+      // timestamp, so duplicate timestamps all stay aligned.
+      for index in indices {
         resultData[index] = data
       }
 
       completed += 1
-      onProgress(Double(completed) / Double(totalCount))
+      onProgress(Double(completed) / Double(distinct.count))
     }
 
     return resultData.map { $0 ?? Data() }
@@ -172,10 +173,15 @@ class ThumbnailGenerator {
   /// completion handler can fire concurrently and out of order (observed on
   /// iOS 26.5).
   ///
-  /// Every shared value (`resultData`, `completed`, `resumed`, and the
-  /// time → index map) is therefore mutated under a single lock, the write index
-  /// is resolved from `requestedTime`, and the continuation is resumed exactly
-  /// once even when frames fail or cancel.
+  /// Every shared value (`resultData`, `completed`, `resumed`) is therefore
+  /// mutated under a single lock, the write indices are resolved from
+  /// `requestedTime`, and the continuation is resumed exactly once even when
+  /// frames fail or cancel.
+  ///
+  /// The generator is handed only the *distinct* requested times, so it invokes
+  /// its callback exactly once per key — the completion count can always reach
+  /// `distinctCount` and resume the continuation, rather than wedging when the
+  /// same timestamp is requested more than once.
   ///
   /// Left at module-internal (not `private`) so the RunnerTests can exercise this
   /// legacy path directly on modern OS versions, which otherwise always take the
@@ -186,17 +192,17 @@ class ThumbnailGenerator {
     config: ThumbnailConfig,
     onProgress: @escaping (Double) -> Void
   ) async -> [Data] {
-    let totalCount = times.count
+    let (distinct, indicesByKey) = distinctTimesAndIndexMap(times)
+    let distinctCount = distinct.count
 
     return await withCheckedContinuation { continuation in
       let lock = NSLock()
-      var indices = indexMap(times: times)
-      var resultData = [Data?](repeating: nil, count: totalCount)
+      var resultData = [Data?](repeating: nil, count: times.count)
       var completed = 0
       var resumed = false
       let start = Date().timeIntervalSince1970
 
-      generator.generateCGImagesAsynchronously(forTimes: times) {
+      generator.generateCGImagesAsynchronously(forTimes: distinct) {
         requestedTime, cgImage, _, _, error in
 
         // Resize + compress happen off the lock; only shared-state mutation is
@@ -207,23 +213,25 @@ class ThumbnailGenerator {
         }
 
         lock.lock()
-        let index = indices[timeKey(requestedTime)]?.popLast() ?? -1
-        if index >= 0, index < totalCount {
+        let indices = indicesByKey[timeKey(requestedTime)] ?? []
+        // Fan the single decoded frame out to every index that requested this
+        // timestamp, so duplicate timestamps all stay aligned.
+        for index in indices {
           resultData[index] = data
         }
         completed += 1
-        let progress = Double(completed) / Double(totalCount)
-        let shouldResume = completed == totalCount && !resumed
+        let progress = Double(completed) / Double(distinctCount)
+        let shouldResume = completed == distinctCount && !resumed
         if shouldResume { resumed = true }
         let payload = shouldResume ? resultData.map { $0 ?? Data() } : nil
         lock.unlock()
 
         if let data = data {
           let elapsed = Int((Date().timeIntervalSince1970 - start) * 1000)
-          PluginLog.print("[\(index)] ✅ frame in \(elapsed) ms (\(data.count) bytes)")
+          PluginLog.print("[\(indices.first ?? -1)] ✅ frame in \(elapsed) ms (\(data.count) bytes)")
         } else {
           let message = error?.localizedDescription ?? "Unknown error"
-          PluginLog.print("[\(index)] ❌ frame failed: \(message)")
+          PluginLog.print("[\(indices.first ?? -1)] ❌ frame failed: \(message)")
         }
 
         onProgress(progress)
@@ -235,19 +243,29 @@ class ThumbnailGenerator {
     }
   }
 
-  /// Builds a map from each requested time's stable key to the result indices
-  /// that requested it, so a completion callback can resolve its output slot from
-  /// `requestedTime` alone. Buckets are reversed so `popLast()` (O(1)) hands out
-  /// ascending indices when the same timestamp is requested more than once.
-  private static func indexMap(times: [NSValue]) -> [String: [Int]] {
-    var map: [String: [Int]] = [:]
+  /// Splits the requested `times` into the *distinct* times to hand the generator
+  /// and a map from each time's stable key to every result index that requested
+  /// it.
+  ///
+  /// The generator is called with distinct times only, so it invokes its callback
+  /// exactly once per key; that single frame is then fanned out to every index in
+  /// the key's bucket. This keeps `result[i]` aligned to `times[i]` even when the
+  /// same timestamp is requested more than once, and guarantees the completion
+  /// count can always reach the number of distinct times — so the continuation
+  /// resumes instead of wedging.
+  private static func distinctTimesAndIndexMap(
+    _ times: [NSValue]
+  ) -> (distinct: [NSValue], indicesByKey: [String: [Int]]) {
+    var indicesByKey: [String: [Int]] = [:]
+    var distinct: [NSValue] = []
     for (i, value) in times.enumerated() {
-      map[timeKey(value.timeValue), default: []].append(i)
+      let key = timeKey(value.timeValue)
+      if indicesByKey[key] == nil {
+        distinct.append(value)
+      }
+      indicesByKey[key, default: []].append(i)
     }
-    for key in map.keys {
-      map[key]?.reverse()
-    }
-    return map
+    return (distinct, indicesByKey)
   }
 
   /// Stable dictionary key for a requested `CMTime`.

--- a/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/thumbnail/ThumbnailGenerator.swift
+++ b/darwin/pro_video_editor/Sources/pro_video_editor/src/shared/features/thumbnail/ThumbnailGenerator.swift
@@ -77,65 +77,203 @@ class ThumbnailGenerator {
         return
       }
 
-      let results = await withCheckedContinuation { continuation in
-        var resultData = [Data?](repeating: nil, count: times.count)
-
-        let totalCount = times.count
-        var completed = 0
-        let start = Date().timeIntervalSince1970
-
-        generator.generateCGImagesAsynchronously(forTimes: times) {
-          requestedTime, cgImage, actualTime, result, error in
-
-          let index = completed
-
-          if let cgImage = cgImage {
-            let resized = resizeCGImageKeepingAspect(
-              cgImage: cgImage,
-              targetWidth: config.outputWidth,
-              targetHeight: config.outputHeight,
-              boxFit: config.boxFit
-            )
-
-            let data = compressCGImage(
-              resized,
-              format: config.outputFormat,
-              jpegQuality: config.jpegQuality
-            )
-
-            resultData[index] = data
-
-            let elapsed = Int((Date().timeIntervalSince1970 - start) * 1000)
-
-            PluginLog.print(
-              "[\(index)] ✅ frame in \(elapsed) ms (\(data.count) bytes)"
-            )
-          } else {
-            let message = error?.localizedDescription ?? "Unknown error"
-            PluginLog.print("[\(index)] ❌ frame failed: \(message)")
-
-            let reportableError =
-              error
-              ?? NSError(
-                domain: "ThumbnailGenerator",
-                code: -1,
-                userInfo: [NSLocalizedDescriptionKey: "Frame generation failed at index \(index)"]
-              )
-            onError(reportableError)
-          }
-
-          completed += 1
-
-          onProgress(Double(completed) / Double(totalCount))
-
-          if completed == totalCount {
-            continuation.resume(returning: resultData.compactMap { $0 })
-          }
-        }
-      }
+      // The output maps 1:1 to `times`: `result[i]` is the thumbnail for
+      // `times[i]` (and therefore for the caller's `timestamps[i]`). A frame that
+      // fails or is cancelled is represented positionally as an empty `Data()`
+      // rather than being compacted out — dropping it would shift every later
+      // frame onto the wrong timestamp. Callers must treat an empty entry as
+      // "no thumbnail for this timestamp".
+      let results = await generateThumbnailData(
+        generator: generator,
+        times: times,
+        config: config,
+        onProgress: onProgress
+      )
 
       onComplete(results)
     }
+  }
+
+  // MARK: - Frame extraction
+
+  /// Decodes every requested frame and returns the compressed thumbnails aligned
+  /// index-for-index with `times`.
+  ///
+  /// The returned array is always `times.count` long. Each slot holds the
+  /// compressed image for the timestamp at the same index, or an empty `Data()`
+  /// when that frame failed or was cancelled. This positional, stable
+  /// representation lets the caller map `result[i]` to `timestamps[i]` without
+  /// any reordering or compaction.
+  private static func generateThumbnailData(
+    generator: AVAssetImageGenerator,
+    times: [NSValue],
+    config: ThumbnailConfig,
+    onProgress: @escaping (Double) -> Void
+  ) async -> [Data] {
+    // An empty request must resolve immediately; feeding an empty array to the
+    // generator would never invoke a completion handler and hang the caller.
+    guard !times.isEmpty else { return [] }
+
+    if #available(iOS 16.0, macOS 13.0, *) {
+      return await generateThumbnailDataOrdered(
+        generator: generator, times: times, config: config, onProgress: onProgress)
+    }
+
+    return await generateThumbnailDataConcurrent(
+      generator: generator, times: times, config: config, onProgress: onProgress)
+  }
+
+  /// Modern path (iOS 16+/macOS 13+): consume the ordered
+  /// `AVAssetImageGenerator.images(for:)` async sequence.
+  ///
+  /// Elements arrive serially, so no locking is needed, but the write index is
+  /// still derived from each element's `requestedTime` — never from a running
+  /// counter — so the alignment guarantee holds regardless of delivery order.
+  @available(iOS 16.0, macOS 13.0, *)
+  private static func generateThumbnailDataOrdered(
+    generator: AVAssetImageGenerator,
+    times: [NSValue],
+    config: ThumbnailConfig,
+    onProgress: @escaping (Double) -> Void
+  ) async -> [Data] {
+    let totalCount = times.count
+    var indices = indexMap(times: times)
+    var resultData = [Data?](repeating: nil, count: totalCount)
+    var completed = 0
+    let start = Date().timeIntervalSince1970
+
+    for await frame in generator.images(for: times.map { $0.timeValue }) {
+      let index = indices[timeKey(frame.requestedTime)]?.popLast() ?? -1
+
+      var data: Data?
+      do {
+        let cgImage = try frame.image
+        let rendered = makeThumbnailData(cgImage, config: config)
+        data = rendered
+        let elapsed = Int((Date().timeIntervalSince1970 - start) * 1000)
+        PluginLog.print("[\(index)] ✅ frame in \(elapsed) ms (\(rendered.count) bytes)")
+      } catch {
+        PluginLog.print("[\(index)] ❌ frame failed: \(error.localizedDescription)")
+      }
+
+      if index >= 0, index < totalCount {
+        resultData[index] = data
+      }
+
+      completed += 1
+      onProgress(Double(completed) / Double(totalCount))
+    }
+
+    return resultData.map { $0 ?? Data() }
+  }
+
+  /// Legacy path (pre-iOS 16 / macOS 13): `generateCGImagesAsynchronously(forTimes:)`
+  /// guarantees neither ordered nor serial delivery — on modern OS builds the
+  /// completion handler can fire concurrently and out of order (observed on
+  /// iOS 26.5).
+  ///
+  /// Every shared value (`resultData`, `completed`, `resumed`, and the
+  /// time → index map) is therefore mutated under a single lock, the write index
+  /// is resolved from `requestedTime`, and the continuation is resumed exactly
+  /// once even when frames fail or cancel.
+  ///
+  /// Left at module-internal (not `private`) so the RunnerTests can exercise this
+  /// legacy path directly on modern OS versions, which otherwise always take the
+  /// ordered async path above.
+  static func generateThumbnailDataConcurrent(
+    generator: AVAssetImageGenerator,
+    times: [NSValue],
+    config: ThumbnailConfig,
+    onProgress: @escaping (Double) -> Void
+  ) async -> [Data] {
+    let totalCount = times.count
+
+    return await withCheckedContinuation { continuation in
+      let lock = NSLock()
+      var indices = indexMap(times: times)
+      var resultData = [Data?](repeating: nil, count: totalCount)
+      var completed = 0
+      var resumed = false
+      let start = Date().timeIntervalSince1970
+
+      generator.generateCGImagesAsynchronously(forTimes: times) {
+        requestedTime, cgImage, _, _, error in
+
+        // Resize + compress happen off the lock; only shared-state mutation is
+        // guarded so heavy decoding still runs concurrently.
+        var data: Data?
+        if let cgImage = cgImage {
+          data = makeThumbnailData(cgImage, config: config)
+        }
+
+        lock.lock()
+        let index = indices[timeKey(requestedTime)]?.popLast() ?? -1
+        if index >= 0, index < totalCount {
+          resultData[index] = data
+        }
+        completed += 1
+        let progress = Double(completed) / Double(totalCount)
+        let shouldResume = completed == totalCount && !resumed
+        if shouldResume { resumed = true }
+        let payload = shouldResume ? resultData.map { $0 ?? Data() } : nil
+        lock.unlock()
+
+        if let data = data {
+          let elapsed = Int((Date().timeIntervalSince1970 - start) * 1000)
+          PluginLog.print("[\(index)] ✅ frame in \(elapsed) ms (\(data.count) bytes)")
+        } else {
+          let message = error?.localizedDescription ?? "Unknown error"
+          PluginLog.print("[\(index)] ❌ frame failed: \(message)")
+        }
+
+        onProgress(progress)
+
+        if let payload = payload {
+          continuation.resume(returning: payload)
+        }
+      }
+    }
+  }
+
+  /// Builds a map from each requested time's stable key to the result indices
+  /// that requested it, so a completion callback can resolve its output slot from
+  /// `requestedTime` alone. Buckets are reversed so `popLast()` (O(1)) hands out
+  /// ascending indices when the same timestamp is requested more than once.
+  private static func indexMap(times: [NSValue]) -> [String: [Int]] {
+    var map: [String: [Int]] = [:]
+    for (i, value) in times.enumerated() {
+      map[timeKey(value.timeValue), default: []].append(i)
+    }
+    for key in map.keys {
+      map[key]?.reverse()
+    }
+    return map
+  }
+
+  /// Stable dictionary key for a requested `CMTime`.
+  ///
+  /// Every requested time is built with timescale `1_000_000` and the generators
+  /// return the requested time unchanged, so an exact `(value, timescale)` key
+  /// matches reliably without any floating-point comparison.
+  private static func timeKey(_ time: CMTime) -> String {
+    "\(time.value)/\(time.timescale)"
+  }
+
+  /// Resizes a decoded frame to the configured bounds and compresses it into the
+  /// configured output format.
+  private static func makeThumbnailData(_ cgImage: CGImage, config: ThumbnailConfig) -> Data {
+    let resized = resizeCGImageKeepingAspect(
+      cgImage: cgImage,
+      targetWidth: config.outputWidth,
+      targetHeight: config.outputHeight,
+      boxFit: config.boxFit
+    )
+
+    return compressCGImage(
+      resized,
+      format: config.outputFormat,
+      jpegQuality: config.jpegQuality
+    )
   }
 
   // MARK: - Keyframe timestamps

--- a/example/integration_test/video_thumbnail_test.dart
+++ b/example/integration_test/video_thumbnail_test.dart
@@ -1,3 +1,6 @@
+import 'dart:math';
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -303,4 +306,149 @@ void main() {
       expect(mime, equals(formatMimeMap[ThumbnailFormat.png]));
     });
   });
+
+  // Regression coverage for the native thumbnail wedge: a large batch of
+  // timestamps whose decoder callbacks could arrive concurrently / out of order
+  // (iOS 26.5). The batch must always complete (no hang), return exactly the
+  // requested count with no dropped frames, and stay index-for-index aligned
+  // with the requested timestamps regardless of request order.
+  group('large-batch timestamp alignment (wedge regression)', () {
+    /// Decodes an encoded thumbnail to raw RGBA bytes so two runs of the same
+    /// timestamp can be compared deterministically (independent of encoder
+    /// metadata).
+    Future<Uint8List> rawRgba(Uint8List encoded) async {
+      final ui.Image image = await decodeImageFromList(encoded);
+      final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      return data!.buffer.asUint8List();
+    }
+
+    bool bytesEqual(Uint8List a, Uint8List b) {
+      if (a.length != b.length) return false;
+      for (var i = 0; i < a.length; i++) {
+        if (a[i] != b[i]) return false;
+      }
+      return true;
+    }
+
+    testWidgets('45 shuffled timestamps stay aligned and complete', (
+      tester,
+    ) async {
+      final meta = await ProVideoEditor.instance.getMetadata(testVideo);
+      final durationMs = meta.duration.inMilliseconds;
+      expect(durationMs, greaterThan(1000), reason: 'need a real duration');
+
+      // Evenly spread inside the video, away from the very start/end.
+      const count = 45;
+      final base = List.generate(count, (i) {
+        final fraction = (i + 1) / (count + 1);
+        return Duration(milliseconds: (durationMs * fraction).round());
+      });
+
+      Future<List<Uint8List>> run(List<Duration> timestamps) {
+        return ProVideoEditor.instance
+            .getThumbnails(
+              ThumbnailConfigs(
+                id: 'wedge-align-${DateTime.now().microsecondsSinceEpoch}',
+                video: testVideo,
+                outputFormat: ThumbnailFormat.png,
+                timestamps: timestamps,
+                outputSize: const Size(48, 27),
+                boxFit: ThumbnailBoxFit.contain,
+              ),
+            )
+            // A wedge used to hang this Future forever.
+            .timeout(const Duration(seconds: 60));
+      }
+
+      // Sorted reference run: build timestamp -> decoded frame.
+      final sorted = await run(base);
+      expect(sorted.length, count, reason: 'count must equal request');
+      for (var i = 0; i < sorted.length; i++) {
+        expect(
+          sorted[i].lengthInBytes,
+          greaterThan(50),
+          reason: 'frame $i must not be empty/dropped',
+        );
+      }
+
+      final referenceByTimestamp = <int, Uint8List>{};
+      for (var i = 0; i < base.length; i++) {
+        referenceByTimestamp[base[i].inMilliseconds] = await rawRgba(sorted[i]);
+      }
+
+      // The video must actually vary, otherwise the alignment check is vacuous.
+      expect(
+        bytesEqual(
+          referenceByTimestamp[base.first.inMilliseconds]!,
+          referenceByTimestamp[base.last.inMilliseconds]!,
+        ),
+        isFalse,
+        reason: 'first and last frames should differ in a real video',
+      );
+
+      // Shuffled run: result[i] must be the frame for shuffled[i], proving the
+      // output maps by requested timestamp and not by completion order.
+      final shuffled = List.of(base)..shuffle(Random(7));
+      final out = await run(shuffled);
+      expect(out.length, count, reason: 'shuffled count must equal request');
+
+      for (var i = 0; i < shuffled.length; i++) {
+        expect(
+          out[i].lengthInBytes,
+          greaterThan(50),
+          reason: 'shuffled frame $i must not be empty/dropped',
+        );
+        final actual = await rawRgba(out[i]);
+        final expected = referenceByTimestamp[shuffled[i].inMilliseconds]!;
+        expect(
+          bytesEqual(actual, expected),
+          isTrue,
+          reason:
+              'frame $i (t=${shuffled[i].inMilliseconds}ms) is not aligned to '
+              'its requested timestamp',
+        );
+      }
+    });
+
+    testWidgets('many sequential batches never wedge', (tester) async {
+      // One wedged call used to block thumbnail generation for every later
+      // batch for the rest of the session. Each batch here must complete on its
+      // own.
+      const batches = 8;
+      const perBatch = 24;
+
+      for (var batch = 0; batch < batches; batch++) {
+        final result = await ProVideoEditor.instance
+            .getThumbnails(
+              ThumbnailConfigs(
+                id: 'wedge-seq-$batch-${DateTime.now().microsecondsSinceEpoch}',
+                video: testVideo,
+                outputFormat: ThumbnailFormat.jpeg,
+                timestamps: List.generate(
+                  perBatch,
+                  (i) => Duration(milliseconds: 300 + i * 900),
+                ),
+                outputSize: const Size(48, 27),
+                boxFit: ThumbnailBoxFit.cover,
+              ),
+            )
+            .timeout(
+              const Duration(seconds: 45),
+              onTimeout: () =>
+                  throw StateError('batch $batch wedged (never completed)'),
+            );
+
+        expect(
+          result.length,
+          perBatch,
+          reason: 'batch $batch returned the wrong count',
+        );
+        expect(
+          result.every((frame) => frame.lengthInBytes > 50),
+          isTrue,
+          reason: 'batch $batch dropped a frame',
+        );
+      }
+    });
+  }, skip: kIsWeb);
 }

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -1,4 +1,8 @@
+import AVFoundation
+import CoreGraphics
+import CoreMedia
 import Flutter
+import ImageIO
 import UIKit
 import XCTest
 
@@ -84,4 +88,423 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(off.y, 0, accuracy: 1e-6)
   }
 
+  // MARK: - Thumbnail timestamp alignment (concurrent-callback regression)
+
+  // A synthetic video is authored with one distinct solid color per second.
+  // Thumbnails are then requested for many timestamps, in shuffled order, and
+  // every returned frame must decode to the color of the second it was
+  // requested for. This exercises the path where
+  // `generateCGImagesAsynchronously(forTimes:)` (and the ordered async
+  // sequence) delivers callbacks concurrently / out of order — the regression
+  // that previously mapped frames to the wrong timestamps or never completed.
+  //
+  // The result must (a) always arrive (no hang), (b) equal the requested count,
+  // and (c) map index-for-index to the requested timestamps with no reordering,
+  // dropped, or duplicated frames — verified across a stress loop.
+  func testThumbnailsAlignToRequestedTimestampsUnderConcurrency() throws {
+    let palette = ThumbnailTimestampFixture.palette
+    let videoURL = try ThumbnailTimestampFixture.makeColorVideo(colors: palette)
+    defer { try? FileManager.default.removeItem(at: videoURL) }
+
+    // Three sub-second offsets per color band, well away from band edges so the
+    // decoded frame is unambiguously inside a single color.
+    var entries: [(us: Int64, colorIndex: Int)] = []
+    for second in 0..<palette.count {
+      for frac in [0.3, 0.5, 0.7] {
+        let seconds = Double(second) + frac
+        entries.append((Int64((seconds * 1_000_000).rounded()), second))
+      }
+    }
+
+    let iterations = 12
+    for iteration in 0..<iterations {
+      // Shuffle so the requested order differs from the natural order; the
+      // returned array must still line up with the request positions.
+      let shuffled = entries.shuffled()
+      let timestampsUs = shuffled.map { $0.us }
+      let expectedColorIndex = shuffled.map { $0.colorIndex }
+
+      let config = ThumbnailConfig(
+        id: "concurrency-\(iteration)",
+        inputPath: videoURL.path,
+        fileExtension: "mp4",
+        boxFit: "contain",
+        outputFormat: "png",
+        jpegQuality: 100,
+        outputWidth: 80,
+        outputHeight: 45,
+        timestampsUs: timestampsUs,
+        maxOutputFrames: nil,
+        lastFrameTolerance: false
+      )
+
+      let completed = expectation(description: "onComplete fires (iteration \(iteration))")
+      completed.assertForOverFulfill = true
+      var received: [Data]?
+      var receivedError: Error?
+
+      ThumbnailGenerator.getThumbnails(
+        config: config,
+        onProgress: { _ in },
+        onComplete: { data in
+          received = data
+          completed.fulfill()
+        },
+        onError: { error in
+          receivedError = error
+          completed.fulfill()
+        }
+      )
+
+      // A timeout here is the guard against the wedge: a lost completion count
+      // used to leave the continuation unresumed forever.
+      wait(for: [completed], timeout: 30)
+
+      XCTAssertNil(receivedError, "iteration \(iteration): unexpected error")
+      guard let result = received else {
+        XCTFail("iteration \(iteration): no result delivered")
+        return
+      }
+
+      XCTAssertEqual(
+        result.count, timestampsUs.count,
+        "iteration \(iteration): result count must equal requested count")
+
+      for i in 0..<min(result.count, expectedColorIndex.count) {
+        XCTAssertFalse(
+          result[i].isEmpty,
+          "iteration \(iteration): frame \(i) is unexpectedly empty")
+
+        guard let color = ThumbnailTimestampFixture.decodedColor(result[i]) else {
+          XCTFail("iteration \(iteration): frame \(i) could not be decoded")
+          continue
+        }
+
+        let classified = ThumbnailTimestampFixture.nearestPaletteIndex(color, palette: palette)
+        XCTAssertEqual(
+          classified, expectedColorIndex[i],
+          "iteration \(iteration): frame \(i) (t=\(timestampsUs[i])us) decoded to "
+            + "color band \(classified) but timestamp belongs to band \(expectedColorIndex[i])")
+      }
+    }
+  }
+
+  // A single failed/out-of-range frame must not drop the others or shift them:
+  // the result stays index-aligned, the bad slot is an empty `Data()`, and the
+  // call still completes.
+  func testThumbnailsRepresentFailedFramePositionally() throws {
+    let palette = ThumbnailTimestampFixture.palette
+    let videoURL = try ThumbnailTimestampFixture.makeColorVideo(colors: palette)
+    defer { try? FileManager.default.removeItem(at: videoURL) }
+
+    // Middle timestamp is far past the end of the video, so that frame fails
+    // while the surrounding ones succeed.
+    let good0 = Int64(0.5 * 1_000_000)
+    let bad = Int64(9_999 * 1_000_000)
+    let good1 = Int64(1.5 * 1_000_000)
+    let timestampsUs = [good0, bad, good1]
+
+    let config = ThumbnailConfig(
+      id: "positional",
+      inputPath: videoURL.path,
+      fileExtension: "mp4",
+      boxFit: "contain",
+      outputFormat: "png",
+      jpegQuality: 100,
+      outputWidth: 80,
+      outputHeight: 45,
+      timestampsUs: timestampsUs,
+      maxOutputFrames: nil,
+      lastFrameTolerance: false
+    )
+
+    let completed = expectation(description: "onComplete fires")
+    var received: [Data]?
+    ThumbnailGenerator.getThumbnails(
+      config: config,
+      onProgress: { _ in },
+      onComplete: { data in
+        received = data
+        completed.fulfill()
+      },
+      onError: { _ in }
+    )
+    wait(for: [completed], timeout: 30)
+
+    guard let result = received else {
+      XCTFail("no result delivered")
+      return
+    }
+
+    XCTAssertEqual(result.count, 3, "result must stay the length of the request")
+    XCTAssertFalse(result[0].isEmpty, "first frame should succeed")
+    XCTAssertFalse(result[2].isEmpty, "third frame should succeed")
+
+    if let c0 = ThumbnailTimestampFixture.decodedColor(result[0]) {
+      XCTAssertEqual(
+        ThumbnailTimestampFixture.nearestPaletteIndex(c0, palette: palette), 0)
+    } else {
+      XCTFail("could not decode frame 0")
+    }
+    if let c2 = ThumbnailTimestampFixture.decodedColor(result[2]) {
+      XCTAssertEqual(
+        ThumbnailTimestampFixture.nearestPaletteIndex(c2, palette: palette), 1)
+    } else {
+      XCTFail("could not decode frame 2")
+    }
+  }
+
+  // Drives the legacy `generateCGImagesAsynchronously` path (lock +
+  // requestedTime→index resolution) directly. Modern OS versions route
+  // production through the ordered async sequence, so this is the only coverage
+  // for the concurrent-callback code — the exact code the wedge lived in.
+  func testConcurrentPathAlignsFramesToTimestamps() throws {
+    let palette = ThumbnailTimestampFixture.palette
+    let videoURL = try ThumbnailTimestampFixture.makeColorVideo(colors: palette)
+    defer { try? FileManager.default.removeItem(at: videoURL) }
+
+    var entries: [(us: Int64, colorIndex: Int)] = []
+    for second in 0..<palette.count {
+      for frac in [0.3, 0.5, 0.7] {
+        let seconds = Double(second) + frac
+        entries.append((Int64((seconds * 1_000_000).rounded()), second))
+      }
+    }
+
+    for iteration in 0..<8 {
+      let shuffled = entries.shuffled()
+      let timestampsUs = shuffled.map { $0.us }
+      let expectedColorIndex = shuffled.map { $0.colorIndex }
+
+      let config = ThumbnailConfig(
+        id: "concurrent-\(iteration)",
+        inputPath: videoURL.path,
+        fileExtension: "mp4",
+        boxFit: "contain",
+        outputFormat: "png",
+        jpegQuality: 100,
+        outputWidth: 80,
+        outputHeight: 45,
+        timestampsUs: timestampsUs,
+        maxOutputFrames: nil,
+        lastFrameTolerance: false
+      )
+
+      let generator = AVAssetImageGenerator(asset: AVURLAsset(url: videoURL))
+      generator.appliesPreferredTrackTransform = true
+      generator.requestedTimeToleranceBefore = .zero
+      generator.requestedTimeToleranceAfter = .zero
+
+      let times = timestampsUs.map {
+        NSValue(time: CMTime(value: $0, timescale: 1_000_000))
+      }
+
+      let done = expectation(description: "concurrent path completes (iteration \(iteration))")
+      Task {
+        let result = await ThumbnailGenerator.generateThumbnailDataConcurrent(
+          generator: generator,
+          times: times,
+          config: config,
+          onProgress: { _ in }
+        )
+
+        XCTAssertEqual(
+          result.count, timestampsUs.count,
+          "iteration \(iteration): concurrent path result count")
+
+        for i in 0..<min(result.count, expectedColorIndex.count) {
+          XCTAssertFalse(
+            result[i].isEmpty,
+            "iteration \(iteration): concurrent frame \(i) is empty")
+          if let color = ThumbnailTimestampFixture.decodedColor(result[i]) {
+            XCTAssertEqual(
+              ThumbnailTimestampFixture.nearestPaletteIndex(color, palette: palette),
+              expectedColorIndex[i],
+              "iteration \(iteration): concurrent frame \(i) misaligned")
+          } else {
+            XCTFail("iteration \(iteration): concurrent frame \(i) could not decode")
+          }
+        }
+        done.fulfill()
+      }
+
+      // Times out (fails) rather than hanging forever if the continuation is
+      // never resumed — the original wedge.
+      wait(for: [done], timeout: 30)
+    }
+  }
+
+}
+
+// MARK: - Thumbnail timestamp test fixtures
+
+/// Helpers for authoring a color-coded test video and reading colors back out
+/// of generated thumbnails. Shared by the iOS and macOS RunnerTests.
+enum ThumbnailTimestampFixture {
+
+  typealias RGB = (r: UInt8, g: UInt8, b: UInt8)
+
+  /// Eight solid colors, each pair separated by a large RGB distance so a
+  /// nearest-color classification survives the RGB→YUV→RGB round trip of H.264
+  /// without ever misclassifying which band a frame came from.
+  static let palette: [RGB] = [
+    (215, 40, 40),
+    (40, 215, 40),
+    (40, 40, 215),
+    (215, 215, 40),
+    (215, 40, 215),
+    (40, 215, 215),
+    (215, 215, 215),
+    (40, 40, 40),
+  ]
+
+  /// Authors an H.264 `.mp4` where second `i` is entirely `colors[i]`.
+  static func makeColorVideo(
+    colors: [RGB],
+    fps: Int32 = 30,
+    size: CGSize = CGSize(width: 160, height: 90)
+  ) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("pve_thumb_\(UUID().uuidString).mp4")
+
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+    let settings: [String: Any] = [
+      AVVideoCodecKey: AVVideoCodecType.h264,
+      AVVideoWidthKey: Int(size.width),
+      AVVideoHeightKey: Int(size.height),
+    ]
+    let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+    input.expectsMediaDataInRealTime = false
+
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+      assetWriterInput: input,
+      sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: Int(size.width),
+        kCVPixelBufferHeightKey as String: Int(size.height),
+      ]
+    )
+
+    guard writer.canAdd(input) else {
+      throw NSError(domain: "ThumbnailTimestampFixture", code: 1)
+    }
+    writer.add(input)
+    writer.startWriting()
+    writer.startSession(atSourceTime: .zero)
+
+    let framesPerColor = Int(fps)
+    var frameIndex = 0
+    for color in colors {
+      let buffer = try makePixelBuffer(color: color, size: size)
+      for _ in 0..<framesPerColor {
+        while !input.isReadyForMoreMediaData {
+          usleep(500)
+        }
+        let pts = CMTime(value: CMTimeValue(frameIndex), timescale: fps)
+        adaptor.append(buffer, withPresentationTime: pts)
+        frameIndex += 1
+      }
+    }
+
+    input.markAsFinished()
+    let finished = DispatchSemaphore(value: 0)
+    writer.finishWriting { finished.signal() }
+    finished.wait()
+
+    guard writer.status == .completed else {
+      throw writer.error
+        ?? NSError(domain: "ThumbnailTimestampFixture", code: 2)
+    }
+    return url
+  }
+
+  private static func makePixelBuffer(color: RGB, size: CGSize) throws -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      Int(size.width),
+      Int(size.height),
+      kCVPixelFormatType_32BGRA,
+      [
+        kCVPixelBufferCGImageCompatibilityKey as String: true,
+        kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+      ] as CFDictionary,
+      &pixelBuffer
+    )
+    guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+      throw NSError(domain: "ThumbnailTimestampFixture", code: 3)
+    }
+
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+    guard
+      let context = CGContext(
+        data: CVPixelBufferGetBaseAddress(buffer),
+        width: Int(size.width),
+        height: Int(size.height),
+        bitsPerComponent: 8,
+        bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+          | CGBitmapInfo.byteOrder32Little.rawValue
+      )
+    else {
+      throw NSError(domain: "ThumbnailTimestampFixture", code: 4)
+    }
+
+    // Logical RGB fill; CoreGraphics writes the correct BGRA bytes.
+    context.setFillColor(
+      red: CGFloat(color.r) / 255,
+      green: CGFloat(color.g) / 255,
+      blue: CGFloat(color.b) / 255,
+      alpha: 1
+    )
+    context.fill(CGRect(x: 0, y: 0, width: size.width, height: size.height))
+
+    return buffer
+  }
+
+  /// Decodes encoded image `data` and returns its average color (the frames are
+  /// solid, so the average is the frame's color).
+  static func decodedColor(_ data: Data) -> RGB? {
+    guard
+      let source = CGImageSourceCreateWithData(data as CFData, nil),
+      let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+    else { return nil }
+
+    var pixel = [UInt8](repeating: 0, count: 4)
+    guard
+      let context = CGContext(
+        data: &pixel,
+        width: 1,
+        height: 1,
+        bitsPerComponent: 8,
+        bytesPerRow: 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+
+    context.interpolationQuality = .high
+    context.draw(image, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+    return (pixel[0], pixel[1], pixel[2])
+  }
+
+  /// Returns the index of the palette color closest to `color`.
+  static func nearestPaletteIndex(_ color: RGB, palette: [RGB]) -> Int {
+    var bestIndex = 0
+    var bestDistance = Int.max
+    for (index, candidate) in palette.enumerated() {
+      let dr = Int(color.r) - Int(candidate.r)
+      let dg = Int(color.g) - Int(candidate.g)
+      let db = Int(color.b) - Int(candidate.b)
+      let distance = dr * dr + dg * dg + db * db
+      if distance < bestDistance {
+        bestDistance = distance
+        bestIndex = index
+      }
+    }
+    return bestIndex
+  }
 }

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -1,5 +1,9 @@
+import AVFoundation
 import Cocoa
+import CoreGraphics
+import CoreMedia
 import FlutterMacOS
+import ImageIO
 import XCTest
 
 
@@ -118,4 +122,423 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(deliveredCount, 0)
   }
 
+  // MARK: - Thumbnail timestamp alignment (concurrent-callback regression)
+
+  // A synthetic video is authored with one distinct solid color per second.
+  // Thumbnails are then requested for many timestamps, in shuffled order, and
+  // every returned frame must decode to the color of the second it was
+  // requested for. This exercises the path where
+  // `generateCGImagesAsynchronously(forTimes:)` (and the ordered async
+  // sequence) delivers callbacks concurrently / out of order — the regression
+  // that previously mapped frames to the wrong timestamps or never completed.
+  //
+  // The result must (a) always arrive (no hang), (b) equal the requested count,
+  // and (c) map index-for-index to the requested timestamps with no reordering,
+  // dropped, or duplicated frames — verified across a stress loop.
+  func testThumbnailsAlignToRequestedTimestampsUnderConcurrency() throws {
+    let palette = ThumbnailTimestampFixture.palette
+    let videoURL = try ThumbnailTimestampFixture.makeColorVideo(colors: palette)
+    defer { try? FileManager.default.removeItem(at: videoURL) }
+
+    // Three sub-second offsets per color band, well away from band edges so the
+    // decoded frame is unambiguously inside a single color.
+    var entries: [(us: Int64, colorIndex: Int)] = []
+    for second in 0..<palette.count {
+      for frac in [0.3, 0.5, 0.7] {
+        let seconds = Double(second) + frac
+        entries.append((Int64((seconds * 1_000_000).rounded()), second))
+      }
+    }
+
+    let iterations = 12
+    for iteration in 0..<iterations {
+      // Shuffle so the requested order differs from the natural order; the
+      // returned array must still line up with the request positions.
+      let shuffled = entries.shuffled()
+      let timestampsUs = shuffled.map { $0.us }
+      let expectedColorIndex = shuffled.map { $0.colorIndex }
+
+      let config = ThumbnailConfig(
+        id: "concurrency-\(iteration)",
+        inputPath: videoURL.path,
+        fileExtension: "mp4",
+        boxFit: "contain",
+        outputFormat: "png",
+        jpegQuality: 100,
+        outputWidth: 80,
+        outputHeight: 45,
+        timestampsUs: timestampsUs,
+        maxOutputFrames: nil,
+        lastFrameTolerance: false
+      )
+
+      let completed = expectation(description: "onComplete fires (iteration \(iteration))")
+      completed.assertForOverFulfill = true
+      var received: [Data]?
+      var receivedError: Error?
+
+      ThumbnailGenerator.getThumbnails(
+        config: config,
+        onProgress: { _ in },
+        onComplete: { data in
+          received = data
+          completed.fulfill()
+        },
+        onError: { error in
+          receivedError = error
+          completed.fulfill()
+        }
+      )
+
+      // A timeout here is the guard against the wedge: a lost completion count
+      // used to leave the continuation unresumed forever.
+      wait(for: [completed], timeout: 30)
+
+      XCTAssertNil(receivedError, "iteration \(iteration): unexpected error")
+      guard let result = received else {
+        XCTFail("iteration \(iteration): no result delivered")
+        return
+      }
+
+      XCTAssertEqual(
+        result.count, timestampsUs.count,
+        "iteration \(iteration): result count must equal requested count")
+
+      for i in 0..<min(result.count, expectedColorIndex.count) {
+        XCTAssertFalse(
+          result[i].isEmpty,
+          "iteration \(iteration): frame \(i) is unexpectedly empty")
+
+        guard let color = ThumbnailTimestampFixture.decodedColor(result[i]) else {
+          XCTFail("iteration \(iteration): frame \(i) could not be decoded")
+          continue
+        }
+
+        let classified = ThumbnailTimestampFixture.nearestPaletteIndex(color, palette: palette)
+        XCTAssertEqual(
+          classified, expectedColorIndex[i],
+          "iteration \(iteration): frame \(i) (t=\(timestampsUs[i])us) decoded to "
+            + "color band \(classified) but timestamp belongs to band \(expectedColorIndex[i])")
+      }
+    }
+  }
+
+  // A single failed/out-of-range frame must not drop the others or shift them:
+  // the result stays index-aligned, the bad slot is an empty `Data()`, and the
+  // call still completes.
+  func testThumbnailsRepresentFailedFramePositionally() throws {
+    let palette = ThumbnailTimestampFixture.palette
+    let videoURL = try ThumbnailTimestampFixture.makeColorVideo(colors: palette)
+    defer { try? FileManager.default.removeItem(at: videoURL) }
+
+    // Middle timestamp is far past the end of the video, so that frame fails
+    // while the surrounding ones succeed.
+    let good0 = Int64(0.5 * 1_000_000)
+    let bad = Int64(9_999 * 1_000_000)
+    let good1 = Int64(1.5 * 1_000_000)
+    let timestampsUs = [good0, bad, good1]
+
+    let config = ThumbnailConfig(
+      id: "positional",
+      inputPath: videoURL.path,
+      fileExtension: "mp4",
+      boxFit: "contain",
+      outputFormat: "png",
+      jpegQuality: 100,
+      outputWidth: 80,
+      outputHeight: 45,
+      timestampsUs: timestampsUs,
+      maxOutputFrames: nil,
+      lastFrameTolerance: false
+    )
+
+    let completed = expectation(description: "onComplete fires")
+    var received: [Data]?
+    ThumbnailGenerator.getThumbnails(
+      config: config,
+      onProgress: { _ in },
+      onComplete: { data in
+        received = data
+        completed.fulfill()
+      },
+      onError: { _ in }
+    )
+    wait(for: [completed], timeout: 30)
+
+    guard let result = received else {
+      XCTFail("no result delivered")
+      return
+    }
+
+    XCTAssertEqual(result.count, 3, "result must stay the length of the request")
+    XCTAssertFalse(result[0].isEmpty, "first frame should succeed")
+    XCTAssertFalse(result[2].isEmpty, "third frame should succeed")
+
+    if let c0 = ThumbnailTimestampFixture.decodedColor(result[0]) {
+      XCTAssertEqual(
+        ThumbnailTimestampFixture.nearestPaletteIndex(c0, palette: palette), 0)
+    } else {
+      XCTFail("could not decode frame 0")
+    }
+    if let c2 = ThumbnailTimestampFixture.decodedColor(result[2]) {
+      XCTAssertEqual(
+        ThumbnailTimestampFixture.nearestPaletteIndex(c2, palette: palette), 1)
+    } else {
+      XCTFail("could not decode frame 2")
+    }
+  }
+
+  // Drives the legacy `generateCGImagesAsynchronously` path (lock +
+  // requestedTime→index resolution) directly. Modern OS versions route
+  // production through the ordered async sequence, so this is the only coverage
+  // for the concurrent-callback code — the exact code the wedge lived in.
+  func testConcurrentPathAlignsFramesToTimestamps() throws {
+    let palette = ThumbnailTimestampFixture.palette
+    let videoURL = try ThumbnailTimestampFixture.makeColorVideo(colors: palette)
+    defer { try? FileManager.default.removeItem(at: videoURL) }
+
+    var entries: [(us: Int64, colorIndex: Int)] = []
+    for second in 0..<palette.count {
+      for frac in [0.3, 0.5, 0.7] {
+        let seconds = Double(second) + frac
+        entries.append((Int64((seconds * 1_000_000).rounded()), second))
+      }
+    }
+
+    for iteration in 0..<8 {
+      let shuffled = entries.shuffled()
+      let timestampsUs = shuffled.map { $0.us }
+      let expectedColorIndex = shuffled.map { $0.colorIndex }
+
+      let config = ThumbnailConfig(
+        id: "concurrent-\(iteration)",
+        inputPath: videoURL.path,
+        fileExtension: "mp4",
+        boxFit: "contain",
+        outputFormat: "png",
+        jpegQuality: 100,
+        outputWidth: 80,
+        outputHeight: 45,
+        timestampsUs: timestampsUs,
+        maxOutputFrames: nil,
+        lastFrameTolerance: false
+      )
+
+      let generator = AVAssetImageGenerator(asset: AVURLAsset(url: videoURL))
+      generator.appliesPreferredTrackTransform = true
+      generator.requestedTimeToleranceBefore = .zero
+      generator.requestedTimeToleranceAfter = .zero
+
+      let times = timestampsUs.map {
+        NSValue(time: CMTime(value: $0, timescale: 1_000_000))
+      }
+
+      let done = expectation(description: "concurrent path completes (iteration \(iteration))")
+      Task {
+        let result = await ThumbnailGenerator.generateThumbnailDataConcurrent(
+          generator: generator,
+          times: times,
+          config: config,
+          onProgress: { _ in }
+        )
+
+        XCTAssertEqual(
+          result.count, timestampsUs.count,
+          "iteration \(iteration): concurrent path result count")
+
+        for i in 0..<min(result.count, expectedColorIndex.count) {
+          XCTAssertFalse(
+            result[i].isEmpty,
+            "iteration \(iteration): concurrent frame \(i) is empty")
+          if let color = ThumbnailTimestampFixture.decodedColor(result[i]) {
+            XCTAssertEqual(
+              ThumbnailTimestampFixture.nearestPaletteIndex(color, palette: palette),
+              expectedColorIndex[i],
+              "iteration \(iteration): concurrent frame \(i) misaligned")
+          } else {
+            XCTFail("iteration \(iteration): concurrent frame \(i) could not decode")
+          }
+        }
+        done.fulfill()
+      }
+
+      // Times out (fails) rather than hanging forever if the continuation is
+      // never resumed — the original wedge.
+      wait(for: [done], timeout: 30)
+    }
+  }
+
+}
+
+// MARK: - Thumbnail timestamp test fixtures
+
+/// Helpers for authoring a color-coded test video and reading colors back out
+/// of generated thumbnails. Shared by the iOS and macOS RunnerTests.
+enum ThumbnailTimestampFixture {
+
+  typealias RGB = (r: UInt8, g: UInt8, b: UInt8)
+
+  /// Eight solid colors, each pair separated by a large RGB distance so a
+  /// nearest-color classification survives the RGB→YUV→RGB round trip of H.264
+  /// without ever misclassifying which band a frame came from.
+  static let palette: [RGB] = [
+    (215, 40, 40),
+    (40, 215, 40),
+    (40, 40, 215),
+    (215, 215, 40),
+    (215, 40, 215),
+    (40, 215, 215),
+    (215, 215, 215),
+    (40, 40, 40),
+  ]
+
+  /// Authors an H.264 `.mp4` where second `i` is entirely `colors[i]`.
+  static func makeColorVideo(
+    colors: [RGB],
+    fps: Int32 = 30,
+    size: CGSize = CGSize(width: 160, height: 90)
+  ) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("pve_thumb_\(UUID().uuidString).mp4")
+
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+    let settings: [String: Any] = [
+      AVVideoCodecKey: AVVideoCodecType.h264,
+      AVVideoWidthKey: Int(size.width),
+      AVVideoHeightKey: Int(size.height),
+    ]
+    let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+    input.expectsMediaDataInRealTime = false
+
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+      assetWriterInput: input,
+      sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: Int(size.width),
+        kCVPixelBufferHeightKey as String: Int(size.height),
+      ]
+    )
+
+    guard writer.canAdd(input) else {
+      throw NSError(domain: "ThumbnailTimestampFixture", code: 1)
+    }
+    writer.add(input)
+    writer.startWriting()
+    writer.startSession(atSourceTime: .zero)
+
+    let framesPerColor = Int(fps)
+    var frameIndex = 0
+    for color in colors {
+      let buffer = try makePixelBuffer(color: color, size: size)
+      for _ in 0..<framesPerColor {
+        while !input.isReadyForMoreMediaData {
+          usleep(500)
+        }
+        let pts = CMTime(value: CMTimeValue(frameIndex), timescale: fps)
+        adaptor.append(buffer, withPresentationTime: pts)
+        frameIndex += 1
+      }
+    }
+
+    input.markAsFinished()
+    let finished = DispatchSemaphore(value: 0)
+    writer.finishWriting { finished.signal() }
+    finished.wait()
+
+    guard writer.status == .completed else {
+      throw writer.error
+        ?? NSError(domain: "ThumbnailTimestampFixture", code: 2)
+    }
+    return url
+  }
+
+  private static func makePixelBuffer(color: RGB, size: CGSize) throws -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      Int(size.width),
+      Int(size.height),
+      kCVPixelFormatType_32BGRA,
+      [
+        kCVPixelBufferCGImageCompatibilityKey as String: true,
+        kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+      ] as CFDictionary,
+      &pixelBuffer
+    )
+    guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+      throw NSError(domain: "ThumbnailTimestampFixture", code: 3)
+    }
+
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+    guard
+      let context = CGContext(
+        data: CVPixelBufferGetBaseAddress(buffer),
+        width: Int(size.width),
+        height: Int(size.height),
+        bitsPerComponent: 8,
+        bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+          | CGBitmapInfo.byteOrder32Little.rawValue
+      )
+    else {
+      throw NSError(domain: "ThumbnailTimestampFixture", code: 4)
+    }
+
+    // Logical RGB fill; CoreGraphics writes the correct BGRA bytes.
+    context.setFillColor(
+      red: CGFloat(color.r) / 255,
+      green: CGFloat(color.g) / 255,
+      blue: CGFloat(color.b) / 255,
+      alpha: 1
+    )
+    context.fill(CGRect(x: 0, y: 0, width: size.width, height: size.height))
+
+    return buffer
+  }
+
+  /// Decodes encoded image `data` and returns its average color (the frames are
+  /// solid, so the average is the frame's color).
+  static func decodedColor(_ data: Data) -> RGB? {
+    guard
+      let source = CGImageSourceCreateWithData(data as CFData, nil),
+      let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+    else { return nil }
+
+    var pixel = [UInt8](repeating: 0, count: 4)
+    guard
+      let context = CGContext(
+        data: &pixel,
+        width: 1,
+        height: 1,
+        bitsPerComponent: 8,
+        bytesPerRow: 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+
+    context.interpolationQuality = .high
+    context.draw(image, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+    return (pixel[0], pixel[1], pixel[2])
+  }
+
+  /// Returns the index of the palette color closest to `color`.
+  static func nearestPaletteIndex(_ color: RGB, palette: [RGB]) -> Int {
+    var bestIndex = 0
+    var bestDistance = Int.max
+    for (index, candidate) in palette.enumerated() {
+      let dr = Int(color.r) - Int(candidate.r)
+      let dg = Int(color.g) - Int(candidate.g)
+      let db = Int(color.b) - Int(candidate.b)
+      let distance = dr * dr + dg * dg + db * db
+      if distance < bestDistance {
+        bestDistance = distance
+        bestIndex = index
+      }
+    }
+    return bestIndex
+  }
 }

--- a/lib/core/platform/native_method_channel.dart
+++ b/lib/core/platform/native_method_channel.dart
@@ -244,7 +244,11 @@ class MethodChannelProVideoEditor extends ProVideoEditor {
       },
     );
     final List<Uint8List> result = response?.cast<Uint8List>() ?? [];
-    return result.isNotEmpty ? result.first : null;
+    if (result.isEmpty) return null;
+    // A frame that failed or fell out of range comes back as an empty entry;
+    // surface that as "no thumbnail" rather than a zero-byte, broken image.
+    final Uint8List first = result.first;
+    return first.isNotEmpty ? first : null;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_video_editor
 description: "A Flutter video editor: Seamlessly enhance your videos with user-friendly editing features."
-version: 2.5.0
+version: 2.5.1
 homepage: https://github.com/hm21/pro_video_editor/
 repository: https://github.com/hm21/pro_video_editor/
 documentation: https://github.com/hm21/pro_video_editor/


### PR DESCRIPTION
## Problem
Loading many clips (40+) into the editor could freeze it "step by step". The native iOS/macOS thumbnail generator's `getThumbnails` completion handler used a single unsynchronized `completed` counter as **both** the write index into the results buffer **and** the completion count.

`AVAssetImageGenerator.generateCGImagesAsynchronously(forTimes:)` does not guarantee serial or in-order callbacks — on modern iOS (observed on **iOS 26.5**) they can fire concurrently. That caused:

1. **Wedge/hang** — lost `completed += 1` updates could miss `== totalCount`, so `continuation.resume` never fired. The Dart `getThumbnails` call has no timeout, so its Future hung forever. The consuming app runs every thumbnail batch through one global serial queue whose release is in a `finally`, so a single wedged call blocked thumbnail generation for **every** clip for the rest of the session.
2. **Misalignment** — mapping completion order to array slots assigned thumbnails to the wrong timestamps on out-of-order delivery.
3. **Shifted frames** — `compactMap { $0 }` dropped failed frames, shifting all later frames.

## Fix
- Derive the result index from each callback's **`requestedTime`** (matched to its position in the requested times), never from a running counter.
- Serialize all shared-state mutation (results buffer + completion count) under a lock, and resume the continuation **exactly once** — even when frames fail or cancel.
- Failed/cancelled frames are represented **positionally** as an empty `Data()` instead of being compacted out, so `result[i]` maps index-for-index to the requested `timestamps[i]`.
- On iOS 16+/macOS 13+, use the ordered `AVAssetImageGenerator.images(for:)` async sequence; older OSes keep the hardened callback path. Also guards against an empty-`times` hang.

Public method signature and the `onProgress`/`onComplete`/`onError` contract are unchanged. Applied to both the UIKit and AppKit paths.

## Behavior note
Individual frame failures now surface as empty entries via `onComplete` rather than firing `onError` per frame (which previously also double-delivered the method-channel result alongside `onComplete`). `onError` still covers operation-level failures (e.g. file not found).

## Tests
- **RunnerTests (iOS + macOS):** author a video with one distinct solid color per second, request thumbnails for many **shuffled** timestamps, decode each result and assert it maps back to its correct timestamp's color band. Covers the ordered path, the legacy concurrent path directly, and positional failure handling — each guarded against hangs.
- **Integration test (`video_thumbnail_test.dart`):** a large shuffled batch must stay index-aligned to its timestamps (sorted-vs-shuffled byte comparison), and many sequential batches must never wedge.

## Verified on macOS
- Native `RunnerTests`: all 10 pass (incl. 3 new).
- `flutter test integration_test/video_thumbnail_test.dart -d macos`: the new wedge-regression group passes.

macOS 26.5 exercises the ordered path — the same path iOS 26.5 uses in production.

## Release
Bumps package to **2.5.1** with a changelog entry.